### PR TITLE
test(k8s): reorder CheckDestroy

### DIFF
--- a/scaleway/data_source_k8s_cluster_test.go
+++ b/scaleway/data_source_k8s_cluster_test.go
@@ -16,9 +16,9 @@ func TestAccScalewayDataSourceK8SCluster_Basic(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.default"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{

--- a/scaleway/data_source_k8s_pool_test.go
+++ b/scaleway/data_source_k8s_pool_test.go
@@ -17,9 +17,9 @@ func TestAccScalewayDataSourceK8SPool_Basic(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.default"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{

--- a/scaleway/resource_k8s_cluster_test.go
+++ b/scaleway/resource_k8s_cluster_test.go
@@ -127,8 +127,8 @@ func TestAccScalewayK8SCluster_Basic(t *testing.T) {
 		},
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -183,8 +183,8 @@ func TestAccScalewayK8SCluster_Autoscaling(t *testing.T) {
 		},
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -259,8 +259,8 @@ func TestAccScalewayK8SCluster_OIDC(t *testing.T) {
 		},
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -329,8 +329,8 @@ func TestAccScalewayK8SCluster_AutoUpgrade(t *testing.T) {
 		},
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -411,8 +411,8 @@ func TestAccScalewayK8SCluster_PrivateNetwork(t *testing.T) {
 		},
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -476,8 +476,8 @@ func TestAccScalewayK8SCluster_TypeChange(t *testing.T) {
 		},
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{

--- a/scaleway/resource_k8s_pool_test.go
+++ b/scaleway/resource_k8s_pool_test.go
@@ -22,10 +22,10 @@ func TestAccScalewayK8SCluster_PoolBasic(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.default"),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.minimal"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -42,6 +42,7 @@ func TestAccScalewayK8SCluster_PoolBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_k8s_pool.default", "tags.0", "terraform-test"),
 					resource.TestCheckResourceAttr("scaleway_k8s_pool.default", "tags.1", "scaleway_k8s_cluster"),
 					resource.TestCheckResourceAttr("scaleway_k8s_pool.default", "tags.2", "default"),
+					testAccCheckScalewayK8SPoolServersAreInPrivateNetwork(tt, "scaleway_k8s_cluster.minimal", "scaleway_k8s_pool.default", "scaleway_vpc_private_network.minimal"),
 				),
 			},
 			{
@@ -58,13 +59,17 @@ func TestAccScalewayK8SCluster_PoolBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_k8s_pool.minimal", "tags.0", "terraform-test"),
 					resource.TestCheckResourceAttr("scaleway_k8s_pool.minimal", "tags.1", "scaleway_k8s_cluster"),
 					resource.TestCheckResourceAttr("scaleway_k8s_pool.minimal", "tags.2", "minimal"),
+					testAccCheckScalewayK8SPoolServersAreInPrivateNetwork(tt, "scaleway_k8s_cluster.minimal", "scaleway_k8s_pool.default", "scaleway_vpc_private_network.minimal"),
+					testAccCheckScalewayK8SPoolServersAreInPrivateNetwork(tt, "scaleway_k8s_cluster.minimal", "scaleway_k8s_pool.minimal", "scaleway_vpc_private_network.minimal"),
 				),
 			},
 			{
 				Config: testAccCheckScalewayK8SPoolConfigMinimal(latestK8SVersion, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayK8SClusterExists(tt, "scaleway_k8s_cluster.minimal"),
+					testAccCheckScalewayK8SPoolExists(tt, "scaleway_k8s_pool.default"),
 					testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.minimal"),
+					testAccCheckScalewayK8SPoolServersAreInPrivateNetwork(tt, "scaleway_k8s_cluster.minimal", "scaleway_k8s_pool.default", "scaleway_vpc_private_network.minimal"),
 				),
 			},
 		},
@@ -79,10 +84,10 @@ func TestAccScalewayK8SCluster_PoolWait(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.default"),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.minimal"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -160,10 +165,10 @@ func TestAccScalewayK8SCluster_PoolPlacementGroup(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.placement_group"),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.placement_group_2"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -217,9 +222,9 @@ func TestAccScalewayK8SCluster_PoolUpgradePolicy(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.upgrade_policy"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -272,9 +277,9 @@ func TestAccScalewayK8SCluster_PoolKubeletArgs(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.kubelet_args"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -311,9 +316,9 @@ func TestAccScalewayK8SCluster_PoolZone(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.zone"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -340,9 +345,9 @@ func TestAccScalewayK8SCluster_PoolSize(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.pool"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -407,63 +412,6 @@ func TestAccScalewayK8SCluster_PoolSize(t *testing.T) {
 	})
 }
 
-func TestAccScalewayK8SCluster_PoolPrivateNetwork(t *testing.T) {
-	tt := NewTestTools(t)
-	defer tt.Cleanup()
-
-	latestK8SVersion := testAccScalewayK8SClusterGetLatestK8SVersion(tt)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: tt.ProviderFactories,
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
-			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.pool_with_pn"),
-		),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-				resource "scaleway_vpc" "vpc" {
-				  name       = "test-k8s-private-network"
-				}
-				resource "scaleway_vpc_private_network" "pn" {
-				  name       = "test-k8s-private-network"
-				  vpc_id = scaleway_vpc.vpc.id
-				}
-
-				resource "scaleway_k8s_cluster" "cluster_with_pn" {
-				  name = "test-k8s-private-network"
-				  version = "%s"
-				  cni     = "cilium"
-				  private_network_id = scaleway_vpc_private_network.pn.id
-				  tags = [ "terraform-test", "scaleway_k8s_cluster", "private_network" ]
-				  delete_additional_resources = true
-				  depends_on = [scaleway_vpc_private_network.pn]
-				}
-
-				resource "scaleway_k8s_pool" "pool_with_pn" {
-				  cluster_id          = scaleway_k8s_cluster.cluster_with_pn.id
-				  name                = "pool"
-				  node_type           = "gp1_xs"
-				  size                = 2
-				  autoscaling         = false
-				  autohealing         = true
-				  wait_for_pool_ready = true
-				  depends_on 		  = [scaleway_vpc_private_network.pn]
-				}`, latestK8SVersion),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayK8SClusterExists(tt, "scaleway_k8s_cluster.cluster_with_pn"),
-					testAccCheckScalewayVPCPrivateNetworkExists(tt, "scaleway_vpc_private_network.pn"),
-					testAccCheckScalewayK8SPoolExists(tt, "scaleway_k8s_pool.pool_with_pn"),
-					testAccCheckScalewayK8sClusterPrivateNetworkID(tt, "scaleway_k8s_cluster.cluster_with_pn", "scaleway_vpc_private_network.pn"),
-					testAccCheckScalewayK8SPoolServersAreInPrivateNetwork(tt, "scaleway_k8s_cluster.cluster_with_pn", "scaleway_k8s_pool.pool_with_pn", "scaleway_vpc_private_network.pn"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccScalewayK8SCluster_PoolPublicIPDisabled(t *testing.T) {
 	tt := NewTestTools(t)
 	defer tt.Cleanup()
@@ -474,12 +422,12 @@ func TestAccScalewayK8SCluster_PoolPublicIPDisabled(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
-			testAccCheckScalewayVPCPublicGatewayDestroy(tt),
-			testAccCheckScalewayVPCPublicGatewayDHCPDestroy(tt),
-			testAccCheckScalewayVPCGatewayNetworkDestroy(tt),
-			testAccCheckScalewayK8SClusterDestroy(tt),
 			testAccCheckScalewayK8SPoolDestroy(tt, "scaleway_k8s_pool.public_ip"),
+			testAccCheckScalewayK8SClusterDestroy(tt),
+			testAccCheckScalewayVPCGatewayNetworkDestroy(tt),
+			testAccCheckScalewayVPCPublicGatewayDHCPDestroy(tt),
+			testAccCheckScalewayVPCPublicGatewayDestroy(tt),
+			testAccCheckScalewayVPCPrivateNetworkDestroy(tt),
 		),
 		Steps: []resource.TestStep{
 			{

--- a/scaleway/testdata/data-source-k8s-cluster-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-cluster-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db1ed812-300d-4590-910d-2f0b53eee818
+      - 8effdc06-4a20-49cf-9a80-7dcd66c3f2b4
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.877623Z","dhcp_enabled":true,"id":"3af57380-12e1-45ae-a9fb-5185a58e974b","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.877623Z","id":"3fed59e6-1578-4f9c-aba7-d7fc93b9c514","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:16:56.877623Z"},{"created_at":"2023-11-10T13:16:56.877623Z","id":"1cc9f0b5-3557-4c3d-8535-59132e212ca9","subnet":"fd63:256c:45f7:c47::/64","updated_at":"2023-11-10T13:16:56.877623Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.877623Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:14.908305Z","dhcp_enabled":true,"id":"f33ee154-1936-4ba8-9e29-79eb6853b794","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:14.908305Z","id":"b944d10b-9468-440f-b682-838f9d43c238","subnet":"172.16.28.0/22","updated_at":"2023-11-13T13:51:14.908305Z"},{"created_at":"2023-11-13T13:51:14.908305Z","id":"0dc4edc3-a072-4421-ab30-cfb111d59806","subnet":"fd63:256c:45f7:2ba6::/64","updated_at":"2023-11-13T13:51:14.908305Z"}],"tags":[],"updated_at":"2023-11-13T13:51:14.908305Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "724"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea6aa712-95d9-4f71-b5ab-1c555cb2a121
+      - 7e236646-ffa2-4024-ab79-477bbcf1d5e6
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3af57380-12e1-45ae-a9fb-5185a58e974b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f33ee154-1936-4ba8-9e29-79eb6853b794
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.877623Z","dhcp_enabled":true,"id":"3af57380-12e1-45ae-a9fb-5185a58e974b","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.877623Z","id":"3fed59e6-1578-4f9c-aba7-d7fc93b9c514","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:16:56.877623Z"},{"created_at":"2023-11-10T13:16:56.877623Z","id":"1cc9f0b5-3557-4c3d-8535-59132e212ca9","subnet":"fd63:256c:45f7:c47::/64","updated_at":"2023-11-10T13:16:56.877623Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.877623Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:14.908305Z","dhcp_enabled":true,"id":"f33ee154-1936-4ba8-9e29-79eb6853b794","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:14.908305Z","id":"b944d10b-9468-440f-b682-838f9d43c238","subnet":"172.16.28.0/22","updated_at":"2023-11-13T13:51:14.908305Z"},{"created_at":"2023-11-13T13:51:14.908305Z","id":"0dc4edc3-a072-4421-ab30-cfb111d59806","subnet":"fd63:256c:45f7:2ba6::/64","updated_at":"2023-11-13T13:51:14.908305Z"}],"tags":[],"updated_at":"2023-11-13T13:51:14.908305Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "724"
+      - "725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99a48593-94b7-4589-8b5d-b7093f96cb83
+      - 366dd99f-4615-40d9-8f01-f30c50cd30c8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster","description":"","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster","description":"","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141690756Z","created_at":"2023-11-10T13:16:59.141690756Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:16:59.157804850Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873215544Z","created_at":"2023-11-13T13:51:18.873215544Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.883618610Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1505"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:59 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d3c51e0-d5be-41b0-9648-b91ffd5df954
+      - f94010a3-46af-4951-8179-87794b36ac55
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:16:59.157805Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.883619Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1496"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:59 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4058dce-a61f-49f6-a475-e8ff39ae33cc
+      - 1144fe97-48b5-4cd6-a4bf-42bb8beca5e6
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.316991Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ea16892-11ac-47cf-9260-894d2f5fdd93
+      - 7dc2900a-3dc6-4e08-bdcf-15a96b90d653
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.316991Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df13c059-f895-4bd3-a661-a25c63e3d7b4
+      - 018f6c9c-bb5f-4b47-92f3-0434c40d930a
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2574"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78d64b66-5bd9-4561-9e00-31d6f9085d0e
+      - b7a727cb-b695-46b2-9f98-8f914947673c
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.316991Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2c5799b-d99e-433e-9398-60f1bca9e987
+      - 2b0ee4bb-5da6-4b8a-89e0-cb2cba672eec
     status: 200 OK
     code: 200
     duration: ""
@@ -316,16 +316,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.316991Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.764555Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1533"
+      - "3038"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b47d1050-c755-4f2e-8011-9e09d5de0b9e
+      - b82aa8c7-8b39-4de1-a66b-3fdbe34e9471
     status: 200 OK
     code: 200
     duration: ""
@@ -346,10 +346,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.316991Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -358,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3bd8766-ace6-48d9-ac3a-1ba447c5c0fc
+      - de1068a3-fd60-4184-881a-a44fa9e65da9
     status: 200 OK
     code: 200
     duration: ""
@@ -379,10 +379,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.322611Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.316991Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -391,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 867cd00d-2b5a-4bdb-b550-c5b5d27e71c9
+      - 09bda399-1222-465c-a19e-4dc1e9d81a80
     status: 200 OK
     code: 200
     duration: ""
@@ -412,10 +412,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2574"
@@ -424,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23a70e29-052f-4228-aae5-8f76d9f3465b
+      - faa58dae-80f8-49f2-9291-8382d80f0f57
     status: 200 OK
     code: 200
     duration: ""
@@ -445,10 +445,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2574"
@@ -457,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d74e8a9-0241-4ccd-8e4f-d454a5ac9566
+      - 93caca29-19bd-4ba6-8b09-1c435be1d4b6
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578003971Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605094Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "620"
@@ -492,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a6b9a28-0f60-4137-bcac-986aaad2f778
+      - f53019c5-3682-464c-a82a-1a830d627f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d227efd5-023e-4f56-9242-215062917e4c
+      - 00192aa2-bc0c-4c34-afc4-2dd050557703
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:10 GMT
+      - Mon, 13 Nov 2023 13:51:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aba53479-09af-4ad2-9213-11ace9e9ff75
+      - 9c1d0b43-0b94-491c-bc16-39e587388533
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -591,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:15 GMT
+      - Mon, 13 Nov 2023 13:51:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 422cb3f0-c922-46c7-b5d4-95643714445c
+      - 52f7311b-e7fe-49b3-99fd-1cbe4285b9fc
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:51:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6619a5eb-5220-4fef-b99f-b026ecaef940
+      - f31fcd40-c5cc-46c7-b10e-e4f62dfae938
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:25 GMT
+      - Mon, 13 Nov 2023 13:51:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66417451-b8c5-4efc-af85-4e7f3fb05faa
+      - c0155232-8698-4084-a44d-455fff12fe68
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:30 GMT
+      - Mon, 13 Nov 2023 13:51:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 133f50d4-4584-4480-bea3-78eb0c1cd0fc
+      - 698f0cf1-fc5c-4ab4-befa-3ac2782d838e
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:35 GMT
+      - Mon, 13 Nov 2023 13:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a05a1755-1406-42c9-b6a2-6642ba9b6b5a
+      - 93038302-79bc-4924-9306-2d1a6c883e04
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:40 GMT
+      - Mon, 13 Nov 2023 13:52:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3589771f-92d2-434f-83ec-e137fed8dc6d
+      - 65c54e8e-01a0-4fc9-8ca1-3477913029ca
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:46 GMT
+      - Mon, 13 Nov 2023 13:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa2ac838-6333-4efc-b5b4-d6d793b46800
+      - cb422ac2-b37d-4025-9995-c167b5987966
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:51 GMT
+      - Mon, 13 Nov 2023 13:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0172b3b0-4bba-4329-8a3a-71a944652ec8
+      - 156e07e6-d49e-4edc-b575-d1dd39d0a4a8
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:56 GMT
+      - Mon, 13 Nov 2023 13:52:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69c52c06-dda9-45b3-8190-355b1f5b5d85
+      - ab474c15-4dac-4046-830b-9c68354c7184
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:01 GMT
+      - Mon, 13 Nov 2023 13:52:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6dc8dec-03d1-46ff-85c1-af2e76db29f7
+      - d2b20cfd-c2e1-4bcb-b5e6-f36211ae33c2
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:06 GMT
+      - Mon, 13 Nov 2023 13:52:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24f63fb7-3331-4b11-9bad-d66affdbce18
+      - 7e1f0c23-3faf-4ab2-a417-dc7a1989733e
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:11 GMT
+      - Mon, 13 Nov 2023 13:52:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b6300fe-48fb-41ef-ba63-d38ba79d30fa
+      - 50ec258f-1ccc-4110-bf80-b973a984b599
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:16 GMT
+      - Mon, 13 Nov 2023 13:52:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48d084b5-9e08-4cd7-854e-2ec66688243e
+      - 836969c5-d035-4bbe-abef-8c07c81dd2a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1020,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:21 GMT
+      - Mon, 13 Nov 2023 13:52:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3458f5e-05c3-415b-ada7-b334eb719ff9
+      - 3225e636-bd09-4fcc-8d99-b469051f4888
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1053,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:26 GMT
+      - Mon, 13 Nov 2023 13:52:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fcd5e36-ca06-42a1-bc69-83c95a2d1900
+      - 6ccf0e9b-68fe-4ef3-8373-08b27cf34cc7
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1086,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:31 GMT
+      - Mon, 13 Nov 2023 13:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbcb9eba-15e4-4ec5-93c3-dff63f4b89c0
+      - 2f1639a1-41e7-41ca-82ff-7ed4f3958ff6
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1119,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:36 GMT
+      - Mon, 13 Nov 2023 13:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cdebcd5-b771-4290-8297-74f0b2fb2b9d
+      - fe04596f-9b62-4c56-9314-26444fedfa63
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1152,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:41 GMT
+      - Mon, 13 Nov 2023 13:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 710b33c3-f603-4e21-befe-62b0bb862898
+      - a4de1ff4-21ea-4f96-a2f4-799a56b12fb5
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1185,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:46 GMT
+      - Mon, 13 Nov 2023 13:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 629f6a3e-7aa0-4754-9bc0-c68fece5e97c
+      - ade123bf-1e1a-46c4-adaf-ec05396f958e
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1218,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:51 GMT
+      - Mon, 13 Nov 2023 13:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f54af78-61f2-4aa1-aab0-2ae5e5c21e3e
+      - 65fdba00-02fc-42ab-8c50-d8575a655df4
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1251,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:56 GMT
+      - Mon, 13 Nov 2023 13:53:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93e004a0-656c-4c5d-bcb9-5d3417ac6ca4
+      - 41f2f34a-89df-429e-bc5b-1459810d7b94
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:02 GMT
+      - Mon, 13 Nov 2023 13:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10f81494-f6b1-42f1-b051-6a48e5e080ad
+      - 2b628f63-a34c-4bd8-8e06-85bc1c74a314
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1317,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:07 GMT
+      - Mon, 13 Nov 2023 13:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbaaa82e-de39-49cd-96b9-fca03dda21fc
+      - 6a18d37a-9b4f-4079-be99-bc07aa342638
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1350,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:12 GMT
+      - Mon, 13 Nov 2023 13:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7a34a74-6d80-4009-aba7-e4ffcca99ed0
+      - c51cc10d-d211-4054-90a7-a5082a1099ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1383,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:17 GMT
+      - Mon, 13 Nov 2023 13:53:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23f7b492-e05f-40b1-a76d-78ba00a1b46f
+      - 7c2057c2-6e81-4e3b-8425-57ba692bd43c
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1416,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:22 GMT
+      - Mon, 13 Nov 2023 13:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbb71d85-8d13-41d5-b442-6e13966df389
+      - 2a1ed5f2-af5a-49bd-bf15-6fb55165c3bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1449,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:27 GMT
+      - Mon, 13 Nov 2023 13:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bba9049-df93-469d-8f30-315cd0092b6a
+      - ffc447cf-35c9-48d1-aa59-5cc6e14df26e
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1482,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:32 GMT
+      - Mon, 13 Nov 2023 13:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9097e431-4000-40aa-97b1-040e46e40107
+      - 467db6e0-3a40-48df-81ad-f2f7be531e31
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1515,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:37 GMT
+      - Mon, 13 Nov 2023 13:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2458201f-6948-4a0e-9896-0e3ba40b01be
+      - fe898449-bf84-44c3-b53f-ddf02096405a
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1548,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:42 GMT
+      - Mon, 13 Nov 2023 13:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b920f7f-25a9-4c31-9aa7-19adaa204c19
+      - 990b071c-5190-44f6-8809-350e9bdd9d30
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1581,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:47 GMT
+      - Mon, 13 Nov 2023 13:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - faa8a6c6-ef8c-4ddc-b230-98fe0ed3b735
+      - 8924581d-1bed-4067-b2cb-8c13245e1565
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1614,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:52 GMT
+      - Mon, 13 Nov 2023 13:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83cf17c2-0907-4742-8521-b6e47e5d7a3f
+      - 50f44484-abdb-4304-83f4-86cde6533588
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1647,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:57 GMT
+      - Mon, 13 Nov 2023 13:54:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a28a1a5a-94aa-4ebd-a1ff-855474f8a5c2
+      - ceb16a6e-f15e-4ad8-bd41-ac731a069cf4
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1680,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:02 GMT
+      - Mon, 13 Nov 2023 13:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec1b1bc3-65c7-4e5b-adfc-4db08636e690
+      - 6e123551-6ecd-4983-bec0-52fec5f3453e
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1713,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:07 GMT
+      - Mon, 13 Nov 2023 13:54:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a745343-adb8-4ba0-bd0d-10011a9dc760
+      - 5e3c10f0-56f2-4d9f-a595-3eb21b8d30c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1746,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:12 GMT
+      - Mon, 13 Nov 2023 13:54:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17d8fa22-a73c-4206-b6ad-ba44deacf7ee
+      - b7a2a75e-2e19-4a69-9bc4-ae6e28a4fe63
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1779,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:18 GMT
+      - Mon, 13 Nov 2023 13:54:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28b18137-a6c3-4ad4-aa81-b4a2b841fd14
+      - 00f33293-ef77-4ed5-a953-59bd2cd22a03
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1812,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:23 GMT
+      - Mon, 13 Nov 2023 13:54:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28ded471-d892-4837-bc5f-85e7403455cc
+      - c749b945-956b-4979-aa74-cecb78c3f2f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1845,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:28 GMT
+      - Mon, 13 Nov 2023 13:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c374a179-eb03-478c-ae4e-8775da0fcb43
+      - c396febe-5536-49e7-8fc4-406d00dfd014
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1878,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:33 GMT
+      - Mon, 13 Nov 2023 13:54:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef80fca4-6ec1-4e30-a34c-7323a40dade7
+      - a9c8a03b-2b04-42b4-9810-ee430199f487
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1911,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:38 GMT
+      - Mon, 13 Nov 2023 13:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b53a10f6-c7df-4ff7-b443-65b88c6f8877
+      - 32df3894-1954-464e-9ab3-9cef78fe415a
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1944,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:43 GMT
+      - Mon, 13 Nov 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e168a2a6-572b-4555-8d81-0a5ea7ef545b
+      - 5e1724d1-4788-498a-8682-e11a7ee05cbf
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -1977,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:48 GMT
+      - Mon, 13 Nov 2023 13:55:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - addf1f8f-e197-4fb4-ae17-40e55bde8988
+      - 22ab05f7-9781-4277-b30b-2da23e0cbf6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2010,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:53 GMT
+      - Mon, 13 Nov 2023 13:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbe101fb-8cfc-45bf-9d07-f573061d6ef3
+      - 81dd0964-39e3-446c-bbe0-cb24d1f55112
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2043,7 +2043,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 13:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f5c7cc2-e1ad-4fe5-9a9e-1fdb26fa6667
+      - 14fee505-ae0f-4c0c-b462-9718689bb6d8
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,10 +2064,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2076,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:03 GMT
+      - Mon, 13 Nov 2023 13:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f8c265a-595c-4b79-ad7b-f3671fe9079e
+      - e1e995a2-a9e4-45c4-9400-e1fe92089c17
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,10 +2097,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2109,7 +2109,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:08 GMT
+      - Mon, 13 Nov 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa99eb35-7893-45e9-b3b8-85ac47196e71
+      - 896b77fd-2b01-474e-ac51-eb13b6adfa0b
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,10 +2130,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2142,7 +2142,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:13 GMT
+      - Mon, 13 Nov 2023 13:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81d81447-a0f4-4fc6-afa8-ebc85b57aebb
+      - bd6afae8-ac32-42cc-988b-a22bfd0d18bc
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,10 +2163,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2175,7 +2175,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:18 GMT
+      - Mon, 13 Nov 2023 13:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a04bcda-d350-4d87-bedf-a83f07e79e6d
+      - d9767515-cb6d-496e-bb67-e54b5f4a6fce
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,10 +2196,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2208,7 +2208,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:23 GMT
+      - Mon, 13 Nov 2023 13:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31d31176-54d5-4141-9096-900bbf1f0e2b
+      - aa5f2931-84ab-449f-93d9-c5ad12301e27
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,10 +2229,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2241,7 +2241,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:28 GMT
+      - Mon, 13 Nov 2023 13:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11ab5d26-f1ee-4644-82fa-16e297ad6882
+      - 02c89b99-8508-4a13-b626-b448b5cf30cc
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,10 +2262,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2274,7 +2274,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:33 GMT
+      - Mon, 13 Nov 2023 13:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e767c1f-e896-4b26-922a-959e47701bd5
+      - 82f73089-5210-4a9b-8cd5-bf8380c8a7bc
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2295,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2307,7 +2307,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:38 GMT
+      - Mon, 13 Nov 2023 13:56:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 555a241c-52b2-44b2-9326-5419d20e9d79
+      - e2a2dce3-8105-4ab6-b178-69cc5efdde13
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,10 +2328,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2340,7 +2340,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:43 GMT
+      - Mon, 13 Nov 2023 13:56:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d1a802a-5d67-4c83-bea3-a5b545b55018
+      - 9dd1d1df-6331-4113-9647-a206ba1c1aa3
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,10 +2361,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2373,7 +2373,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:48 GMT
+      - Mon, 13 Nov 2023 13:56:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c56fc88-f898-4278-a2db-c1b3c49c23a3
+      - ae25ca5d-bdc6-4623-8625-d4e6f1ed4943
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,10 +2394,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2406,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:53 GMT
+      - Mon, 13 Nov 2023 13:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00489b34-74f4-44b2-9aa1-730aa7385443
+      - 095fe7eb-2203-4d8c-8d2b-5fe7ef25e297
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,10 +2427,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2439,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:59 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8fcb4fb-7d19-43b6-bb48-9152e98ad0cf
+      - 3ff7f6ed-f40e-436b-bc41-554c4395bfb5
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,10 +2460,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2472,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:04 GMT
+      - Mon, 13 Nov 2023 13:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 033601cd-7a5a-407d-bf42-83ba34332018
+      - e6aecdea-c0fe-4e4b-b5d3-bb863c6b0c44
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,10 +2493,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.304605Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "617"
@@ -2505,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:09 GMT
+      - Mon, 13 Nov 2023 13:56:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a49ce3e-f408-4bc0-b834-38963ad6fa91
+      - 3f281707-e605-4de7-95eb-0867e9ff6241
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,241 +2526,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb815c4a-1e38-453b-b7a1-b60700ca0b3b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1383e3cb-7bd8-46f5-b5d7-aa0bde0b6892
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8413b236-9aeb-4ac8-8bb6-0a18a777e86b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cb8357e4-41de-4849-aa00-c6670fe99039
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b7f66b27-3f05-4616-b5a9-e59b3ee6e888
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ee6c426d-da33-4640-a490-74ba943a5e63
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.578004Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85f20e88-e1e8-423c-bd95-684b93f323b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:47.865133Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:35.351236Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -2769,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:49 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2779,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2a584d7-b863-46b6-9738-ad246bcb0af7
+      - d3fc4cac-c7bf-4611-b158-c896b5597816
     status: 200 OK
     code: 200
     duration: ""
@@ -2790,10 +2559,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1493"
@@ -2802,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:49 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2812,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f226eb86-2574-4c3e-9374-e23c1f97cf89
+      - 5d84e7af-7a05-41e1-8ee0-6e1c8fd2b602
     status: 200 OK
     code: 200
     duration: ""
@@ -2823,10 +2592,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:47.865133Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:35.351236Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -2835,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:49 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2845,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 087a92a5-4c42-4726-81e3-0e285c8a2c45
+      - d45abd94-137c-46d7-be60-b444a083c06f
     status: 200 OK
     code: 200
     duration: ""
@@ -2856,19 +2625,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/nodes?order_by=created_at_asc&page=1&pool_id=6b36e370-15bb-4229-be44-a68b2a5cff3a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/nodes?order_by=created_at_asc&page=1&pool_id=7fe9f813-2453-4fe9-a891-af3b455a34bc&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:54.677Z","error_message":null,"id":"acd0b331-06d2-4905-ab09-320f7cb69c79","name":"scw-tf-cluster-default-acd0b33106d24905ab09320","pool_id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","provider_id":"scaleway://instance/fr-par-1/10e84246-1002-4357-a749-80dcdd74a4c9","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:49.539023Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:13.234288Z","error_message":null,"id":"1a3aaa1d-af86-415f-b87b-dd6d6e775d7a","name":"scw-tf-cluster-default-1a3aaa1daf86415fb87bdd6","pool_id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","provider_id":"scaleway://instance/fr-par-1/de7f7c95-6a53-4aa9-a905-7d4c3b3ca8fa","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:35.337279Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:49 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2878,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9c4091c-e789-48fb-8f0c-5a53d1a9e2d5
+      - b6f0a364-e570-4575-ad1b-319625d52810
     status: 200 OK
     code: 200
     duration: ""
@@ -2889,43 +2658,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 81426cd4-b9f2-4423-8a0c-bef1e28c0837
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1493"
@@ -2934,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:49 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2944,7 +2680,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d02325d6-3c02-404b-bee1-704ceb52ae53
+      - cc65fbee-3f3d-4e57-b976-534d5ed5a60d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1493"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0fa38948-d026-42e7-9764-414b5de53281
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1493"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2f2cb3ee-40f7-4558-ab9b-b13d589a7fc7
     status: 200 OK
     code: 200
     duration: ""
@@ -2958,7 +2760,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.703659Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
     headers:
       Content-Length:
       - "3022"
@@ -2967,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2977,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 002f80c7-5e8d-4918-ac85-ffff2e4dd927
+      - 55d271cd-0aa9-4e1b-be67-574c37641c8d
     status: 200 OK
     code: 200
     duration: ""
@@ -2988,76 +2790,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a4f2cc9-b4c4-47ce-b707-8c171c24dd74
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de782c0d-f926-40ef-bd1b-ab290bc75bef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2574"
@@ -3066,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3076,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d3f9537-70bf-4b30-8855-39fc994084f4
+      - b79baeba-21e3-4365-964b-fbb8724dad1f
     status: 200 OK
     code: 200
     duration: ""
@@ -3087,76 +2823,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2574"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7806252b-47dd-4d14-b537-afd1270ab222
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3af57380-12e1-45ae-a9fb-5185a58e974b
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-10T13:16:56.877623Z","dhcp_enabled":true,"id":"3af57380-12e1-45ae-a9fb-5185a58e974b","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.877623Z","id":"3fed59e6-1578-4f9c-aba7-d7fc93b9c514","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:16:56.877623Z"},{"created_at":"2023-11-10T13:16:56.877623Z","id":"1cc9f0b5-3557-4c3d-8535-59132e212ca9","subnet":"fd63:256c:45f7:c47::/64","updated_at":"2023-11-10T13:16:56.877623Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.877623Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "724"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d34b929f-fdfe-4c53-b8b6-7c7cf4dac3e2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1493"
@@ -3165,7 +2835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3175,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19a0c908-3a9e-4027-a4a0-064c1cd3ddfd
+      - 4b6ee24f-4eed-4cae-8e89-435fb118da58
     status: 200 OK
     code: 200
     duration: ""
@@ -3186,10 +2856,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2574"
@@ -3198,7 +2868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3208,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a463e45-093c-4c0b-8152-6f40c812c9cc
+      - 8d3b2cf3-a295-49c3-a9a0-03611dd9eb02
     status: 200 OK
     code: 200
     duration: ""
@@ -3219,10 +2889,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f33ee154-1936-4ba8-9e29-79eb6853b794
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:47.865133Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-13T13:51:14.908305Z","dhcp_enabled":true,"id":"f33ee154-1936-4ba8-9e29-79eb6853b794","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:14.908305Z","id":"b944d10b-9468-440f-b682-838f9d43c238","subnet":"172.16.28.0/22","updated_at":"2023-11-13T13:51:14.908305Z"},{"created_at":"2023-11-13T13:51:14.908305Z","id":"0dc4edc3-a072-4421-ab30-cfb111d59806","subnet":"fd63:256c:45f7:2ba6::/64","updated_at":"2023-11-13T13:51:14.908305Z"}],"tags":[],"updated_at":"2023-11-13T13:51:14.908305Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06be3e88-9406-442a-bfa7-9ef118df769c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1493"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cb440af9-0619-4dda-80c0-7d106024b40c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2574"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7d3c9392-9172-4910-b4de-be0e4ad74671
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:35.351236Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -3231,7 +3000,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3241,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16dae40c-fb21-41d9-ab2e-d67d940d4d0c
+      - c270acd4-b71b-480a-830b-2aa0060fb4c0
     status: 200 OK
     code: 200
     duration: ""
@@ -3252,10 +3021,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1493"
@@ -3264,7 +3033,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3274,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a30d882-0a49-49d0-987e-9c4518c3d7ea
+      - 735baf51-4991-4d0b-a7ff-16a30dcad01b
     status: 200 OK
     code: 200
     duration: ""
@@ -3288,7 +3057,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.703659Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
     headers:
       Content-Length:
       - "3022"
@@ -3297,7 +3066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3307,7 +3076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 391e8e04-5f4a-46f7-8d99-a7f59886fb4f
+      - 68ba7b09-b85b-4a08-8101-1dffecdbe6d4
     status: 200 OK
     code: 200
     duration: ""
@@ -3318,19 +3087,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/nodes?order_by=created_at_asc&page=1&pool_id=6b36e370-15bb-4229-be44-a68b2a5cff3a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/nodes?order_by=created_at_asc&page=1&pool_id=7fe9f813-2453-4fe9-a891-af3b455a34bc&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:54.677Z","error_message":null,"id":"acd0b331-06d2-4905-ab09-320f7cb69c79","name":"scw-tf-cluster-default-acd0b33106d24905ab09320","pool_id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","provider_id":"scaleway://instance/fr-par-1/10e84246-1002-4357-a749-80dcdd74a4c9","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:49.539023Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:13.234288Z","error_message":null,"id":"1a3aaa1d-af86-415f-b87b-dd6d6e775d7a","name":"scw-tf-cluster-default-1a3aaa1daf86415fb87bdd6","pool_id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","provider_id":"scaleway://instance/fr-par-1/de7f7c95-6a53-4aa9-a905-7d4c3b3ca8fa","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:35.337279Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3340,7 +3109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09f758d8-6b16-4c13-8a7c-61ab28c849e5
+      - af5074b9-624a-4eec-bb4c-5e03f8222cd0
     status: 200 OK
     code: 200
     duration: ""
@@ -3351,109 +3120,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b489faaa-a417-4f31-9e8d-c01dec1aa754
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2574"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 78fa5ac6-3d1b-4dfd-b61e-d665bb5b44a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2574"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - da6f8b97-f66c-4758-b662-afc6e7d37e68
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1493"
@@ -3462,7 +3132,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:51 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3472,7 +3142,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5273d7bc-0627-4fa3-8c4f-8317f5b7c768
+      - f8431638-cfa2-409b-b826-e38ede09b648
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2574"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 53180790-b753-4caa-a82e-b1662d220f89
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2574"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11365161-c108-4b4e-82e1-37e6b664b047
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1493"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cf18cb3a-635d-484c-a390-79d1e658b24d
     status: 200 OK
     code: 200
     duration: ""
@@ -3486,7 +3255,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"},{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.703659Z","upgrade_available":false,"version":"1.28.2"}],"total_count":2}'
     headers:
       Content-Length:
       - "3022"
@@ -3495,7 +3264,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:51 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3505,7 +3274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12c7c594-699f-49e3-9992-87b75db8e2ce
+      - 7bb359ca-8f6e-4630-af10-7e236a5b3116
     status: 200 OK
     code: 200
     duration: ""
@@ -3516,10 +3285,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:18:20.662463Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.506629Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1493"
@@ -3528,7 +3297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:51 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3538,7 +3307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18dde832-8f52-4235-8fe9-41c0270d0fe8
+      - ca8f5afa-6d16-4919-9f04-c0d7a80f8bc7
     status: 200 OK
     code: 200
     duration: ""
@@ -3549,10 +3318,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2574"
@@ -3561,7 +3330,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:51 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3571,7 +3340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f129b120-e5e0-4ac8-b2ac-b1de38b2137b
+      - 84068622-48de-44f5-b588-265af9c956db
     status: 200 OK
     code: 200
     duration: ""
@@ -3582,10 +3351,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJqZDAxR2IxaEVWRTE2VFZSRmQwOVVSWHBOVkdOM1RVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG1FNUNubFRibWRUZGpGbVNpOXlXbEV6ZG5sYVMxaHpNU3N5YzJ0NFFtbHVia3h4VUdwa1VuUjBhSGRFVmxCSFNWRlNUMk5HWmxsaFdVczJTR1JDTUVKUFYwTUtOM2M0U1d4V1JVY3hkbFl3TmtNMmQwVmlaR1U1WWtOQmMyNVhhRE5PVFRBdlNVRkxRbWx6SzBkYWVFcFpkME5OYm5Selp6Wm1Sa1pyVDI4NWRtMUZkZ3BpU25JeEsxRklZUzlEYjI1RlZFZzRVazVCZURneGNuRldVRUZhVDJ4cmVXSnpWMlpSUW1OUVVYSkpLekZpU2tkb1ltaEpWRm81YlZKS0wwVlVlRGxrQ21SVVlsTkJjMGQ1VkdOcVkwWjJiVTVuUTI5WVpqQXlhVlZHWWxCM2RESk5Rak15WXl0d1NrWkplaXQwWjAxNmVWcENTWEZHUm5KV01GUnFVMU15SzA0S01XMXdOMjU0YW5jMlMxY3JLMVJrZDNWeFNIWXJOa3hWWVRoQ2RXSXllVVI0VTFCamJ6WkxjR2xGUVdkbFJYTTRWVzVsVVd0WlozTmFlVE5QZWtSRFRncFhaR0ZqY0ZFNVdHaFVkVlJNYlV0MVVtODRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZielZNZDJabVVUWXZVMUpEVG1Gb1EzQXdVblV2YVc1MWNsVk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJTVTh3VG1ncmRYRm9RM2RzYjBWdk9YUldNa0UyUVdacWVHMHlhRXQ0S3pZNWMyMHdTRU5DZFcxa1pURjJWMlJCZHdvcmFIaE1SV1JtYWtSdWQxSkVlRll3WmtZMlRXMVRVMlZyTHpSMFdUUkRWalUwU2psdU55OXlVa1pLWW1OaU9UZG5NVzl1UzBabUswOWlNVzVpT1VGR0NuRklVbXRyTUhSRVlrcHFWWGR3Wm1KVk1XVjNhRWsySzJOR1RIY3dLMHMxTUVzMGRXUmxkbGRrYmpOS00zaE5RbmwzYlZSb1ZuVTNOSEFyYVZKNFZVRUtPV3BpU25vemFrcHNhR1ZJZGtsUVVYZFZlbFZYYW5oR2QyRjRaWEY2VldRNE1sUnhRWEJWS3pKUFlYaGxXVmREWkRsMkwxZFRUalo2YTNjNVdUbHVSZ3BLS3pOTlQxZHViVlZHZG5Wck0yVjJUamRyWWtSb2Mwb3llVll6T1hKa1JUZzNlRVIyVWpWNk1XOUtSSE5CU21GdU4xUkJTekUxUlZCYVoyYzJPSGxTQ205b1Qwa3pjVUpaUVVGT1VGUkxjR1ZxTm05U1JsWlJWVWRMT0dkM2RFcFVja1JhYUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzA0OTRmNzhmLTc5YmUtNGE4NC1iZGI0LTQ3M2M0YzU1ODZkNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB6c3lVbmd4TnZ0S0RtUGZIbWlhSGlpVElYWEFBQ1ZhazdkNXlKZTN4ODVwS05SZXVmVk9JZTVxQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCU3pWTENuTnVlazEyVWtWMmVXRjROMEZtVlN0amFIWm5TVXBLT1ZGNlozSllibk5pY0VWWU1FWjNjMWt5YVhKTFFsTnVVMVY0SzI5amNWSllSblpQTkdwVVFUTUtNMFk0YVV0eGRrMUlkMHRJZG1OMFVYQXpaa2h1SzJkTFYxaDZkRFJIWjNneVNuaDVRMFF3VUhadWVYWndWemQwWm10V1pVUXpSbU4xWmxOTWEzQk9VQXBNUzAxMFRqVTFiWE5KZUhGd2RWQm1WR3hETTFSQ2FGZDBSMHBvYjI5ak5UaFZPVm8wUW1GR2NIWTNWWEE1TUROUVlXbFVlV1YzUVc5RVJVeHlXR3hwQ2xjM2FrVnFLM1F2WW5VNVZrVkJNR0pMYjNCVGIyOTZNelpKTmtFMFdVdFlTV2RoVlZkNVZtTm1VMmxhWkZBM1VGWjBjUzlJVG05a1JrRlNTRTVYVEhnS01HOXVUblZvU1ZkalZIWlpOVVp2YW5kUU5YVmhZa1ZFTjJaV01EUXdURU5LTHk4MWJsbFFhWEJzT1VnMWR6Tk9NME5yTlRsTlYwaDZlVGRyZHpodUx3cFNNblE0Y25oa1RYaDZaRlFyVVZOMmNFTk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaRk5LY1dGbmVrY3ZVWGcyVVVwNE5XMUlhMFJGZFZKd2JUWk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZMlZYTVU4eVluUldPRWhRVmtOeE9URlRRME5yYTBWVFVtcG1TVmhWWmpaUmRscGxUbWR2UlhkNFNWRkVOMWhxY0FwdVVIa3JSRU42TjA1T1pXaGlhRlZySzBnMWFsWmhjelI0TUhwalZHRjRkSGMzYWxrNUwyeEtkWFZMVjBkbGVFb3lUVmx1Y0RGS1NYTjJWRmg2ZUZWcENrSm5SRE5XTjIwMWNERkZaV2xNT0hSVlZFTnNLMmR1YlU5bWExbFJXRUZKVXpGTGRtZzRaMHAyZWs1UmMwTkNUMnRwU1VOdldrWTBURmxCWmtGd1ZrY0tWVlYxWVRRcmNFZG5NRVZ4YTBsM2IxcFVWMWRGY25SYWRsSmhOV0pKT0d0MWRFVnpiVnBxWjBKdFdIcEZORVp5U0hBeWNsUmFlamQwZDNWUFdtMUVWZ3BDYUhOaVVHMVJTbE5JUTFkMU1GQnpOblIxY0VSVEwxUjJSWE5hZFVOSk4yMHdUbFJFVldGc1dUTm5UR3ROZG00NVRWUlJhVU0xZWt4TVJrWnFjemhWQ2tWaUwyZzRORlZZYVZsUFJWbEthMDVITjNkRVVFZE5jbUpsTTFZeWNrWnNlbWM0YWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0ZjFkNGZhLWQ2MTgtNGI3Ni1iNDc0LWYwYjQwMThmMmVmNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUMktobDA1SjhTVXZxVDNqOHI3VGR4bHdxU1pKdFNPenYwQWRKY3ZSOE1vUTVGOEc2Q0ZNZldOVg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2574"
@@ -3594,7 +3363,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:51 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3604,7 +3373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63d59077-83c4-4dd7-88e2-0920cc44b685
+      - 34eddc33-076f-4454-87ba-a67a75f46b41
     status: 200 OK
     code: 200
     duration: ""
@@ -3615,10 +3384,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013994571Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:39.794596627Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "621"
@@ -3627,7 +3396,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:52 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3637,7 +3406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 826e278d-73d1-484f-821f-a82dcb433fce
+      - d4f2534c-b841-47ca-ae3e-7683aac5a78e
     status: 200 OK
     code: 200
     duration: ""
@@ -3648,10 +3417,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:39.794597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "618"
@@ -3660,7 +3429,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:52 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3670,7 +3439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d35fa23b-7031-4fd6-a28f-052789e0c3b2
+      - 8d5d9d57-ed1e-43db-9e14-96fc4ac3ab2e
     status: 200 OK
     code: 200
     duration: ""
@@ -3681,10 +3450,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:39.794597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "618"
@@ -3693,7 +3462,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:57 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3703,7 +3472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b4e0571-05f2-4a7b-916a-acba666dd56a
+      - dde3b357-28df-4d90-845a-52159b7194ac
     status: 200 OK
     code: 200
     duration: ""
@@ -3714,10 +3483,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:39.794597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "618"
@@ -3726,7 +3495,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:02 GMT
+      - Mon, 13 Nov 2023 13:56:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3736,7 +3505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9d121ac-9eaa-4771-87e0-a65fe964b854
+      - b5479e5b-cdd5-432b-b587-985658c41f9c
     status: 200 OK
     code: 200
     duration: ""
@@ -3747,10 +3516,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:39.794597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "618"
@@ -3759,7 +3528,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 13:56:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3769,7 +3538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e754b677-ef38-4161-a11f-57e6a61f1d5b
+      - e71b5384-a722-4b88-95ac-16b37341062a
     status: 200 OK
     code: 200
     duration: ""
@@ -3780,10 +3549,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.569504Z","id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:52.013995Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.292564Z","id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:39.794597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "618"
@@ -3792,7 +3561,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:12 GMT
+      - Mon, 13 Nov 2023 13:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3802,7 +3571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5611d7c-b83b-4145-8ed3-826627bcc008
+      - 3e73ddb8-f4d9-45bb-8a29-4d631dce8f55
     status: 200 OK
     code: 200
     duration: ""
@@ -3813,10 +3582,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3825,7 +3594,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:17 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3835,7 +3604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f12343a-af09-4eab-9731-4dde357b7033
+      - 262810e4-3fa3-4e66-a82b-99d79fe82960
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3846,10 +3615,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:23:17.452553357Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:57:05.161059518Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1499"
@@ -3858,7 +3627,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:17 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3868,7 +3637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e02dfb5-2508-45bb-b941-c2cfabf8f4fc
+      - fd562e8e-8158-45ae-914c-6e9cf0e32311
     status: 200 OK
     code: 200
     duration: ""
@@ -3879,10 +3648,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:23:17.452553Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:57:05.161060Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1496"
@@ -3891,7 +3660,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:17 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3901,7 +3670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d8287c0-71ef-4855-9848-72961e92c4d4
+      - 88058137-8da8-4b7a-b2bd-6f01d08f73a8
     status: 200 OK
     code: 200
     duration: ""
@@ -3912,10 +3681,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0494f78f-79be-4a84-bdb4-473c4c5586d6.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:59.141691Z","created_at":"2023-11-10T13:16:59.141691Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0494f78f-79be-4a84-bdb4-473c4c5586d6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:23:17.452553Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.873216Z","created_at":"2023-11-13T13:51:18.873216Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e4f1d4fa-d618-4b76-b474-f0b4018f2ef5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:57:05.161060Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1496"
@@ -3924,7 +3693,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:22 GMT
+      - Mon, 13 Nov 2023 13:57:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3934,7 +3703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2861e31-4088-47c1-816a-6327f3f94687
+      - 8b8c0b6b-02ca-43ca-906e-bbdb65370fcb
     status: 200 OK
     code: 200
     duration: ""
@@ -3945,10 +3714,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3957,7 +3726,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
+      - Mon, 13 Nov 2023 13:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3967,7 +3736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be32a83f-5dc7-41e4-a627-fba220a9b5c6
+      - bd165875-6390-4956-9e9e-633fbe44f3a8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3978,10 +3747,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3af57380-12e1-45ae-a9fb-5185a58e974b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f33ee154-1936-4ba8-9e29-79eb6853b794
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3990,7 +3759,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
+      - Mon, 13 Nov 2023 13:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4000,7 +3769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 075c3544-e899-4530-b98c-447502809c81
+      - bf58a058-fc52-4791-846d-31fc6bc1ea5d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4011,142 +3780,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3af57380-12e1-45ae-a9fb-5185a58e974b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7fe9f813-2453-4fe9-a891-af3b455a34bc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3af57380-12e1-45ae-a9fb-5185a58e974b","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1746aa09-85ac-4a7e-af97-511e5271ad53
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 34216f58-59b1-464b-bf84-d033a416b9ef
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dc4fe4c1-d22d-4c36-a237-1dbd93986431
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0494f78f-79be-4a84-bdb4-473c4c5586d6
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0494f78f-79be-4a84-bdb4-473c4c5586d6","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 61e0a550-5c84-47e1-911a-670954d60292
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b36e370-15bb-4229-be44-a68b2a5cff3a
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"6b36e370-15bb-4229-be44-a68b2a5cff3a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"7fe9f813-2453-4fe9-a891-af3b455a34bc","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4155,7 +3792,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
+      - Mon, 13 Nov 2023 13:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4165,7 +3802,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ba9a5d4-e26f-439e-a7a8-bedbd9f69bc4
+      - 55eedae3-0249-42b2-bddf-12d66cb34718
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f1eac9cc-62d0-4b89-9e5a-96e508ec275b
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd94283d-695c-4891-9af9-2ad0168e6f5c
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e4f1d4fa-d618-4b76-b474-f0b4018f2ef5
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e4f1d4fa-d618-4b76-b474-f0b4018f2ef5","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 520daffe-6c17-49af-9bf9-544131b75300
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f33ee154-1936-4ba8-9e29-79eb6853b794
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"f33ee154-1936-4ba8-9e29-79eb6853b794","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 193f6971-74f3-4840-8baf-01a90f70495b
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:19 GMT
+      - Mon, 13 Nov 2023 13:51:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95c70dd7-244f-4acc-ae59-7d0f43d58d44
+      - 1a7584c7-23af-4e43-afe3-da24108cfaef
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:17.107936Z","dhcp_enabled":true,"id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:17.107936Z","id":"ebd144e8-9689-4ab8-aee3-25922300adb6","subnet":"172.16.48.0/22","updated_at":"2023-11-13T13:51:17.107936Z"},{"created_at":"2023-11-13T13:51:17.107936Z","id":"8a9f9657-f39c-4fa2-a5cc-351758a7349f","subnet":"fd63:256c:45f7:198c::/64","updated_at":"2023-11-13T13:51:17.107936Z"}],"tags":[],"updated_at":"2023-11-13T13:51:17.107936Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:21 GMT
+      - Mon, 13 Nov 2023 13:51:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 850f8cb2-476e-4356-a107-0c702b8a5d93
+      - 19f388aa-4a74-498f-ac77-153b3f8fb0c1
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7d4cdc29-ed97-4c47-9dad-9866c3e4716e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:17.107936Z","dhcp_enabled":true,"id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:17.107936Z","id":"ebd144e8-9689-4ab8-aee3-25922300adb6","subnet":"172.16.48.0/22","updated_at":"2023-11-13T13:51:17.107936Z"},{"created_at":"2023-11-13T13:51:17.107936Z","id":"8a9f9657-f39c-4fa2-a5cc-351758a7349f","subnet":"fd63:256c:45f7:198c::/64","updated_at":"2023-11-13T13:51:17.107936Z"}],"tags":[],"updated_at":"2023-11-13T13:51:17.107936Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:21 GMT
+      - Mon, 13 Nov 2023 13:51:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 219ba511-e211-4c41-92f6-6d9799521ecf
+      - 10de5183-1d7a-4ab0-abc1-71d77a3a4565
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414032Z","created_at":"2023-11-10T13:20:21.287414032Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:21.300261653Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864190Z","created_at":"2023-11-13T13:51:19.725864190Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:19.742746338Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:21 GMT
+      - Mon, 13 Nov 2023 13:51:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91e2fde2-60f0-4212-9d40-f9d0cf46c353
+      - 0f51ec16-e510-4cc2-bdae-c6bc0c1f0e5f
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:21.300262Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:19.742746Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1498"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:21 GMT
+      - Mon, 13 Nov 2023 13:51:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1351af8c-92b0-4bd5-9ff5-4004c4c3eb5c
+      - bf573287-5010-4274-8300-3cca3d23c022
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:26.314430Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.764555Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:26 GMT
+      - Mon, 13 Nov 2023 13:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17e23893-5052-4179-bd3e-10da977529a3
+      - 7341c386-e4f6-43f2-9d12-10614a3d1ece
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:26.314430Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.764555Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:26 GMT
+      - Mon, 13 Nov 2023 13:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b80d2e48-fbc8-4f1d-857c-7ea8dce52167
+      - 58cc3021-b03b-4913-800d-c1a95e9fccfb
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVR0ZOQ2xnd2JURnZXRmx3WjI5eVowTnFlSFI2Unk5dVVHRmxWa1ppWWtOWlJISlRTRXRuYzFsSWJHZFplV05JTUdGV2FrOWFlbUZYUlZjMFdqUm5lbWxNZFRRS1VGbHFXRnBsVkdSb1ZEZzFWVlZ3U0dWTGRrWldRblZMSzFkS2FXUm5XRGgyTkUxd0swZHhOMUZ5TVRWelpFdHhNMVJHVVZORFVISnhVMUpPU0RJNGFBcHdTM1pITDJwT04yZ3lPRWR6UzFoNEwyNUpORXhhYjJSVlVYRTBUVkF3Ylc1b1ZFaG5UMnhEVUN0WWVTODRLMEpZWVVaRVJIVmFWbVZ0VDFCU2JEbE1DbFJsUkUxelYwWTBUMkY0ZVU1TFpFVnRTak4wVURrd1ZqaHBWRkV5V1dSaVkwaGFSMFZqYkVwM1ZFdFlWRmRWU1RKWVVrWkZjMGxHZWpKMlRuTnFRM0lLYlU5WE5YUTFNSEZ3VEdoa1oxTmxlVk50ZUdsa01YQkJPVVpwZEdKQlZXOVBaa2hIYzNCWlEwOHpkMFkwTjNGWVRWZGhUbkpZUW5aTmJtUnVPRzQ1Y3dwaWMxbDVTRFpTTWswemFHY3Jka0pyT0Znd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS0wzWkNVa1JZVDNweFJ6ZzJha0paUTNobFIyNXBiRkJXYVU1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVowSlNVMVpQYjI1WVRWSmFlbXRvZEd4bFl6TnZURms1UWtaUGRscHpWbnBuVEM5UmNHUlVPRmRpTVhwQlVpczNLd3BXZVhnM01YSTJZWEV6Y0RKdE0wTnJUVXBzYUU1S2EwcFZLMXBOV205dE5USkRWbGhaZUdWYVZVc3djaXN5VFhGd1FXMVBZV3RUVlZaaU1VbzBVM0JDQ2pWS01VZzFNR2R4ZUhnd2NsWkdkV2xRU1RKbE1ubHpSM0ZMVldGU1NETkhVR1pQTlZKQlRtMUZVVzA1Wml0cU5WWnNjV1JXTmpGcWIzYzNjR0YyV0ZVS2VtMHJPWGczWVN0b1VFVnljazlGTDBzdk1EVXJOeTgwTWt0UVVubENVM2RVVUhWd2IwMUJTRU5ZYUc1bWVFZDBWVWxRWlUxVVlVd3dkMGxrTkROUlZncHpaMDlLUVUxalRWZDZSWHB3TDFOS01VTkpUVlZqUjNabGJXOVBTamRwTVhCcWFXTlpWa2RNV0cxSVJrZzBPWFpWTlZwUFFtMXFNalF2VDFnNVJGWk5DbGxEUlVGM2VFeFRlVUZtY25wcWRWTnFWSEZJV0hWSUswRnZkVmM0S3pBelNFMURiQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOWMyNTA1YmEtMjlkNC00NDcxLWI3MTYtMzQ3MGQ0MTlmMzM3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNbU9iTjI2WWlxeHJNSFl0bHN0RjdJVDV4NDJMVDJGRWs3WmJ3ZGI3OFVhMGFIRzJneXU1ankxVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2614"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:26 GMT
+      - Mon, 13 Nov 2023 13:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d1583e7-be9a-40e9-96d0-ad8f251593c0
+      - b3c8f818-1458-4746-98d5-45c3b08035c4
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:20:26.314430Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:51:21.764555Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:26 GMT
+      - Mon, 13 Nov 2023 13:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5f9a727-4e2d-4088-8ee7-b8aec19b3f94
+      - 96e1a658-2151-4d3e-ac65-b93a122d140e
     status: 200 OK
     code: 200
     duration: ""
@@ -315,10 +315,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736439781Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005298Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "672"
@@ -327,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:27 GMT
+      - Mon, 13 Nov 2023 13:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0392ede-d696-495a-83c3-a4d92f0ebc93
+      - d4f0a2c5-dcde-4f17-bbfe-2ca8cbaa3869
     status: 200 OK
     code: 200
     duration: ""
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -360,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:27 GMT
+      - Mon, 13 Nov 2023 13:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05f73793-b6f6-4222-be56-73741130691c
+      - cba83321-7fbe-4362-a2a1-0d7249bd14c1
     status: 200 OK
     code: 200
     duration: ""
@@ -381,10 +381,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -393,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:32 GMT
+      - Mon, 13 Nov 2023 13:51:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d74c048-c759-492c-93d5-69b3916990a2
+      - ee72aedf-abd1-488a-a3d5-b2067f6d4c9a
     status: 200 OK
     code: 200
     duration: ""
@@ -414,10 +414,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -426,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:37 GMT
+      - Mon, 13 Nov 2023 13:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e5ae8f1-9c22-4638-9fbb-17ef49146770
+      - 53ea2a05-b537-4539-9d1e-741c41e481f6
     status: 200 OK
     code: 200
     duration: ""
@@ -447,10 +447,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -459,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:42 GMT
+      - Mon, 13 Nov 2023 13:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eda4121a-c62d-4f13-ba80-5877da4ebd47
+      - d168e8c3-7750-453c-a15e-3100df4b6842
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -492,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:47 GMT
+      - Mon, 13 Nov 2023 13:51:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dd02ce5-7120-4a1a-b15d-ad647d91c780
+      - 8e2ce9af-dca9-42e3-8a85-35a33461eb6a
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:52 GMT
+      - Mon, 13 Nov 2023 13:51:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a969165-7635-4619-9f41-f84f0bb2bff2
+      - f76ee768-fede-4564-a937-72cdc9fa27fc
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:57 GMT
+      - Mon, 13 Nov 2023 13:51:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66a0a6a8-a6c9-411c-9b67-42235d794f9b
+      - 6ece621b-7e8e-4545-9a97-5b81f81e823a
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -591,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:02 GMT
+      - Mon, 13 Nov 2023 13:52:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4576e574-49ee-48f7-9491-57093eb74619
+      - 3f950ca6-cdd3-46dd-88dd-9f27cb3cb2e8
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:07 GMT
+      - Mon, 13 Nov 2023 13:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a83e6be-273f-44d3-b151-b0320a3b8be1
+      - ec35a6b6-3298-41c5-be7d-f5a54f3f2e98
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:12 GMT
+      - Mon, 13 Nov 2023 13:52:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27b214a1-7193-433a-b30b-e6b61088264d
+      - 08d9722b-3f2e-4294-9d88-c5d673749880
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:17 GMT
+      - Mon, 13 Nov 2023 13:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbd6f4ba-c2e4-4c1d-8252-8149b207004c
+      - 46018305-2a1f-4651-9ad8-10f20a55f2d3
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:22 GMT
+      - Mon, 13 Nov 2023 13:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d6e99b5-d06a-42e7-a1a9-d1bffcddf579
+      - 9655b003-baf0-4af7-8c6a-0adb785a7bfa
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:27 GMT
+      - Mon, 13 Nov 2023 13:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c111de0-23ad-4e17-a844-15fe6fdaa524
+      - 38125c40-54a7-413b-acaa-08fbf1dd05ce
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:32 GMT
+      - Mon, 13 Nov 2023 13:52:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2575cc44-51e9-4ead-8fc3-3ed53d8c502b
+      - 8731df6d-e926-4b38-bebe-96cabb09b0e3
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:37 GMT
+      - Mon, 13 Nov 2023 13:52:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df024beb-a082-4b8f-b020-e8e13c790e3c
+      - 56c91a46-d1f7-4412-b4f4-15c0e287d1e3
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:42 GMT
+      - Mon, 13 Nov 2023 13:52:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41f4a019-bcd6-4fc1-a494-040fc8ed22a8
+      - 01d90ddd-b546-4daa-a978-ee3d694a8d6f
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:47 GMT
+      - Mon, 13 Nov 2023 13:52:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 817ccb47-b529-4e0f-b662-fa116f62d8ef
+      - a21485c0-4f51-4855-ad57-f434a9920885
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:52 GMT
+      - Mon, 13 Nov 2023 13:52:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 146550e7-87b5-44bf-aba0-d1c8b3a6c7c9
+      - adcc550f-2add-4bea-b654-e1ae58402bee
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:58 GMT
+      - Mon, 13 Nov 2023 13:52:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5e962f2-ae7e-4245-8c11-cd798fdddc4c
+      - 33d566cb-12c3-4298-b777-a4f9f985b044
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:03 GMT
+      - Mon, 13 Nov 2023 13:53:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b8a9733-de4d-4f42-b2ba-8ac3ad9ff3c1
+      - 4ed26a73-ee24-4044-b4d0-61c8bd5e26c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1020,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:08 GMT
+      - Mon, 13 Nov 2023 13:53:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9e02ac0-ce9b-404c-a793-0f48df5b941e
+      - 845976d6-fab0-4829-b6e4-ec880337903f
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1053,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:13 GMT
+      - Mon, 13 Nov 2023 13:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97fd0392-b35e-45d1-914f-64222c9047ce
+      - 24a5a9d6-31e5-41ed-b812-205c22cdb7f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1086,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:18 GMT
+      - Mon, 13 Nov 2023 13:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81ebf0ed-e44e-4ed2-89e6-1b4b6d191dbf
+      - d3dc4194-7614-4215-9c21-ea0b3df37b1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1119,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:23 GMT
+      - Mon, 13 Nov 2023 13:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c44c4e35-63fd-4831-b688-7b6f409c28b2
+      - 9a326557-4202-4b9b-8e37-f5f17c066d8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1152,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:28 GMT
+      - Mon, 13 Nov 2023 13:53:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 449e7e73-013a-4841-b3e7-ec2204c0b8b9
+      - 5cec5e2c-ba68-4e2c-af45-cf8300b8c55b
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1185,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:33 GMT
+      - Mon, 13 Nov 2023 13:53:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99024ea0-14bf-4367-b760-e9526e8fdda5
+      - 00af4d6c-b401-4446-bcc2-5cbc5b417f3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1218,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:38 GMT
+      - Mon, 13 Nov 2023 13:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db54aa26-478a-4d17-a678-f524f06237a5
+      - d36f7622-7764-4f53-9106-30e290a2f42d
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1251,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:43 GMT
+      - Mon, 13 Nov 2023 13:53:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1d8ea3b-632f-42d7-962d-c8fd6adc830e
+      - 74659670-40e1-48c1-8bc9-a4d7d8192b52
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:48 GMT
+      - Mon, 13 Nov 2023 13:53:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5974ea9e-9824-43be-b375-9268bbf42293
+      - 74b6ef16-4d93-4721-b551-3053303c3f59
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1317,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:53 GMT
+      - Mon, 13 Nov 2023 13:53:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b6109c1-4275-4c6d-9ded-1056831d3bda
+      - 4d353008-20eb-46b5-9f4f-16bfaa2c490e
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1350,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:58 GMT
+      - Mon, 13 Nov 2023 13:54:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9376831-8893-4245-a810-60cc6286c4b3
+      - 7881a128-9fd3-4345-b03c-b63eb08e364b
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1383,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:03 GMT
+      - Mon, 13 Nov 2023 13:54:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59c967fe-d901-46a1-a062-cf82b8b7d0ce
+      - f4d3510a-1880-4053-aa17-9d50c282ae73
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1416,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:08 GMT
+      - Mon, 13 Nov 2023 13:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17df9ecc-bd8d-4738-a1c8-00e9528df6ee
+      - 43bd8e84-726a-43c1-82c5-cccab8bee9de
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1449,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:13 GMT
+      - Mon, 13 Nov 2023 13:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 282265ca-e1ce-4d79-9611-3db48fe0ae6a
+      - d3c616c9-5253-4502-a170-7f03637c9870
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1482,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
+      - Mon, 13 Nov 2023 13:54:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3435437-deb9-4f68-ba0c-a4ab753f44ae
+      - 71fc7e89-e6cf-4fa6-869f-9fe51bbf363e
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1515,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:24 GMT
+      - Mon, 13 Nov 2023 13:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dfb5209-d9c9-494b-bd38-f497aa8f828c
+      - aa77d4b7-603a-4e46-b83a-88f2dfe8ba92
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1548,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:29 GMT
+      - Mon, 13 Nov 2023 13:54:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a53a217-3f50-4f26-935a-a6be70ac4fd3
+      - fe4cbd4f-a273-4b50-9388-b5c00ecdfb70
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1581,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:34 GMT
+      - Mon, 13 Nov 2023 13:54:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf6e0978-7599-47d4-8874-27466093af0b
+      - de7a0c92-4a07-4715-9a2e-2b6b56d8cc28
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1614,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:39 GMT
+      - Mon, 13 Nov 2023 13:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ee2c939-b0a3-42f3-9efd-c953c5510d41
+      - f9718642-e993-48ad-b1c3-b043535a67ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1647,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:44 GMT
+      - Mon, 13 Nov 2023 13:54:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfa14035-583b-4a4b-8c92-7e476947b91c
+      - 94feb1b9-a9ee-423c-9819-bbdf72da74eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1680,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:49 GMT
+      - Mon, 13 Nov 2023 13:54:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc4e0e44-8ae5-426f-a6a1-1c7d0f684e32
+      - 4718ef75-b752-4e51-85f7-933f92780e95
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1713,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:54 GMT
+      - Mon, 13 Nov 2023 13:54:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3fd9058-75bf-4603-8c04-e8f868029730
+      - abc6b490-9b79-4e39-8724-630927151cbf
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1746,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:59 GMT
+      - Mon, 13 Nov 2023 13:55:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 817f8cdd-8ffc-4bcf-9c79-be2e3537a1fa
+      - 2c2e5faf-0660-4264-b4cb-5f4cf6f258c1
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1779,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:04 GMT
+      - Mon, 13 Nov 2023 13:55:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9973ddd8-6ca0-4e4a-9092-7c15609376dc
+      - 4b2250dc-3130-4b75-8684-86f4356c03f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1812,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:09 GMT
+      - Mon, 13 Nov 2023 13:55:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2625bf36-bdfa-4449-af0a-8900d7875177
+      - a626aff1-af4f-4b66-8de9-6081695fe2e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1845,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:14 GMT
+      - Mon, 13 Nov 2023 13:55:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f31e0f3-4397-479c-8697-6c37d2ae32ac
+      - cfa7606f-7a08-4c25-916e-afdcaa000a80
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1878,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:19 GMT
+      - Mon, 13 Nov 2023 13:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2953f7b8-15b5-4dd2-812e-83a5ce2e43a9
+      - c23dc247-6a4a-46b4-89e3-72b8532aef98
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1911,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:25 GMT
+      - Mon, 13 Nov 2023 13:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfa65ffb-cf30-4212-af84-967d3fbc25c3
+      - c4e88092-9d73-4bf4-a295-2db37ab5b851
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1944,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:30 GMT
+      - Mon, 13 Nov 2023 13:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 133a66dc-30db-4787-a19c-e8a98348c611
+      - 212d553b-86d0-4699-832e-cf49d36d0d36
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -1977,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:35 GMT
+      - Mon, 13 Nov 2023 13:55:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f85e075-e4bf-4463-b0ca-c8d1fc89e16f
+      - b039fa28-9204-4460-87f7-a5e914ab1ecd
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:20:26.736440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -2010,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:40 GMT
+      - Mon, 13 Nov 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e4c92bf-8d6d-4936-98e5-a686724e97e1
+      - cb1fc8fe-2b56-4190-a7c8-20448a2f9114
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2031,373 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:55:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7dc1c786-8be9-413a-a9ba-72aad8326f59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:55:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2cda37db-ae04-4cbf-bd44-3c5f788a0e65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:55:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 712d452e-57bc-4773-baeb-5884821bc2ae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8c7b549-e780-45f1-a512-2e6041602416
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c02ca8b-98c9-4b98-a0bd-8eb2bda8f563
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 933e511e-9500-41a5-99b5-abc23fa8ad45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5600becc-6059-46fa-9456-675e00596d08
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 10eaff24-3129-422f-abcd-c587940559e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86904402-a98d-4dae-ac82-f70b232dc101
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86765f18-5386-452f-adbe-436e6ee757dc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:51:25.343005Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "669"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 073d5843-09f1-446b-b60f-ceb8a4cf805b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -2043,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:45 GMT
+      - Mon, 13 Nov 2023 13:56:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11059429-9736-4ec4-a061-e9aaf44e677b
+      - 0376149f-dc8a-4d9a-8459-c2b72d82875a
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,10 +2427,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.703659Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1495"
@@ -2076,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:45 GMT
+      - Mon, 13 Nov 2023 13:56:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3efa5d7-f057-4762-8deb-8077defff308
+      - e0a1375f-b068-43b7-ae5d-269bc8885c56
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,10 +2460,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -2109,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:45 GMT
+      - Mon, 13 Nov 2023 13:56:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61b4ef3d-6b3b-493d-bb7f-ff76d00694a0
+      - 1d799ddf-a7c8-4825-a468-edf473d8e371
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:37.831450Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:45 GMT
+      - Mon, 13 Nov 2023 13:56:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 643ca245-b1d3-431f-86f3-74e199d7a09b
+      - 8fbf019e-6843-42e6-9301-e32d556f0da3
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,10 +2526,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7d4cdc29-ed97-4c47-9dad-9866c3e4716e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:17.107936Z","dhcp_enabled":true,"id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:17.107936Z","id":"ebd144e8-9689-4ab8-aee3-25922300adb6","subnet":"172.16.48.0/22","updated_at":"2023-11-13T13:51:17.107936Z"},{"created_at":"2023-11-13T13:51:17.107936Z","id":"8a9f9657-f39c-4fa2-a5cc-351758a7349f","subnet":"fd63:256c:45f7:198c::/64","updated_at":"2023-11-13T13:51:17.107936Z"}],"tags":[],"updated_at":"2023-11-13T13:51:17.107936Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -2175,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:45 GMT
+      - Mon, 13 Nov 2023 13:56:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a36f0613-e757-4bf2-bb14-9fe8ab351aa8
+      - fbdcaf02-8721-4a33-bd81-6decef429dea
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,10 +2559,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.703659Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1495"
@@ -2208,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:45 GMT
+      - Mon, 13 Nov 2023 13:56:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f2f748c-7b84-447d-9812-6d1a54b73540
+      - 6b81c90a-3be6-4f5d-a4f3-c82dc9cfd176
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,10 +2592,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVR0ZOQ2xnd2JURnZXRmx3WjI5eVowTnFlSFI2Unk5dVVHRmxWa1ppWWtOWlJISlRTRXRuYzFsSWJHZFplV05JTUdGV2FrOWFlbUZYUlZjMFdqUm5lbWxNZFRRS1VGbHFXRnBsVkdSb1ZEZzFWVlZ3U0dWTGRrWldRblZMSzFkS2FXUm5XRGgyTkUxd0swZHhOMUZ5TVRWelpFdHhNMVJHVVZORFVISnhVMUpPU0RJNGFBcHdTM1pITDJwT04yZ3lPRWR6UzFoNEwyNUpORXhhYjJSVlVYRTBUVkF3Ylc1b1ZFaG5UMnhEVUN0WWVTODRLMEpZWVVaRVJIVmFWbVZ0VDFCU2JEbE1DbFJsUkUxelYwWTBUMkY0ZVU1TFpFVnRTak4wVURrd1ZqaHBWRkV5V1dSaVkwaGFSMFZqYkVwM1ZFdFlWRmRWU1RKWVVrWkZjMGxHZWpKMlRuTnFRM0lLYlU5WE5YUTFNSEZ3VEdoa1oxTmxlVk50ZUdsa01YQkJPVVpwZEdKQlZXOVBaa2hIYzNCWlEwOHpkMFkwTjNGWVRWZGhUbkpZUW5aTmJtUnVPRzQ1Y3dwaWMxbDVTRFpTTWswemFHY3Jka0pyT0Znd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS0wzWkNVa1JZVDNweFJ6ZzJha0paUTNobFIyNXBiRkJXYVU1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVowSlNVMVpQYjI1WVRWSmFlbXRvZEd4bFl6TnZURms1UWtaUGRscHpWbnBuVEM5UmNHUlVPRmRpTVhwQlVpczNLd3BXZVhnM01YSTJZWEV6Y0RKdE0wTnJUVXBzYUU1S2EwcFZLMXBOV205dE5USkRWbGhaZUdWYVZVc3djaXN5VFhGd1FXMVBZV3RUVlZaaU1VbzBVM0JDQ2pWS01VZzFNR2R4ZUhnd2NsWkdkV2xRU1RKbE1ubHpSM0ZMVldGU1NETkhVR1pQTlZKQlRtMUZVVzA1Wml0cU5WWnNjV1JXTmpGcWIzYzNjR0YyV0ZVS2VtMHJPWGczWVN0b1VFVnljazlGTDBzdk1EVXJOeTgwTWt0UVVubENVM2RVVUhWd2IwMUJTRU5ZYUc1bWVFZDBWVWxRWlUxVVlVd3dkMGxrTkROUlZncHpaMDlLUVUxalRWZDZSWHB3TDFOS01VTkpUVlZqUjNabGJXOVBTamRwTVhCcWFXTlpWa2RNV0cxSVJrZzBPWFpWTlZwUFFtMXFNalF2VDFnNVJGWk5DbGxEUlVGM2VFeFRlVUZtY25wcWRWTnFWSEZJV0hWSUswRnZkVmM0S3pBelNFMURiQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOWMyNTA1YmEtMjlkNC00NDcxLWI3MTYtMzQ3MGQ0MTlmMzM3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNbU9iTjI2WWlxeHJNSFl0bHN0RjdJVDV4NDJMVDJGRWs3WmJ3ZGI3OFVhMGFIRzJneXU1ankxVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2614"
@@ -2241,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64687790-cbd5-4fff-85cf-84c31c856cbf
+      - 68b99d2c-df8e-4ae6-9a03-4ce0c009fd96
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,10 +2625,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -2274,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e90ec57-7ecb-43e1-84a3-7e7066e672a2
+      - 01f687fe-6d7b-4d26-b824-a988cb787e1d
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2658,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:37.831450Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2545b9e0-dd9d-4533-bcd9-bbde775cb5e7
+      - c660548c-ce7d-47ff-8a4e-f37cdfaa14dc
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,10 +2691,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7d4cdc29-ed97-4c47-9dad-9866c3e4716e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:17.107936Z","dhcp_enabled":true,"id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:17.107936Z","id":"ebd144e8-9689-4ab8-aee3-25922300adb6","subnet":"172.16.48.0/22","updated_at":"2023-11-13T13:51:17.107936Z"},{"created_at":"2023-11-13T13:51:17.107936Z","id":"8a9f9657-f39c-4fa2-a5cc-351758a7349f","subnet":"fd63:256c:45f7:198c::/64","updated_at":"2023-11-13T13:51:17.107936Z"}],"tags":[],"updated_at":"2023-11-13T13:51:17.107936Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -2340,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d97ea0c9-a921-401e-8aee-f857f95fce98
+      - 80e70ec8-dfd8-4930-8759-f87dad8ad7ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,10 +2724,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-10T13:22:25.000919Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.703659Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1495"
@@ -2373,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21db017f-a865-4672-98f9-a0b335d31730
+      - d57860d6-7cc3-4259-b95f-53d8f165417b
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,10 +2757,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVR0ZOQ2xnd2JURnZXRmx3WjI5eVowTnFlSFI2Unk5dVVHRmxWa1ppWWtOWlJISlRTRXRuYzFsSWJHZFplV05JTUdGV2FrOWFlbUZYUlZjMFdqUm5lbWxNZFRRS1VGbHFXRnBsVkdSb1ZEZzFWVlZ3U0dWTGRrWldRblZMSzFkS2FXUm5XRGgyTkUxd0swZHhOMUZ5TVRWelpFdHhNMVJHVVZORFVISnhVMUpPU0RJNGFBcHdTM1pITDJwT04yZ3lPRWR6UzFoNEwyNUpORXhhYjJSVlVYRTBUVkF3Ylc1b1ZFaG5UMnhEVUN0WWVTODRLMEpZWVVaRVJIVmFWbVZ0VDFCU2JEbE1DbFJsUkUxelYwWTBUMkY0ZVU1TFpFVnRTak4wVURrd1ZqaHBWRkV5V1dSaVkwaGFSMFZqYkVwM1ZFdFlWRmRWU1RKWVVrWkZjMGxHZWpKMlRuTnFRM0lLYlU5WE5YUTFNSEZ3VEdoa1oxTmxlVk50ZUdsa01YQkJPVVpwZEdKQlZXOVBaa2hIYzNCWlEwOHpkMFkwTjNGWVRWZGhUbkpZUW5aTmJtUnVPRzQ1Y3dwaWMxbDVTRFpTTWswemFHY3Jka0pyT0Znd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS0wzWkNVa1JZVDNweFJ6ZzJha0paUTNobFIyNXBiRkJXYVU1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVowSlNVMVpQYjI1WVRWSmFlbXRvZEd4bFl6TnZURms1UWtaUGRscHpWbnBuVEM5UmNHUlVPRmRpTVhwQlVpczNLd3BXZVhnM01YSTJZWEV6Y0RKdE0wTnJUVXBzYUU1S2EwcFZLMXBOV205dE5USkRWbGhaZUdWYVZVc3djaXN5VFhGd1FXMVBZV3RUVlZaaU1VbzBVM0JDQ2pWS01VZzFNR2R4ZUhnd2NsWkdkV2xRU1RKbE1ubHpSM0ZMVldGU1NETkhVR1pQTlZKQlRtMUZVVzA1Wml0cU5WWnNjV1JXTmpGcWIzYzNjR0YyV0ZVS2VtMHJPWGczWVN0b1VFVnljazlGTDBzdk1EVXJOeTgwTWt0UVVubENVM2RVVUhWd2IwMUJTRU5ZYUc1bWVFZDBWVWxRWlUxVVlVd3dkMGxrTkROUlZncHpaMDlLUVUxalRWZDZSWHB3TDFOS01VTkpUVlZqUjNabGJXOVBTamRwTVhCcWFXTlpWa2RNV0cxSVJrZzBPWFpWTlZwUFFtMXFNalF2VDFnNVJGWk5DbGxEUlVGM2VFeFRlVUZtY25wcWRWTnFWSEZJV0hWSUswRnZkVmM0S3pBelNFMURiQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOWMyNTA1YmEtMjlkNC00NDcxLWI3MTYtMzQ3MGQ0MTlmMzM3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNbU9iTjI2WWlxeHJNSFl0bHN0RjdJVDV4NDJMVDJGRWs3WmJ3ZGI3OFVhMGFIRzJneXU1ankxVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2614"
@@ -2406,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6259c62-c39f-4ff9-9f35-6273ad9f1755
+      - e2ecaf34-f464-4482-8ab9-f555f7a01297
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,10 +2790,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -2439,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb3185f0-6871-4f8d-8903-f401cb5db101
+      - 6103a260-735d-4898-ba11-24d7b32b0285
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2823,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:37.831450Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaad91c8-32c0-44d9-bc0f-4b53c647f964
+      - f4bc8ea5-440e-4ec1-a845-961400a8928f
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,76 +2856,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "667"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:24:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a12cf907-9efd-4067-ace6-98ebf282c677
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "657"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:24:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7c6d0900-53b9-4211-a045-cfab1241c8fb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -2571,7 +2868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:47 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89444ce5-0e9f-423d-b454-254b16755f46
+      - 1830b6ef-21f7-433a-ad52-45bcd4f44443
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +2889,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:44.590213Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:37.831450Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:47 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2911,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ec08c7d-9b41-4003-8a71-0cd5f2f67a55
+      - 0a770bf7-505a-4145-81e3-42981b652e1f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "667"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 066e9418-8636-4098-b90d-91f22b2e68ae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:37.831450Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "656"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5d2ed462-c42a-41ac-be9a-39217f77a4e3
     status: 200 OK
     code: 200
     duration: ""
@@ -2627,10 +2990,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990463Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584119584Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1504"
@@ -2639,7 +3002,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:47 GMT
+      - Mon, 13 Nov 2023 13:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2649,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50a98322-889f-4573-99cd-720da322289c
+      - b4ea9b1a-c026-47cc-b1be-9a2668786564
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,10 +3023,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584120Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -2672,7 +3035,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:48 GMT
+      - Mon, 13 Nov 2023 13:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2682,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63f1dc64-bdc1-4255-9edd-ae1dc3df2044
+      - b948833a-496d-4850-bbb2-cddafbaa4b4c
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,10 +3056,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584120Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -2705,7 +3068,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:53 GMT
+      - Mon, 13 Nov 2023 13:56:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2715,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cfd0bf1-dfa4-43d9-996d-2c8299a674a6
+      - f944cacb-964c-4402-afc6-0703873b25b2
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,10 +3089,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584120Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -2738,7 +3101,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:58 GMT
+      - Mon, 13 Nov 2023 13:56:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d095606f-a019-4fe4-87ee-8b1a9aca15af
+      - e1d0c387-5d19-4fcf-9022-11f49052b92e
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,10 +3122,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584120Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -2771,7 +3134,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:03 GMT
+      - Mon, 13 Nov 2023 13:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2781,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baa0f599-bd90-46de-a1b9-c9a424ff58c6
+      - c83d8fb9-40fb-4638-b3dd-e444a3560f8b
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,10 +3155,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584120Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -2804,7 +3167,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:08 GMT
+      - Mon, 13 Nov 2023 13:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37848b03-1d29-4718-a85c-fe8b9345368d
+      - 40dabf73-7dba-4b35-8a7d-d7632a91c780
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,10 +3188,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584120Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -2837,7 +3200,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:13 GMT
+      - Mon, 13 Nov 2023 13:57:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e4d0db1-2433-46d7-87ab-1544fcc5fc2a
+      - 9d29ddc9-eeca-4188-af81-1171c3396b56
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,10 +3221,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:24:47.909990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584120Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -2870,7 +3233,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:18 GMT
+      - Mon, 13 Nov 2023 13:57:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06da0964-bac1-41f9-897f-c03503045143
+      - ecb8ed16-9f79-494c-b75d-74250ba36563
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,10 +3254,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:25:22.193603Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:56:46.584120Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1501"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 646fb691-2745-4e2e-97a1-5cfe66781357
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:57:22.773798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1498"
@@ -2903,7 +3299,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:23 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32e29da6-5e95-42e2-a8a4-793858bb92ef
+      - 296b2274-b726-4816-9760-9209c80ad352
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,10 +3320,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:25:22.193603Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:57:22.773798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1498"
@@ -2936,7 +3332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:23 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdc59d0a-75f2-4a5d-b9b3-d191bb3ddeca
+      - d35b6593-4a1d-4dcd-9830-b39c36178b26
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,10 +3353,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVR0ZOQ2xnd2JURnZXRmx3WjI5eVowTnFlSFI2Unk5dVVHRmxWa1ppWWtOWlJISlRTRXRuYzFsSWJHZFplV05JTUdGV2FrOWFlbUZYUlZjMFdqUm5lbWxNZFRRS1VGbHFXRnBsVkdSb1ZEZzFWVlZ3U0dWTGRrWldRblZMSzFkS2FXUm5XRGgyTkUxd0swZHhOMUZ5TVRWelpFdHhNMVJHVVZORFVISnhVMUpPU0RJNGFBcHdTM1pITDJwT04yZ3lPRWR6UzFoNEwyNUpORXhhYjJSVlVYRTBUVkF3Ylc1b1ZFaG5UMnhEVUN0WWVTODRLMEpZWVVaRVJIVmFWbVZ0VDFCU2JEbE1DbFJsUkUxelYwWTBUMkY0ZVU1TFpFVnRTak4wVURrd1ZqaHBWRkV5V1dSaVkwaGFSMFZqYkVwM1ZFdFlWRmRWU1RKWVVrWkZjMGxHZWpKMlRuTnFRM0lLYlU5WE5YUTFNSEZ3VEdoa1oxTmxlVk50ZUdsa01YQkJPVVpwZEdKQlZXOVBaa2hIYzNCWlEwOHpkMFkwTjNGWVRWZGhUbkpZUW5aTmJtUnVPRzQ1Y3dwaWMxbDVTRFpTTWswemFHY3Jka0pyT0Znd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS0wzWkNVa1JZVDNweFJ6ZzJha0paUTNobFIyNXBiRkJXYVU1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVowSlNVMVpQYjI1WVRWSmFlbXRvZEd4bFl6TnZURms1UWtaUGRscHpWbnBuVEM5UmNHUlVPRmRpTVhwQlVpczNLd3BXZVhnM01YSTJZWEV6Y0RKdE0wTnJUVXBzYUU1S2EwcFZLMXBOV205dE5USkRWbGhaZUdWYVZVc3djaXN5VFhGd1FXMVBZV3RUVlZaaU1VbzBVM0JDQ2pWS01VZzFNR2R4ZUhnd2NsWkdkV2xRU1RKbE1ubHpSM0ZMVldGU1NETkhVR1pQTlZKQlRtMUZVVzA1Wml0cU5WWnNjV1JXTmpGcWIzYzNjR0YyV0ZVS2VtMHJPWGczWVN0b1VFVnljazlGTDBzdk1EVXJOeTgwTWt0UVVubENVM2RVVUhWd2IwMUJTRU5ZYUc1bWVFZDBWVWxRWlUxVVlVd3dkMGxrTkROUlZncHpaMDlLUVUxalRWZDZSWHB3TDFOS01VTkpUVlZqUjNabGJXOVBTamRwTVhCcWFXTlpWa2RNV0cxSVJrZzBPWFpWTlZwUFFtMXFNalF2VDFnNVJGWk5DbGxEUlVGM2VFeFRlVUZtY25wcWRWTnFWSEZJV0hWSUswRnZkVmM0S3pBelNFMURiQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOWMyNTA1YmEtMjlkNC00NDcxLWI3MTYtMzQ3MGQ0MTlmMzM3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNbU9iTjI2WWlxeHJNSFl0bHN0RjdJVDV4NDJMVDJGRWs3WmJ3ZGI3OFVhMGFIRzJneXU1ankxVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2614"
@@ -2969,7 +3365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:24 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42aefa65-f13b-4f76-993d-f778885aa358
+      - a62db7a3-94a6-49ec-a1c7-b8992daae834
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,10 +3386,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "696"
@@ -3002,7 +3398,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:24 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72671969-17ff-424f-9a96-6aa178faa965
+      - 0b84e1ba-8254-4280-889a-a0af6a62d2ad
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,10 +3419,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -3035,7 +3431,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:24 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14b6eddb-38ad-4dfb-a5e5-0aa22b80f37f
+      - 7c6098fc-c64f-4482-b126-aa8af464e5e6
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,19 +3452,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:58.708010Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "687"
+      - "686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:24 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00748af5-1fee-4b1b-8389-6760692bcddc
+      - 1365f06a-fe3a-4b3b-9b7e-db38d92b6275
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,43 +3485,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "667"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:25:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 610a034a-d367-419c-80b8-faab0aa43bd2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -3134,7 +3497,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:24 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1259d7b-b7e7-4c4b-9192-24d2e5c72eab
+      - 38663408-78c1-4a41-8670-9958ea0860ee
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,10 +3518,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -3167,7 +3530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8a8c4a1-6363-4bdd-bf1e-828418635a0a
+      - 32af167e-936f-4559-805f-5b25efcecb0e
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,10 +3551,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "667"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df8697db-a7c1-42c1-995b-a634730f50d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:58.708010Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "686"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 801cccbc-2d67-4b82-989e-25e7c76b7fd1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    method: GET
+  response:
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "696"
@@ -3200,7 +3629,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3210,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3081e3d1-1350-4732-98e2-f4fa9eeb4603
+      - 8e8c7768-6152-429a-b1c3-b8fba27d493c
     status: 200 OK
     code: 200
     duration: ""
@@ -3221,43 +3650,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "687"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e70a434-64bf-4952-8f02-cc3772364031
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -3266,7 +3662,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81f685bf-ff6c-4c54-bd88-31803c2b8ddb
+      - 852bbaf8-4895-4d3e-b42b-c45a2e355953
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,19 +3683,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:58.708010Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "687"
+      - "686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a81e770e-d480-45e3-9f1d-9e4e105cd2c3
+      - 3b1e6cac-7a38-489c-a18c-31a6c32da975
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,10 +3716,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7d4cdc29-ed97-4c47-9dad-9866c3e4716e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:20:20.267040Z","dhcp_enabled":true,"id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:20:20.267040Z","id":"0f17ab4e-83d6-4cc7-abe9-3a9b52ac47b0","subnet":"172.16.48.0/22","updated_at":"2023-11-10T13:20:20.267040Z"},{"created_at":"2023-11-10T13:20:20.267040Z","id":"90536852-0f91-4db9-98ca-f7add485bbda","subnet":"fd63:256c:45f7:ba6e::/64","updated_at":"2023-11-10T13:20:20.267040Z"}],"tags":[],"updated_at":"2023-11-10T13:20:20.267040Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:17.107936Z","dhcp_enabled":true,"id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:17.107936Z","id":"ebd144e8-9689-4ab8-aee3-25922300adb6","subnet":"172.16.48.0/22","updated_at":"2023-11-13T13:51:17.107936Z"},{"created_at":"2023-11-13T13:51:17.107936Z","id":"8a9f9657-f39c-4fa2-a5cc-351758a7349f","subnet":"fd63:256c:45f7:198c::/64","updated_at":"2023-11-13T13:51:17.107936Z"}],"tags":[],"updated_at":"2023-11-13T13:51:17.107936Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -3332,7 +3728,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92d4e150-397e-4223-8fc6-386361cb12ad
+      - b21b4ee9-f3b4-4df8-8821-ef413972ed85
     status: 200 OK
     code: 200
     duration: ""
@@ -3353,10 +3749,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:25:22.193603Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:57:22.773798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1498"
@@ -3365,7 +3761,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +3771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfc2a708-dafc-44ca-9c0a-0df73c47523e
+      - 779d1900-611e-4ad4-b2b5-90bc436f7f68
     status: 200 OK
     code: 200
     duration: ""
@@ -3386,10 +3782,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcEJlVTFzYjFoRVZFMTZUVlJGZDA5VVJYcE5ha0Y1VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVU56Q2xGYVEzTXdRalJrVlRkQ1VFY3lVRnBXWmxWV2NuWnVhVGRxT0ZCQldWRXpNMUpsVms1SVFtcEplRXRVVkVzM1l6azVNMkZEUTNock9FSldhalZPYmxnS1JEQlFiMGhoUVd4Q1NYbDJTWE5yVlZOWU9GRk1iMVZqTUVabk0yVm1lVnBHU0VFM09YbG9hbGRVVUVoRlkzUlZUMDE1SzJSNlNWRlVhVVZsUVhKclRBcE5XRWhRWlU0NVMzTk1OWFV4Y0RreGFWWjVRVloyTVVadmFtOTFSVEZNZURSMVIyaHlPVXg0UjA0ck9HVk1PRmtyYVZKVllYcEplVmR2V0RnME1ETjBDa3hMV0hoNVNDczNkbk5aYkRkVWVIQkhWbE5TZFU1RVRWUmlaMnBVWkdSSVVUTllMMlZLY0UxcFdUZExabmxVVm1wQkwwbE1VbEZxVkhKdFJrUjRNVlVLZVRWSlFsUlBWa294TXpkcWQwSkxSMDlSTVRGdk5VMUtTVlIxTmxWc2RVMUxhRkJqUTFOclduVnVOSFpwWlhGR1dqUm9XakF2VTJGNllrNWpWazFuZGdwcVZWbHRjR2wwWkRsMU9IRkJhWFZOVW5WalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUU1FZzNaazFKYUZCNlltb3ZlbloyWlROU1JUZG9VRmR5VVhWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREwybFpZa2hKTDB4ek1FUXlOV1pwWkRaWlpIZ3pla2htTmpod1ZGQmlTelZFTUVKcmJHMDJiMFJVTXk5cVQxTXhUd3BJVWpCbGN6ZFNVa293VUZkTFRXZ3hWRmhRVDFWVE1rWk1iVEpDTDNORksyVmthMjFzY0dwV01qVlRlRWw1YzNGdVMyNXZhRzV6TUZOS2RWUjBSelk1Q2s5VVR6RXpaRlkyYTB4S05VaEdNbnBDUjNWaFNuQkZkM3BxUVdNMVpucEdjSEFyUW5sS2ExSnRhVVpqV0hONU9DdG5iSEp0UTFCcksxSlhlVXR1VlhBS1JsUktiM1p2VFRaUFNHWk9kVmxaUlRCamRFRjVjVGhZTW5kbVJYSnlabEoxTmxvNWREbE9NRmhETDNrMUwycDJkVFYxWlZoVVZYVjBURXhZYVZwM1dncFlkSFZTYTJ4Q1ZYUlFiVFUwY2tjeWMxbHFjMHhJTjFVelJXcG5VelpZV2tnME5GUllVbGszY1ZOeUwyMWtUa0oyYkRGRlpHVlZiVmgyUW5STWIyMDVDbFJ3YWxaeU1FUXhVaTk2SzBjdlVUUlhUVkkyZEVOV2VYRnJTMjFvVjBONVVpOW1Ud290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjZkNTMwMDctZTM4ZC00ZDYxLWE3ZjQtNDI2NTI3YjMwYmUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiN2JEbkNaemIwb3Y5NXpuVGZ1N0tweFRIYVRKZHQ1bnAxaGVmWmQ2OWQ4d2pzdHdyYWVQR2dsNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVR0ZOQ2xnd2JURnZXRmx3WjI5eVowTnFlSFI2Unk5dVVHRmxWa1ppWWtOWlJISlRTRXRuYzFsSWJHZFplV05JTUdGV2FrOWFlbUZYUlZjMFdqUm5lbWxNZFRRS1VGbHFXRnBsVkdSb1ZEZzFWVlZ3U0dWTGRrWldRblZMSzFkS2FXUm5XRGgyTkUxd0swZHhOMUZ5TVRWelpFdHhNMVJHVVZORFVISnhVMUpPU0RJNGFBcHdTM1pITDJwT04yZ3lPRWR6UzFoNEwyNUpORXhhYjJSVlVYRTBUVkF3Ylc1b1ZFaG5UMnhEVUN0WWVTODRLMEpZWVVaRVJIVmFWbVZ0VDFCU2JEbE1DbFJsUkUxelYwWTBUMkY0ZVU1TFpFVnRTak4wVURrd1ZqaHBWRkV5V1dSaVkwaGFSMFZqYkVwM1ZFdFlWRmRWU1RKWVVrWkZjMGxHZWpKMlRuTnFRM0lLYlU5WE5YUTFNSEZ3VEdoa1oxTmxlVk50ZUdsa01YQkJPVVpwZEdKQlZXOVBaa2hIYzNCWlEwOHpkMFkwTjNGWVRWZGhUbkpZUW5aTmJtUnVPRzQ1Y3dwaWMxbDVTRFpTTWswemFHY3Jka0pyT0Znd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS0wzWkNVa1JZVDNweFJ6ZzJha0paUTNobFIyNXBiRkJXYVU1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVowSlNVMVpQYjI1WVRWSmFlbXRvZEd4bFl6TnZURms1UWtaUGRscHpWbnBuVEM5UmNHUlVPRmRpTVhwQlVpczNLd3BXZVhnM01YSTJZWEV6Y0RKdE0wTnJUVXBzYUU1S2EwcFZLMXBOV205dE5USkRWbGhaZUdWYVZVc3djaXN5VFhGd1FXMVBZV3RUVlZaaU1VbzBVM0JDQ2pWS01VZzFNR2R4ZUhnd2NsWkdkV2xRU1RKbE1ubHpSM0ZMVldGU1NETkhVR1pQTlZKQlRtMUZVVzA1Wml0cU5WWnNjV1JXTmpGcWIzYzNjR0YyV0ZVS2VtMHJPWGczWVN0b1VFVnljazlGTDBzdk1EVXJOeTgwTWt0UVVubENVM2RVVUhWd2IwMUJTRU5ZYUc1bWVFZDBWVWxRWlUxVVlVd3dkMGxrTkROUlZncHpaMDlLUVUxalRWZDZSWHB3TDFOS01VTkpUVlZqUjNabGJXOVBTamRwTVhCcWFXTlpWa2RNV0cxSVJrZzBPWFpWTlZwUFFtMXFNalF2VDFnNVJGWk5DbGxEUlVGM2VFeFRlVUZtY25wcWRWTnFWSEZJV0hWSUswRnZkVmM0S3pBelNFMURiQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOWMyNTA1YmEtMjlkNC00NDcxLWI3MTYtMzQ3MGQ0MTlmMzM3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNbU9iTjI2WWlxeHJNSFl0bHN0RjdJVDV4NDJMVDJGRWs3WmJ3ZGI3OFVhMGFIRzJneXU1ankxVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2614"
@@ -3398,7 +3794,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9501fd51-3f08-4f20-837d-dc66e6a62390
+      - cde6a6a1-a46f-4a18-a3d0-17e1f04f86c9
     status: 200 OK
     code: 200
     duration: ""
@@ -3419,10 +3815,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -3431,7 +3827,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3441,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b08ef583-82ea-4990-8d75-37f734d1759f
+      - 83525529-af0c-4afd-9a23-d3ae5a4f6e55
     status: 200 OK
     code: 200
     duration: ""
@@ -3452,19 +3848,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:58.708010Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "687"
+      - "686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3474,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ecb58ed-313f-433c-b42a-f6d82b1661f1
+      - a6bd978d-42a0-4ee7-9a7b-826c4f1f9124
     status: 200 OK
     code: 200
     duration: ""
@@ -3485,43 +3881,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "667"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e054b7d-7a11-4403-9411-34cddd835840
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools?name=tf-pool&order_by=created_at_asc&status=unknown
-    method: GET
-  response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "696"
@@ -3530,7 +3893,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +3903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1019d140-2ea1-49d2-96e8-9fff74a25c84
+      - febff508-c179-47b7-aa29-2409a66517a6
     status: 200 OK
     code: 200
     duration: ""
@@ -3551,43 +3914,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "687"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f1c5b41-99f6-4e78-aede-6451f3aba6e5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -3596,7 +3926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3606,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 286167db-6db2-45c0-a378-8c14f497de11
+      - 8fc886bd-5fda-456e-b510-da1823d741fd
     status: 200 OK
     code: 200
     duration: ""
@@ -3617,43 +3947,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "687"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 076f2dfe-8b44-4afc-a8f3-2cc22fdbdfe9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -3662,7 +3959,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6eb2c6c8-cbee-4bd8-aa6d-7c33fa90a7ee
+      - 442979e8-0faa-42b5-90e9-7a2fa08f1a70
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,10 +3980,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:58.708010Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "686"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 43bfbc6a-c8d8-48ca-b688-37881a74135d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:58.708010Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "686"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40087429-0d0e-4fb2-b2ce-7c3bdc9374a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "667"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - de12ade5-ddc2-4b6d-b8f3-14e31edccdf4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    method: GET
+  response:
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "696"
@@ -3695,7 +4091,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
+      - Mon, 13 Nov 2023 13:57:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +4101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a8ce601-7356-43c3-af91-7f7c06e7166c
+      - 213b70c8-7aec-4de2-a2f9-33d6bdaaff02
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,19 +4112,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:58.708010Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "687"
+      - "686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
+      - Mon, 13 Nov 2023 13:57:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3738,7 +4134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5b728cd-d1be-42f2-b171-7a4da55d4fc0
+      - 1ab9000b-b462-48d9-ae50-66d0da2cd24d
     status: 200 OK
     code: 200
     duration: ""
@@ -3749,10 +4145,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:24:44.614504Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:56:37.894426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "667"
@@ -3761,7 +4157,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
+      - Mon, 13 Nov 2023 13:57:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3771,7 +4167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbd28597-33d1-4fd7-9498-3cbc28133c9d
+      - 5566ed0e-0a1e-4a1a-89ce-3372ecc9b462
     status: 200 OK
     code: 200
     duration: ""
@@ -3782,19 +4178,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0/nodes?order_by=created_at_asc&page=1&pool_id=329885b3-6ef0-4c39-b604-53eeceb0a5ee&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337/nodes?order_by=created_at_asc&page=1&pool_id=5c166d0b-235e-4e0a-a9b1-9fbc18148e0a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:22:02.233599Z","error_message":null,"id":"6c73622d-3069-460a-8c39-0a70db0c3ee9","name":"scw-tf-cluster-pool-tf-pool-6c73622d3069460a8c","pool_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","provider_id":"scaleway://instance/fr-par-1/6fc5a8e0-ce9f-4b38-aff2-f5e853943edf","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:24:59.972394Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:15.240227Z","error_message":null,"id":"8fa519f8-1d3a-49d1-be87-5672acc7d6dc","name":"scw-tf-cluster-pool-tf-pool-8fa519f81d3a49d1be","pool_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","provider_id":"scaleway://instance/fr-par-1/176710ef-315e-40aa-9e86-120333f90623","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:58.708010Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "687"
+      - "686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
+      - Mon, 13 Nov 2023 13:57:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +4200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 769435cd-7404-4b91-aa90-6afe0048d1c5
+      - 49a882fa-e2a5-4c63-84c4-837533f659a3
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,10 +4211,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388488Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:57:30.388158664Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "673"
@@ -3827,7 +4223,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:27 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +4233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eab6c9d8-43fe-4913-997d-03e18d73e5b9
+      - c09c6ca5-337b-4d33-ac5f-94cce3d50a1a
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,10 +4244,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:57:30.388159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "670"
@@ -3860,7 +4256,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:27 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3870,7 +4266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f7c13c2-96f3-4345-9429-4e57039e7ba3
+      - f2e1b543-3506-4e0f-b557-dadf0e99dd35
     status: 200 OK
     code: 200
     duration: ""
@@ -3881,10 +4277,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:57:30.388159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "670"
@@ -3893,7 +4289,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:32 GMT
+      - Mon, 13 Nov 2023 13:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +4299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e85e20e5-b4bc-4ea6-8196-aa8591e3f1e3
+      - 12739422-33f5-42df-b195-4f328b8828b0
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,10 +4310,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:57:30.388159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "670"
@@ -3926,7 +4322,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:37 GMT
+      - Mon, 13 Nov 2023 13:57:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +4332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2040726a-0b69-4b03-afd4-1024b6e645b2
+      - a2c6860c-52eb-4483-bc84-afe1d21a17af
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,10 +4343,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:57:30.388159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "670"
@@ -3959,7 +4355,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:42 GMT
+      - Mon, 13 Nov 2023 13:57:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +4365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11304ab8-2196-4485-a62d-9de678d1132e
+      - 2df26929-6afe-48cb-9a99-23d30f2d4afa
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,10 +4376,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:57:30.388159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "670"
@@ -3992,7 +4388,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:47 GMT
+      - Mon, 13 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +4398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac55ff6e-60e5-41e9-b2bf-529625922d95
+      - 511a350d-82eb-4f8c-9861-c7b449511add
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,10 +4409,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:57:30.388159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "670"
@@ -4025,7 +4421,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:52 GMT
+      - Mon, 13 Nov 2023 13:57:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4035,7 +4431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bf9ad8e-d53c-4506-859b-50805ee2c03f
+      - efafecfd-5e76-4f35-83d3-567d756ef801
     status: 200 OK
     code: 200
     duration: ""
@@ -4046,10 +4442,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9c2505ba-29d4-4471-b716-3470d419f337","container_runtime":"containerd","created_at":"2023-11-13T13:51:25.333979Z","id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-13T13:57:30.388159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "670"
@@ -4058,7 +4454,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:57 GMT
+      - Mon, 13 Nov 2023 13:58:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4068,7 +4464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 764e152b-aca5-4072-b5f1-98d3e612ab0d
+      - b4b4bf65-7b1c-4546-86aa-eaa576caaf17
     status: 200 OK
     code: 200
     duration: ""
@@ -4079,175 +4475,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8f6b5d25-3c7b-4ec3-8cd5-51846c12422d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0748662e-377d-4c98-a3fb-8e1db3c70d8e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5af051c-7da9-49f9-b996-fa8250e9b67f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7fe021a3-1e2b-4fe7-8df5-bec5e540b1c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","container_runtime":"containerd","created_at":"2023-11-10T13:20:26.721890Z","id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-10T13:25:27.314388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bda04819-25be-4a4f-b527-8ec083d44734
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4256,7 +4487,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:28 GMT
+      - Mon, 13 Nov 2023 13:58:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4266,7 +4497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64d9b17e-2a0e-4766-969f-186af971337b
+      - 59dd98e9-f3d9-48ae-9909-29a93c84b6bb
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4277,10 +4508,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:26:28.088149007Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:58:06.926590470Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1504"
@@ -4289,7 +4520,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:28 GMT
+      - Mon, 13 Nov 2023 13:58:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4299,7 +4530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18458e60-bfc4-4450-8904-5c6b3ba2721a
+      - 4234eb4b-36f2-4145-8e88-e3db66b20b7a
     status: 200 OK
     code: 200
     duration: ""
@@ -4310,10 +4541,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:26:28.088149Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:58:06.926590Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -4322,7 +4553,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:28 GMT
+      - Mon, 13 Nov 2023 13:58:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4332,7 +4563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4eec4cd9-d9de-4eae-92aa-5ea9cc640219
+      - c0f9d8bb-0c52-4773-9c4e-b7dacaa4b4c4
     status: 200 OK
     code: 200
     duration: ""
@@ -4343,10 +4574,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b6d53007-e38d-4d61-a7f4-426527b30be0.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:20:21.287414Z","created_at":"2023-11-10T13:20:21.287414Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b6d53007-e38d-4d61-a7f4-426527b30be0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b6d53007-e38d-4d61-a7f4-426527b30be0","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-10T13:26:28.088149Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9c2505ba-29d4-4471-b716-3470d419f337.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:19.725864Z","created_at":"2023-11-13T13:51:19.725864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9c2505ba-29d4-4471-b716-3470d419f337.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9c2505ba-29d4-4471-b716-3470d419f337","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-13T13:58:06.926590Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1501"
@@ -4355,7 +4586,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:33 GMT
+      - Mon, 13 Nov 2023 13:58:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +4596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89cd43bd-8263-4dde-a324-b77261b4f0e0
+      - 027b99f3-6498-4a2b-adfc-599b5e7b6e99
     status: 200 OK
     code: 200
     duration: ""
@@ -4376,10 +4607,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"9c2505ba-29d4-4471-b716-3470d419f337","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4388,7 +4619,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:38 GMT
+      - Mon, 13 Nov 2023 13:58:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +4629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7671821d-aec9-4b2b-bd6c-611c4136d554
+      - 52f2eac5-889a-4169-9f39-c5c11172151f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4409,10 +4640,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7d4cdc29-ed97-4c47-9dad-9866c3e4716e
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4421,7 +4652,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:38 GMT
+      - Mon, 13 Nov 2023 13:58:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +4662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff9a8876-330a-4fea-ac20-200bd4fac2e6
+      - 925be9f5-e47d-485f-9702-015cbd6aec62
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4442,76 +4673,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ec4c44f0-878f-442a-873e-4098d5c5d1ec
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5c166d0b-235e-4e0a-a9b1-9fbc18148e0a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"ec4c44f0-878f-442a-873e-4098d5c5d1ec","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d478f9e-451b-4948-a3e3-b87d94587e7b
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b6d53007-e38d-4d61-a7f4-426527b30be0
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b6d53007-e38d-4d61-a7f4-426527b30be0","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33fbeede-bfc9-4dd0-afd0-edae4be79675
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/329885b3-6ef0-4c39-b604-53eeceb0a5ee
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"329885b3-6ef0-4c39-b604-53eeceb0a5ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"5c166d0b-235e-4e0a-a9b1-9fbc18148e0a","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4520,7 +4685,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:38 GMT
+      - Mon, 13 Nov 2023 13:58:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4530,7 +4695,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b73b999b-7666-45ab-8912-4e949b65dfbb
+      - 43e33123-3165-4ef9-ac67-7c29d5c5c712
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9c2505ba-29d4-4471-b716-3470d419f337
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"9c2505ba-29d4-4471-b716-3470d419f337","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 230210b0-ba82-4780-8767-459774b3daf5
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7d4cdc29-ed97-4c47-9dad-9866c3e4716e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"7d4cdc29-ed97-4c47-9dad-9866c3e4716e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1d7d54d4-eb1a-4565-8fd5-cbb42aad69de
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-auto-upgrade.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-auto-upgrade.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 14:05:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4cb66dc-3f09-4602-9793-f271cadeea4b
+      - b6317019-33e3-4897-b314-daacd3cc9003
     status: 200 OK
     code: 200
     duration: ""
@@ -61,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 14:05:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dea8b09c-1d4b-4e69-911e-f9a2ba000437
+      - b0a3a002-4598-452f-bb41-014ec2f54566
     status: 200 OK
     code: 200
     duration: ""
@@ -98,7 +98,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 14:05:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -108,7 +108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5640369-388d-4a07-8985-82cb400b8fea
+      - df4b8e52-cee7-4656-9ce2-f31d970814c1
     status: 200 OK
     code: 200
     duration: ""
@@ -135,7 +135,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 14:05:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -145,7 +145,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e20ec089-7a94-4237-988e-9f871c36ebb0
+      - 5aa1fbf1-ab14-4a2f-84f4-21bf2eaa62dd
     status: 200 OK
     code: 200
     duration: ""
@@ -161,7 +161,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -170,7 +170,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:01 GMT
+      - Mon, 13 Nov 2023 14:05:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -180,7 +180,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c728e11-3a1f-4a16-b848-b3a55d67bc06
+      - d317acd8-d378-4d8e-b609-5e1368370629
     status: 200 OK
     code: 200
     duration: ""
@@ -191,10 +191,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -203,7 +203,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:01 GMT
+      - Mon, 13 Nov 2023 14:05:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -213,12 +213,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3712dc3-1c38-4d16-be59-ee3970bd58e0
+      - b917884d-6685-4186-ba06-882591a45f00
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-auto-upgrade","description":"","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":false,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-auto-upgrade","description":"","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":false,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad"}'
     form: {}
     headers:
       Content-Type:
@@ -229,7 +229,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506226949Z","created_at":"2023-11-10T13:23:01.506226949Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:01.517085294Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198873725Z","created_at":"2023-11-13T14:05:41.198873725Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:41.210633536Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1513"
@@ -238,7 +238,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:01 GMT
+      - Mon, 13 Nov 2023 14:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -248,7 +248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 874b386c-ad99-4834-994f-a044b28ea8e0
+      - f36a6ec0-b451-4c89-92f6-3f74bee0448d
     status: 200 OK
     code: 200
     duration: ""
@@ -259,10 +259,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:01.517085Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:41.210634Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1504"
@@ -271,7 +271,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:01 GMT
+      - Mon, 13 Nov 2023 14:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -281,7 +281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4228167-39da-48fb-b56f-6b155a7e35be
+      - a005c74a-ab50-4cb1-bb35-b50e089c6e25
     status: 200 OK
     code: 200
     duration: ""
@@ -292,10 +292,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:42.859042Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1509"
@@ -304,7 +304,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:06 GMT
+      - Mon, 13 Nov 2023 14:05:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -314,7 +314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 648d5c4d-8f55-408e-ab53-85a910f00d36
+      - 73cbadd0-f569-450e-a905-e827f484a216
     status: 200 OK
     code: 200
     duration: ""
@@ -325,10 +325,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:42.859042Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1509"
@@ -337,7 +337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:06 GMT
+      - Mon, 13 Nov 2023 14:05:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -347,7 +347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1812c224-fcd7-48cd-8e88-64a4bd8f0a64
+      - fe711463-d36a-4e11-8c35-859a4ebb3812
     status: 200 OK
     code: 200
     duration: ""
@@ -358,10 +358,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -370,7 +370,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:06 GMT
+      - Mon, 13 Nov 2023 14:05:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -380,7 +380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c517e969-9208-46b6-ad01-d7b5817f7a33
+      - 01945593-0456-430c-8325-67704c7f2c6c
     status: 200 OK
     code: 200
     duration: ""
@@ -391,10 +391,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:42.859042Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1509"
@@ -403,7 +403,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:06 GMT
+      - Mon, 13 Nov 2023 14:05:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -413,7 +413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53f1bed0-3a37-4e2f-ba5a-dcf22d74af13
+      - b3f35a14-85da-4f44-9e65-186983739d4e
     status: 200 OK
     code: 200
     duration: ""
@@ -424,10 +424,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -436,7 +436,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 14:05:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -446,7 +446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdb4221a-1ff3-4e67-823e-a6aebce17b41
+      - a4e7133d-b122-4b32-b346-9a13b4f65dc3
     status: 200 OK
     code: 200
     duration: ""
@@ -457,10 +457,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:42.859042Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1509"
@@ -469,7 +469,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 14:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -479,7 +479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6af8ff35-05f0-40f9-89c9-fecec5eeee8e
+      - cfefb4b7-d9bd-4ccb-83f1-4a074529d8a5
     status: 200 OK
     code: 200
     duration: ""
@@ -490,10 +490,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -502,7 +502,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 14:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -512,7 +512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 691a5550-b93c-4a02-8139-96591bde8cbe
+      - 755f8e79-3eca-4753-9d98-73e754c760b1
     status: 200 OK
     code: 200
     duration: ""
@@ -523,10 +523,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -535,7 +535,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 14:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -545,7 +545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0db439c-63c4-42e4-a9c4-1bcdb3b0dfa9
+      - bdbb8a57-d8c3-4549-ae2f-13a5bd2e15b3
     status: 200 OK
     code: 200
     duration: ""
@@ -556,10 +556,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:42.859042Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1509"
@@ -568,7 +568,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 14:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -578,7 +578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1d23dee-8aea-4131-b194-bd5166fa5997
+      - e017db25-69b1-4b5b-ae89-59705e5ea556
     status: 200 OK
     code: 200
     duration: ""
@@ -589,10 +589,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -601,7 +601,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 14:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -611,7 +611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 293fe177-7ce4-4675-8566-eb3364d9cfd8
+      - 3c57a792-4a6d-409e-95e9-408177ce0524
     status: 200 OK
     code: 200
     duration: ""
@@ -638,7 +638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:08 GMT
+      - Mon, 13 Nov 2023 14:05:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -648,7 +648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27f13a0c-8896-4631-ba04-31a79fd06681
+      - 42d4ded9-4037-4221-8778-c91325685824
     status: 200 OK
     code: 200
     duration: ""
@@ -659,10 +659,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:03.331737Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:42.859042Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1509"
@@ -671,7 +671,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:08 GMT
+      - Mon, 13 Nov 2023 14:05:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -681,7 +681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81c4b99c-85dc-4bcb-aee5-609bad980c1c
+      - 76e1f56c-f710-4d32-924d-2c11462ffb72
     status: 200 OK
     code: 200
     duration: ""
@@ -694,10 +694,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:08.439822544Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:48.251551650Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1506"
@@ -706,7 +706,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:08 GMT
+      - Mon, 13 Nov 2023 14:05:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -716,7 +716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04c80eaa-d998-46db-8fc5-880c6c17ea4f
+      - c489de2c-a308-4bcb-8b2a-c55d3a2027d2
     status: 200 OK
     code: 200
     duration: ""
@@ -727,10 +727,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:08.439823Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:48.251552Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1503"
@@ -739,7 +739,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:08 GMT
+      - Mon, 13 Nov 2023 14:05:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -749,7 +749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56709b88-3a0d-4208-947c-f8042179de67
+      - 9418aba4-cbc5-4357-8bfd-3fba626ac69b
     status: 200 OK
     code: 200
     duration: ""
@@ -760,10 +760,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:49.390585Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1508"
@@ -772,7 +772,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:13 GMT
+      - Mon, 13 Nov 2023 14:05:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -782,7 +782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9802ad7a-fa95-4550-a5e7-a292ff45b950
+      - 27d40b8e-f65c-48bf-aa3b-48d7e49df291
     status: 200 OK
     code: 200
     duration: ""
@@ -793,10 +793,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:49.390585Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1508"
@@ -805,7 +805,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:13 GMT
+      - Mon, 13 Nov 2023 14:05:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -815,7 +815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc8047a7-93f0-4bc2-b38b-d9708d7f05fe
+      - d4a21ae4-5289-4144-890d-b0fea22ac156
     status: 200 OK
     code: 200
     duration: ""
@@ -826,10 +826,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -838,7 +838,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:13 GMT
+      - Mon, 13 Nov 2023 14:05:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -848,7 +848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b5e01f5-e4ca-4773-a1ec-bb5ad3d4772f
+      - 8b9bcaf3-5b23-457b-953d-a363952c275c
     status: 200 OK
     code: 200
     duration: ""
@@ -859,10 +859,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:49.390585Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1508"
@@ -871,7 +871,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:13 GMT
+      - Mon, 13 Nov 2023 14:05:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -881,7 +881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a4a5b39-1c6a-4a1f-aba3-c7bd5af94c68
+      - 21a9cbaf-eb85-45f1-a501-6a7a981106e8
     status: 200 OK
     code: 200
     duration: ""
@@ -892,10 +892,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -904,7 +904,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:14 GMT
+      - Mon, 13 Nov 2023 14:05:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -914,7 +914,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2723a334-269e-461a-ae59-bafb50a5e1ac
+      - 37b47095-0e74-41e6-8e81-5694d8d2b150
     status: 200 OK
     code: 200
     duration: ""
@@ -925,10 +925,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:49.390585Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1508"
@@ -937,7 +937,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:14 GMT
+      - Mon, 13 Nov 2023 14:05:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -947,7 +947,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a9f65f2-6a2a-470c-b499-fa2b6411f7f5
+      - bb66f9e6-bd41-447b-b46f-f2cc70b4a210
     status: 200 OK
     code: 200
     duration: ""
@@ -958,10 +958,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -970,7 +970,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:14 GMT
+      - Mon, 13 Nov 2023 14:05:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -980,7 +980,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fb44cc6-084d-4b35-84d4-c222b6ab684c
+      - 3803d0e9-fa2c-4e6f-8909-9cba9df50229
     status: 200 OK
     code: 200
     duration: ""
@@ -991,10 +991,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -1003,7 +1003,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:14 GMT
+      - Mon, 13 Nov 2023 14:05:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1013,7 +1013,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d6f4fc0-309b-4783-a377-360596e91e1b
+      - d3feb62d-9313-4175-ad6f-b3a2bd45daf6
     status: 200 OK
     code: 200
     duration: ""
@@ -1024,10 +1024,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:49.390585Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1508"
@@ -1036,7 +1036,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:14 GMT
+      - Mon, 13 Nov 2023 14:05:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1046,7 +1046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52fe7f39-edbd-4476-b9ae-600a8def122f
+      - 82bfb9f4-9404-4d47-af19-1e2456e7ea30
     status: 200 OK
     code: 200
     duration: ""
@@ -1057,10 +1057,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -1069,7 +1069,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:14 GMT
+      - Mon, 13 Nov 2023 14:05:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1079,7 +1079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e58db1e9-bc65-4111-9070-c2949db4b822
+      - da08b9ca-3942-4dc7-bb12-472250e2aabc
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,7 +1106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:15 GMT
+      - Mon, 13 Nov 2023 14:05:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1116,7 +1116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8088e7c2-a5f1-4430-a75b-1b0b06c2cbc3
+      - 5894c263-3bba-44fa-a427-b2b870d85eeb
     status: 200 OK
     code: 200
     duration: ""
@@ -1127,10 +1127,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:09.542551Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:49.390585Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1508"
@@ -1139,7 +1139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:15 GMT
+      - Mon, 13 Nov 2023 14:05:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1149,7 +1149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5284ed0f-72ca-4f09-af62-3cb987563f64
+      - a82d1c7c-d2e4-46e6-a496-c52304d18d7c
     status: 200 OK
     code: 200
     duration: ""
@@ -1162,10 +1162,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:15.443631381Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:55.316499299Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1506"
@@ -1174,7 +1174,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:15 GMT
+      - Mon, 13 Nov 2023 14:05:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1184,7 +1184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aeb719a-7c7a-4ff1-9621-a55efcf9348f
+      - 29a79291-276d-4b47-8571-df29a3ac1705
     status: 200 OK
     code: 200
     duration: ""
@@ -1195,10 +1195,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:15.443631Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:55.316499Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1503"
@@ -1207,7 +1207,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:15 GMT
+      - Mon, 13 Nov 2023 14:05:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1217,7 +1217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de8e2717-a85f-4659-a6c3-2dfe7d11c5c3
+      - 2b6989ff-4e4d-49bb-904f-496ca821996e
     status: 200 OK
     code: 200
     duration: ""
@@ -1228,10 +1228,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:16.577657Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:05:56.441796Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1508"
@@ -1240,7 +1240,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:20 GMT
+      - Mon, 13 Nov 2023 14:06:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1250,7 +1250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38e9c8fd-4dd1-4a37-8230-f806dd4489b5
+      - 2e3c9b85-d66c-4611-8938-5226de1e24fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1263,10 +1263,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/upgrade
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/upgrade
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:20.610441424Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:00.622684597Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -1275,7 +1275,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:20 GMT
+      - Mon, 13 Nov 2023 14:06:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1285,7 +1285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38431cdb-703f-4579-923d-fcf41de26861
+      - 7ac8050e-9cfd-4625-9bb9-ed7c14fd87fe
     status: 200 OK
     code: 200
     duration: ""
@@ -1296,10 +1296,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:20.610441Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:00.622685Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1504"
@@ -1308,7 +1308,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:20 GMT
+      - Mon, 13 Nov 2023 14:06:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1318,7 +1318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc08c0f4-bcc5-43d7-8c0a-fc8b4e84a2b4
+      - 4662866a-0f23-4035-ac75-3cde932deedf
     status: 200 OK
     code: 200
     duration: ""
@@ -1329,10 +1329,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:01.740229Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -1341,7 +1341,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:25 GMT
+      - Mon, 13 Nov 2023 14:06:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1351,7 +1351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26f94a26-9215-41b3-a883-52a72c497b00
+      - 7d98c3a2-5a3a-47d2-bf0b-9f4ca9929599
     status: 200 OK
     code: 200
     duration: ""
@@ -1362,10 +1362,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:01.740229Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -1374,7 +1374,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:25 GMT
+      - Mon, 13 Nov 2023 14:06:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1384,7 +1384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c474802-8840-48aa-8bbd-b8f58b264247
+      - 8ceba8c9-0146-440d-9632-f81a2a5e1158
     status: 200 OK
     code: 200
     duration: ""
@@ -1395,10 +1395,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -1407,7 +1407,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:25 GMT
+      - Mon, 13 Nov 2023 14:06:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1417,7 +1417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14ee9928-6b2c-4f84-80cb-22076ab25fe2
+      - 9bc5e0c8-4eb2-4769-9340-d9db3527a415
     status: 200 OK
     code: 200
     duration: ""
@@ -1428,10 +1428,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:01.740229Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -1440,7 +1440,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:26 GMT
+      - Mon, 13 Nov 2023 14:06:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1450,7 +1450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1c85e5e-310b-4400-b978-df8edb2ac207
+      - 847ebbad-0595-4777-be74-00597a2fe43e
     status: 200 OK
     code: 200
     duration: ""
@@ -1461,10 +1461,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -1473,7 +1473,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:26 GMT
+      - Mon, 13 Nov 2023 14:06:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1483,7 +1483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ddce9769-e0ed-4e2e-9fa8-05e4aa142c28
+      - f85f2d65-4eff-4b32-8990-0eabb0031295
     status: 200 OK
     code: 200
     duration: ""
@@ -1494,10 +1494,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:01.740229Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -1506,7 +1506,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:26 GMT
+      - Mon, 13 Nov 2023 14:06:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1516,7 +1516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ab88d72-84f6-4ca0-ae88-565a2db5a4cc
+      - ade99ea9-9ec5-4e8b-8a68-f84607ee9de7
     status: 200 OK
     code: 200
     duration: ""
@@ -1527,10 +1527,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -1539,7 +1539,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:26 GMT
+      - Mon, 13 Nov 2023 14:06:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1549,7 +1549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b9f3350-99ed-4b24-a720-114bb352367d
+      - b10d3fed-6c99-4989-acda-59c470420874
     status: 200 OK
     code: 200
     duration: ""
@@ -1560,10 +1560,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -1572,7 +1572,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:26 GMT
+      - Mon, 13 Nov 2023 14:06:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1582,7 +1582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fafc23b-08fb-4455-ad80-054b9f2dd302
+      - e9beea90-b4f9-4266-b4f2-b73627d82a7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1593,10 +1593,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:01.740229Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -1605,7 +1605,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
+      - Mon, 13 Nov 2023 14:06:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1615,7 +1615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc65340d-1a93-4fc0-9bd3-3ce217f1f564
+      - 347098ba-018a-4308-9388-337f633518d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1626,10 +1626,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -1638,7 +1638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
+      - Mon, 13 Nov 2023 14:06:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1648,7 +1648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee3d0464-55b0-4b4c-8067-2dcbe91f80a7
+      - b603dd1a-9880-490b-9482-89ec31e8ff75
     status: 200 OK
     code: 200
     duration: ""
@@ -1659,10 +1659,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:21.806653Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:01.740229Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -1671,7 +1671,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
+      - Mon, 13 Nov 2023 14:06:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1681,7 +1681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33cff578-f4c6-40ab-90db-a6b0df8ba5c5
+      - e63c9a56-60eb-47d6-a574-92c44b395199
     status: 200 OK
     code: 200
     duration: ""
@@ -1694,10 +1694,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:27.665320906Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:11.490135053Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -1706,7 +1706,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
+      - Mon, 13 Nov 2023 14:06:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1716,7 +1716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d22dff70-238f-47ef-8bbb-5d1a9e1ce045
+      - 9136e431-856c-4e85-acd3-1928f1adb0d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1727,10 +1727,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:27.665321Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:11.490135Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1505"
@@ -1739,7 +1739,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:27 GMT
+      - Mon, 13 Nov 2023 14:06:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1749,7 +1749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31f7a8c8-95e4-4165-bdf9-fc265bcd0687
+      - ee21e9ef-aa58-45d1-938d-a2a8ae2fec75
     status: 200 OK
     code: 200
     duration: ""
@@ -1760,43 +1760,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:27.665321Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1505"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b82a2cf2-356b-43e8-af06-49ebe20ccabb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:12.616164Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -1805,7 +1772,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:37 GMT
+      - Mon, 13 Nov 2023 14:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1815,7 +1782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c1f4811-94f5-4819-8a05-110c226308bb
+      - 7b8058e2-b5e2-4c51-bede-6f742779e799
     status: 200 OK
     code: 200
     duration: ""
@@ -1826,10 +1793,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:12.616164Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -1838,7 +1805,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:37 GMT
+      - Mon, 13 Nov 2023 14:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1848,7 +1815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8849fb27-64b7-48e5-bb0c-ce182ba060b7
+      - 644ff141-37f8-47eb-a869-e5a52f12170e
     status: 200 OK
     code: 200
     duration: ""
@@ -1859,10 +1826,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -1871,7 +1838,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:38 GMT
+      - Mon, 13 Nov 2023 14:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1881,7 +1848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e33e5c5-96b4-4980-b0bb-3ed4f80115a1
+      - b3cc0e92-e648-411e-939e-2e9a72cac643
     status: 200 OK
     code: 200
     duration: ""
@@ -1892,10 +1859,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:12.616164Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -1904,7 +1871,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:38 GMT
+      - Mon, 13 Nov 2023 14:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1914,7 +1881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d7a4f7f-c061-41e6-81c9-207ced4b1852
+      - 66879260-74a5-43d7-a067-3bd6eefdd63b
     status: 200 OK
     code: 200
     duration: ""
@@ -1925,10 +1892,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -1937,7 +1904,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:38 GMT
+      - Mon, 13 Nov 2023 14:06:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1947,7 +1914,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57eab7cb-b907-494b-a2a5-5286117fbd1d
+      - 19805c5d-97a0-4739-860a-cc89d0f4cf74
     status: 200 OK
     code: 200
     duration: ""
@@ -1958,10 +1925,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:12.616164Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -1970,7 +1937,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:38 GMT
+      - Mon, 13 Nov 2023 14:06:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1980,7 +1947,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9f3dc86-13a5-4e5c-b3eb-7d300fd21c1a
+      - 7808ee26-99b4-4219-a4a3-4aeeae53325c
     status: 200 OK
     code: 200
     duration: ""
@@ -1991,10 +1958,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2003,7 +1970,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:38 GMT
+      - Mon, 13 Nov 2023 14:06:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2013,7 +1980,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0d75865-01c8-444b-8e1e-82eda74d548c
+      - fbecdb1e-fdbe-4453-8d2d-e815b02e1a7a
     status: 200 OK
     code: 200
     duration: ""
@@ -2024,10 +1991,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -2036,7 +2003,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:39 GMT
+      - Mon, 13 Nov 2023 14:06:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2046,7 +2013,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0aa9a11-7fd1-49e4-ba95-8469e3761c73
+      - acac4292-7c4c-4a58-a07c-9ec3bb9999b8
     status: 200 OK
     code: 200
     duration: ""
@@ -2057,10 +2024,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:12.616164Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -2069,7 +2036,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:39 GMT
+      - Mon, 13 Nov 2023 14:06:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2079,7 +2046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1680143-9e01-4f6b-8b5f-27d1fdf4300b
+      - 7e683409-bd61-4c7d-8ed0-2f2edae13000
     status: 200 OK
     code: 200
     duration: ""
@@ -2090,10 +2057,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2102,7 +2069,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:39 GMT
+      - Mon, 13 Nov 2023 14:06:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2112,7 +2079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f102b75e-c592-4743-85f8-4b7b815554c3
+      - 2bdcaa30-0e6d-493e-a744-7c4cae6d58f0
     status: 200 OK
     code: 200
     duration: ""
@@ -2139,7 +2106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:39 GMT
+      - Mon, 13 Nov 2023 14:06:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,7 +2116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30885abf-ffa4-46c7-b4e5-0595525c04f1
+      - 4bcf7555-97b8-4573-93fc-35a70ed174e3
     status: 200 OK
     code: 200
     duration: ""
@@ -2160,10 +2127,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:32.933898Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:12.616164Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -2172,7 +2139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:39 GMT
+      - Mon, 13 Nov 2023 14:06:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2182,7 +2149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40411ce4-f81a-4467-a9be-cc4071b07daa
+      - 93323b2d-9cfa-400b-8c5e-ffd130d6a423
     status: 200 OK
     code: 200
     duration: ""
@@ -2195,10 +2162,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:39.950990034Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:18.704657663Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1511"
@@ -2207,7 +2174,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:39 GMT
+      - Mon, 13 Nov 2023 14:06:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2217,7 +2184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ea4e6ed-052d-4a1e-bb52-ca6826140de0
+      - e81f2aaa-7a06-4744-a511-1a08cc913558
     status: 200 OK
     code: 200
     duration: ""
@@ -2228,10 +2195,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:39.950990Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:18.704658Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -2240,7 +2207,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:40 GMT
+      - Mon, 13 Nov 2023 14:06:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2250,7 +2217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 472c29fc-027c-4a84-b391-7de081fcde0d
+      - bd1fa278-123e-4d83-b5d3-9641b49d918a
     status: 200 OK
     code: 200
     duration: ""
@@ -2261,10 +2228,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:19.846011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2273,7 +2240,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:06:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2283,7 +2250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c6ccf86-4db9-48d8-9f14-bc365d048cd2
+      - 255f6c2a-280a-48bd-85a9-ceab7ad027d1
     status: 200 OK
     code: 200
     duration: ""
@@ -2294,10 +2261,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:19.846011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2306,7 +2273,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:06:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2316,7 +2283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ac1e50c-c12d-4673-9b18-e5c0328f38db
+      - f24b50bd-adb3-443a-84f9-7f9a2cf4e8e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2327,10 +2294,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2339,7 +2306,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:06:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2349,7 +2316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 614efcdf-9521-4203-b84e-f35e90be9612
+      - 48eb9bfc-2948-4b66-b49d-d60bcc511ddb
     status: 200 OK
     code: 200
     duration: ""
@@ -2360,10 +2327,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:19.846011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2372,7 +2339,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:06:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2382,7 +2349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 313beb5a-134a-4eef-89d1-b1de0e1251c3
+      - 616c4232-3466-4a68-945c-33b0ad5232ad
     status: 200 OK
     code: 200
     duration: ""
@@ -2393,10 +2360,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -2405,7 +2372,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:06:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2415,7 +2382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30d32833-26a1-48d0-b08c-5dc20bab7416
+      - 56348b78-bc6c-4b9f-b384-095653299749
     status: 200 OK
     code: 200
     duration: ""
@@ -2426,10 +2393,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:19.846011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2438,7 +2405,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:06:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2448,7 +2415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bbb73b7-5e07-4f88-9d77-f3a7bf8db7b8
+      - 5fe744ce-c9b8-4212-b224-46ccce6a8711
     status: 200 OK
     code: 200
     duration: ""
@@ -2459,10 +2426,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2471,7 +2438,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:06:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2481,7 +2448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ddaf255-c9d0-4b14-9d90-b3bf016220fd
+      - 0ef7a3da-39fc-42fd-ae67-b7f9d8ce92e5
     status: 200 OK
     code: 200
     duration: ""
@@ -2492,10 +2459,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -2504,7 +2471,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:46 GMT
+      - Mon, 13 Nov 2023 14:06:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2514,7 +2481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35f2013e-7d85-4b7c-9edf-ad09d67f2156
+      - 76d75bff-34a9-4941-bbf1-83a54c783101
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,10 +2492,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:41.106172Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:19.846011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2537,7 +2504,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:46 GMT
+      - Mon, 13 Nov 2023 14:06:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2547,7 +2514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59e84523-5f54-4f16-85a6-417f16e40a17
+      - ac9258ac-6d0b-4192-8ec5-27e9ded08bae
     status: 200 OK
     code: 200
     duration: ""
@@ -2558,10 +2525,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2570,7 +2537,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:46 GMT
+      - Mon, 13 Nov 2023 14:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2580,7 +2547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e09b2d1-9960-4700-b134-6248e596de38
+      - d9eac0d5-c41c-4f4c-8831-b27cf6756afe
     status: 200 OK
     code: 200
     duration: ""
@@ -2607,7 +2574,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:47 GMT
+      - Mon, 13 Nov 2023 14:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2617,7 +2584,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d46c564b-badc-461f-a7da-055fba1a231c
+      - eb1fabe3-8ad6-46b6-a5ab-dafb7264a562
     status: 200 OK
     code: 200
     duration: ""
@@ -2630,10 +2597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:47.229804131Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:25.640446391Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -2642,7 +2609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:47 GMT
+      - Mon, 13 Nov 2023 14:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2652,7 +2619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4700c99f-b82a-4915-a9a6-2691df050491
+      - 53bb5c74-e046-4e61-be7d-541c95c2a2fe
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,10 +2630,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:47.229804Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:25.640446Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1504"
@@ -2675,7 +2642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:47 GMT
+      - Mon, 13 Nov 2023 14:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2685,7 +2652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 937d66eb-c609-46e9-ac07-65a5e352dd67
+      - 08d03860-87c4-4403-8e70-bf7e66055060
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,10 +2663,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:49.013436Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:26.827323Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -2708,7 +2675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:52 GMT
+      - Mon, 13 Nov 2023 14:06:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2718,7 +2685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68087ff0-7fc0-411f-84d9-e864c56abb3a
+      - c8f2ab78-fff9-4cfb-a4b5-198837c53d22
     status: 200 OK
     code: 200
     duration: ""
@@ -2729,10 +2696,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:49.013436Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:26.827323Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -2741,7 +2708,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:52 GMT
+      - Mon, 13 Nov 2023 14:06:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2751,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1be73df-cb27-4572-ab9b-654d0f6d4a1a
+      - 26c2cbed-d7cf-4f19-80f8-b1ce7fc3e1e4
     status: 200 OK
     code: 200
     duration: ""
@@ -2762,10 +2729,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2774,7 +2741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:52 GMT
+      - Mon, 13 Nov 2023 14:06:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2784,7 +2751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bab398a-b06c-4556-89ad-2c35abc60499
+      - 82423dc9-452b-4224-90ea-46f217ffae61
     status: 200 OK
     code: 200
     duration: ""
@@ -2795,10 +2762,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:49.013436Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:26.827323Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -2807,7 +2774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:52 GMT
+      - Mon, 13 Nov 2023 14:06:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2817,7 +2784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38793228-229d-4913-a3e5-bd7b767ba520
+      - 48bceefc-e53b-4e36-85a1-256374845dfe
     status: 200 OK
     code: 200
     duration: ""
@@ -2828,10 +2795,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:00.498850Z","dhcp_enabled":true,"id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:00.498850Z","id":"f6d6935f-446c-467d-8fca-9e181e851bc6","subnet":"172.16.44.0/22","updated_at":"2023-11-10T13:23:00.498850Z"},{"created_at":"2023-11-10T13:23:00.498850Z","id":"d94dafe3-78f0-4822-a5ba-a69b2a41c02d","subnet":"fd63:256c:45f7:b2cd::/64","updated_at":"2023-11-10T13:23:00.498850Z"}],"tags":[],"updated_at":"2023-11-10T13:23:00.498850Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:05:36.639929Z","dhcp_enabled":true,"id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:05:36.639929Z","id":"f65125d1-e91e-422c-8c77-868dafccecea","subnet":"172.16.28.0/22","updated_at":"2023-11-13T14:05:36.639929Z"},{"created_at":"2023-11-13T14:05:36.639929Z","id":"a378e3a1-cad8-41f9-8c0b-4278c2c814da","subnet":"fd63:256c:45f7:27a9::/64","updated_at":"2023-11-13T14:05:36.639929Z"}],"tags":[],"updated_at":"2023-11-13T14:05:36.639929Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -2840,7 +2807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:53 GMT
+      - Mon, 13 Nov 2023 14:06:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2850,7 +2817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 869c8133-57ea-4969-993a-370b972767c9
+      - d77403d5-4fc1-4cd7-8b22-f8c379e698a0
     status: 200 OK
     code: 200
     duration: ""
@@ -2861,10 +2828,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:49.013436Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:26.827323Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -2873,7 +2840,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:53 GMT
+      - Mon, 13 Nov 2023 14:06:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2883,7 +2850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78324622-bb37-43ba-8980-3d1eb616a73d
+      - 1630565c-b422-4f1f-a9bc-9e276c4c4650
     status: 200 OK
     code: 200
     duration: ""
@@ -2894,10 +2861,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwTmQwMXNiMWhFVkUxNlRWUkZkMDlVUlhwTmFrMTNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRFZFJDa2htYlU5SFdqWlNhMWg0VVRKclkxaGxOMUp3VVRWclYwTktWMVZLV2sweVoxSTNRMjR2UVZsVlFuWkRhak5IYTBvMFUwNTFNWGRuWkVkUFpWSm1lSEVLV213ck16aHNZblpUV2xGaGQwTmtUekJVVjIxb1kweFJSMWhxUzI5cVZtMUZXbGRFWkM5SVZtYzFUbE55UTFCSVkzSm5Oa1EyTmpKc2NqRlVjVlI0VmdwM01tOVJSVmd5VURWMVl6Qm5WemxpZEhaSVJIWjZVak15VkZSWFJWSnZWMGxPWWtJemVrSkphUzl2VW5KWk5EazBlbWRsUmtSc1NYVmhiRVF6YjNORkNqWXZTR3RzU0VKdmRVcFRXWE5LYkhSblNEaGxiVVU1TmxSVFZYWkZhazEzYVZoMllUYzNiVmhoYWpGUWIyWklXVmRrTm1OVFdHb3lXVVZRU1hjMmJIVUtWUzlzTkdvMWVFZFFhMlZGY0c5aFlVbDNVaTlZV2tSQlkwNVBaM2xVSzFORFUwVnlURUZ3UlZOR1UyNHliR05ZYnpaMFJsZHVhRk5JUzI1amVTOXllUXB6ZUV4VmRtbEVaMUowWTNCelIxZzJZVUpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGVDAxTGRsUTVWbEZqVGs5aU5XODVhRUpMWlVaU1ZEUlJWalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZEdKWVUwNVZhWFJhTTAwMFEyeDZORU5UVUVaVmRtaDJWMFpYZFV0U1VqSXJlalJLYnk5cldIcGliSEJuTmpSMk1ncHBOM05RZFd4Mk5IWnNaakpZY21Wc1YydDZTWGhvUzNWTFkwWjZMMlZGVkRscWIyOHJTRXBpVlZGVGVtcG1LMlE1Ym5ocFpXZFlha3N2Y1ZScGFEWk1DalUwWVM5WVkyVmFlbW81WTBkb0x6aEJXVlJMTlVwM1pucFRUREk1V2tSM1NWVlJTaXRSSzNGT2JuZFpaVVYwUmxsNFFXeFpRMnBDZDI1dU0xWnNZa01LY0d4SGFqQlJMM0pDUlZOVFVYWTVPV3B4TldSRlNUa3hPVkEzVldaeFowRjNhVzFwY1ZKUldqWXJjMGRQU25WSlJtcHBVbUpwSzBGSVoyUlFNSFpGVXdwSlZ6UkljbU5VWTJ3d1ozSnlhRUZRT1ZSV1J6WXpiVXR0VEZVNUszQjNNbFJpU2pObE1FUmthWE5OTldSNFkwUm9SMHhGVUM5S05uaEdZV1ZrUmpGbENsSnRja1p0UzFKT1VtdEpWSEp0UTJscmQwMVVSVEJJWVdWUlptSkhlblJFUm1aS05Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81MzBkNjQyMy0yYmFlLTQ2ODMtOTc4ZC04OTY3MDA3OTQ0ZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2RHRKTk5RZ2lVZE03YWNKZkpyZHlEM3pvNVEySkE1M0JkTDlmYXByMGZaUWpjeWlyaWdQYmI1RQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSVk1FMXNiMWhFVkUxNlRWUkZlRTFxUlRCTlJGVXdUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYbFZDa3hXU1dreFZsUXlNMVp4Ym1KRFYwVktjeXMwVmxrMlptUnVXVTVaYzJ0bVUxZ3lPSHBRU1ZZMlNHRnhWVkJrTkZNeVQzcFJVSGxNUnpOYVpDdDBPR0VLT0hwRk5WVnZUR2x6UmtsWmRHeGpNV2xuWlc4MGIySndjMDQ1VmpaT1VUSmFTblJoVjFkUmMwRXhWRzFYYUdKblJVSm9aaTlSUTJzNFFVbElhSEJJVWdvMVREUnhjVWhKTjNSMWJUZHNNM1JEVDNOMEwxWnFkVWMyUjJoaFdrOTFUVk5xT0dOdFkzQkJlVE41YVVoSU5VNWhRV0V4ZWxabFRWRTJTVEpZS3k5VENuTkJlRE0yV1hWT2EyaFhSWEIyYkZFMFFsb3pWMjV0YXpKWWRuRnRObUZZVWtwamNtUXlZM0JQYmxsMmEyaFRXWFpSTldoVGEycFllSGREVldkMGVVVUthVVY2VVRSQ1RGb3JhbWhrUW01Mk4zUkpNakJZVmt4a05VcHhjRWwwTWtGMFEwTXZNVFZwZFVSeU9HbG5XRXRxVkdwWlRGVlFlbkJXWVhKQmJWUnBiZ3BQZVdkTFVFOU1ZWEJDYUZaV2NIZENhM0ZyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIZFdwMVNXaE5RMkU0T1hWMFJTdEJVelJwYkdabE9HeFdabU5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFU1RoalpUUjRZMkYxTnpCTlpsWlBUMjVyVFdwb1pEQjZRMEZwZEVoT1JVczROalpCWVVkWlZHZHFhMEpMYjBkdlVBcGxaMlpUZFRKRFp6TndUbkZaVUhsMVJVZDVUWFFyVUhGQk1tcElSbmd2UmpadGMyY3hVR3hJSzFCcU1FdG1RbWhOWmxSWVZpdHFVRlk1TW5kQ0szUktDbHBqVm5GQmVHeFVielJDVlRsRlJHUlNiV2sxY1doWmVrdDNaa0pYTVRjMWNrMHdaVUp3WTFRelUyaDBiR3BaZEZwUGFGbHhSVUpIUWtad1FtaERNR3dLS3pBNFdFMXdUWFEwWjJSaFNEVnRhMVZhYWk5RmNXWlpiWEF5VmtReVdVbEtaRGxHTlhwV2MwZDFSbkF2ZDBGbU1qVkVkbTVQUW1Ka1JFTlZWSFJGVFFwVFNHRlNhek40WnpKcmMzQnlkMkZtVERaTUx6bHpXa1k1YjFGRlNIWkdOSEJzZHpWU2NFSTVaRmRYWWl0a1oxUkVTVGxMTkM5YWVsQXZiMUJEZDFoVENsbE5kbE15ZDBSYVVFUk1aR2RhTUV4WWNFczBhV2tyWTJrdmFrOHhVREJWU25Gallnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hZmQyNmUzZC1jNzExLTQ4NWUtYTk0NS01NjNmNmYyZTM0NWYuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBNQ2psTkxEc09sOWpZYW1SNVA5R2F3eExPZ1lGVXpLbHloazI4MjltSmx0UjlIbEphdzVDNXBkOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2906,7 +2873,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:53 GMT
+      - Mon, 13 Nov 2023 14:06:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2916,7 +2883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2ffc8fa-e19f-4e75-8a47-3665422fe272
+      - 022c7fae-a760-4c6b-abb6-c3deb3f8e8f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2927,10 +2894,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.227313101Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:32.170723854Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -2939,7 +2906,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:54 GMT
+      - Mon, 13 Nov 2023 14:06:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2949,7 +2916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1681a94-7923-4b4e-9a7c-1de80ab4bedf
+      - d545c1c7-7b85-4ede-b817-7ea0f2262b8a
     status: 200 OK
     code: 200
     duration: ""
@@ -2960,10 +2927,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.227313Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:32.170724Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1504"
@@ -2972,7 +2939,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:54 GMT
+      - Mon, 13 Nov 2023 14:06:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2982,7 +2949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf10dd22-c4eb-4312-8cc5-5ef346d41ab9
+      - ec268043-0ebf-4ff6-a6d5-0c7a8632352d
     status: 200 OK
     code: 200
     duration: ""
@@ -2993,10 +2960,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.227313Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://afd26e3d-c711-485e-a945-563f6f2e345f.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:05:41.198874Z","created_at":"2023-11-13T14:05:41.198874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.afd26e3d-c711-485e-a945-563f6f2e345f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"afd26e3d-c711-485e-a945-563f6f2e345f","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-13T14:06:32.170724Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1504"
@@ -3005,7 +2972,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:59 GMT
+      - Mon, 13 Nov 2023 14:06:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3015,7 +2982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9faeb5d-40dd-4748-ae48-771613e626b2
+      - 5c3ff934-0819-4dc0-aba8-426a96133cd8
     status: 200 OK
     code: 200
     duration: ""
@@ -3026,43 +2993,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://530d6423-2bae-4683-978d-8967007944fc.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:23:01.506227Z","created_at":"2023-11-10T13:23:01.506227Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.530d6423-2bae-4683-978d-8967007944fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"530d6423-2bae-4683-978d-8967007944fc","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.227313Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1504"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:24:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19c84935-eb81-497d-abb0-2527fa63c86d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"530d6423-2bae-4683-978d-8967007944fc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"afd26e3d-c711-485e-a945-563f6f2e345f","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3071,7 +3005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:09 GMT
+      - Mon, 13 Nov 2023 14:06:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3081,7 +3015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cafab20-7fb7-4ec6-8d66-4fac363fc5f9
+      - 9d87d4e9-9d3c-4f7a-a2ce-97d6f410932e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3092,10 +3026,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3104,7 +3038,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:09 GMT
+      - Mon, 13 Nov 2023 14:06:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3114,7 +3048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7261c0d-860f-489d-a358-ca6b5c54f21c
+      - 03c922b5-b692-4960-b3f3-c96ef9625dc4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3125,43 +3059,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/afd26e3d-c711-485e-a945-563f6f2e345f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3a9550cf-a2cf-4b5f-9434-bd0bc7b94f5c","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:24:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be425169-c068-4e7c-87f0-523d012f3d28
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/530d6423-2bae-4683-978d-8967007944fc
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"530d6423-2bae-4683-978d-8967007944fc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"afd26e3d-c711-485e-a945-563f6f2e345f","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3170,7 +3071,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:09 GMT
+      - Mon, 13 Nov 2023 14:06:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3180,7 +3081,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95ecfeff-fe67-4660-be57-0a6db16dc8a0
+      - c316b6db-d8a9-4965-94ea-1d38fb61090e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/002d77e6-63ab-4b8e-a4e5-87e0605dfbad
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"002d77e6-63ab-4b8e-a4e5-87e0605dfbad","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4cfe0ccc-b906-4f4d-a14f-f1da1f8820b6
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-autoscaling.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-autoscaling.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf963749-9261-4a77-aabf-d464b8de8ce2
+      - 8efe81c2-922c-4d0d-82e5-edb2f50fe081
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:51:12.824411Z","dhcp_enabled":true,"id":"c4ca902e-f3d1-4dff-826c-9f983b165319","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:51:12.824411Z","id":"12546c9a-0001-4298-afd9-20b1f2815cf7","subnet":"172.16.8.0/22","updated_at":"2023-11-13T13:51:12.824411Z"},{"created_at":"2023-11-13T13:51:12.824411Z","id":"c6526c83-49ad-4382-9b1a-988cdcde55bc","subnet":"fd68:d440:21c4:8e29::/64","updated_at":"2023-11-13T13:51:12.824411Z"}],"tags":[],"updated_at":"2023-11-13T13:51:12.824411Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "715"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:57 GMT
+      - Mon, 13 Nov 2023 13:51:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea2d3e0e-dc6a-4c06-b2df-19f1d65cdba2
+      - 891902c9-6cb2-4187-b187-e5374dd40338
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c4ca902e-f3d1-4dff-826c-9f983b165319
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:51:12.824411Z","dhcp_enabled":true,"id":"c4ca902e-f3d1-4dff-826c-9f983b165319","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:51:12.824411Z","id":"12546c9a-0001-4298-afd9-20b1f2815cf7","subnet":"172.16.8.0/22","updated_at":"2023-11-13T13:51:12.824411Z"},{"created_at":"2023-11-13T13:51:12.824411Z","id":"c6526c83-49ad-4382-9b1a-988cdcde55bc","subnet":"fd68:d440:21c4:8e29::/64","updated_at":"2023-11-13T13:51:12.824411Z"}],"tags":[],"updated_at":"2023-11-13T13:51:12.824411Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "715"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6548859-3b89-4ccb-a814-2046284d3718
+      - 3bc1a925-0770-40cc-a783-20b87cd3ee19
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-autoscaler-01","description":"","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-autoscaler-01","description":"","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452737578Z","created_at":"2023-11-10T13:16:58.452737578Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.470605368Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671492Z","created_at":"2023-11-13T13:51:18.000671492Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.017176129Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1525"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ea28460-5b7c-423e-a134-5a67738f2ed0
+      - 16d8d131-2e3e-422c-9f6f-3ac6e08caceb
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.470605Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.017176Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae7e876e-60c7-41fb-876c-067dfb1cf3ad
+      - e643e3f6-3001-478d-a231-26d8b20b8568
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:19.761117Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ccef75-5cac-45ac-bd7b-9608e8e8b6b1
+      - bc3c433b-1294-4a24-9ba8-942c5a2ac183
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:19.761117Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecd5d316-ab38-4a43-8e67-043146ed6bfa
+      - 1cd8d1d5-c15d-4844-81af-7f3d291c8e97
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGg2Q2k5YUwyWnZVRnBtYnpreE1EWk1XRWN5YTNkMFpFRlJSbTR2Wm1FdllYUXhkbmxXUmxndmMyMVVVakJYTkZsYVJtaEpSMmszSzI1TFZWSkpkMHRDVEVrS2NHaFNabGRxVUhOS00wTmFRVXhWTVRRd2RUTmlTblowYUROVVdYWm9UV1ZWVEhoWWVsRkVjMU5UZURad1UwRXhVRGgxZG1VMU1uTTJOWHBpZGxWWmJ3cGpjVlUyTldkQlUzZHRXbnAwUlhweVEwcGFSamxVY0dKVWFHRnVMMWxJUW5wbVJsWlBZemxFTURKamRYVk9SRk5QZG1WWlJrMU1SWGRoUm05blpuUmhDbXBzU1VkUk9WWk5lR1FyVFhoVlNITlFVM05KVDA5bVFrZHRSMFF3ZFVRdmRURklablZ6VEUxNVpsbFBVRXN3UWpCRFpXWnpXa3RtY3pSMlNFZENSbGtLUWtKb1dtSm1halZJYmpCMVpuTmpiMkY1VGtaMFVEQnRORFpsWkVkdFVWZ3daRWhpYkRkR1FuRXpjWGhIYVVRemRFUktTVUZKVDJvd1NEWjJlbTgyZHdwSFdUTkROVzFpYVhWVFQzaE9LM05pTVcxalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVVWQmxkSFF4WkZJeWRVNVJaRkpqV0VKUVltRkdRMjlDTVd4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05YRllRM0pUUm1aS09FWlNNV2RITUhOdFMxaEdRVzVsWlRsQ1IyMUlPR2hMYlVKTlozcGxXVXQ0VGpod2NqSlpUUXB3UkZCTGJGRnVWMHBFY1hCVWIyOUJUSGRhVWxWYVVVUXpVVVY2TTBKSEwxUkNhV0pVUzJOQlRtTm5LMFJ3YnpOQ1FrTlVlazFGV2t4a2JFbFBlVlpyQ21wSlVGZHNTREZuWWxGVGJVRnpjVE14VUhGTE5sTk1ZbVJyYm5WaE5URnNMM1pzZG14a1JIRnVNMms0UkhJMlN6SXpNbVZGVVZSM01GRkxabUZSUVdJS2J6a3hkSHB0YUZjeFNXY3dLMmRKWjJWNVpUbGhkVEpIYkdJMVpHWTFhams0VUM4d1pXZDZXRmx4VG5kb1NXb3JWeTlJVVZBd1UwUnJhWEJ5WVZSTVdncGhTaXRoVFRKMU1VOW5hVXhCZDFoaVFWRkNOVTlNUkRkT2MxcDFWbEpRZFV0Slp6UnRUak5GY2l0NVVqUmpiREpuTjJORlpEaFlhVkYzUmpSUFlVOW9DbEZSWmxndlJHRjJNRzlxUVVoMFNsZFRkVlJ0VkV3M05uQllhMmRKYjJGdlpYVnNaZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTBiZDM5NWQtOTY0OC00N2I4LWE5N2EtYTA3ZTNjOThkZjBkLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHamhFbDB0MGV3VzFxTHJBSTZZNWVEcXIyRFJlTlE4cmJ1ZE5nbFJrWFkzUXhGMlBhRHhYaVZmWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85a54af3-e432-4803-9ace-6c359f09fb24
+      - 5087b192-9e85-4249-9a1a-57be194d9eee
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:19.761117Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2d9b8ce-1b46-4786-b13d-15af850b927b
+      - ecb3de0f-bf6c-465d-bb82-cc8bf683b3ea
     status: 200 OK
     code: 200
     duration: ""
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c4ca902e-f3d1-4dff-826c-9f983b165319
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:51:12.824411Z","dhcp_enabled":true,"id":"c4ca902e-f3d1-4dff-826c-9f983b165319","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:51:12.824411Z","id":"12546c9a-0001-4298-afd9-20b1f2815cf7","subnet":"172.16.8.0/22","updated_at":"2023-11-13T13:51:12.824411Z"},{"created_at":"2023-11-13T13:51:12.824411Z","id":"c6526c83-49ad-4382-9b1a-988cdcde55bc","subnet":"fd68:d440:21c4:8e29::/64","updated_at":"2023-11-13T13:51:12.824411Z"}],"tags":[],"updated_at":"2023-11-13T13:51:12.824411Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "715"
@@ -325,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45592fd3-b43a-41a6-9eeb-394f17e05c4d
+      - 770ef970-6913-4aea-b72c-1c07832ceb69
     status: 200 OK
     code: 200
     duration: ""
@@ -346,10 +346,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:19.761117Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -358,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf2930ac-0112-4b41-a4f7-4874ffb1d22b
+      - fef53508-50b8-42da-ab20-6f00c0ff79e4
     status: 200 OK
     code: 200
     duration: ""
@@ -379,10 +379,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGg2Q2k5YUwyWnZVRnBtYnpreE1EWk1XRWN5YTNkMFpFRlJSbTR2Wm1FdllYUXhkbmxXUmxndmMyMVVVakJYTkZsYVJtaEpSMmszSzI1TFZWSkpkMHRDVEVrS2NHaFNabGRxVUhOS00wTmFRVXhWTVRRd2RUTmlTblowYUROVVdYWm9UV1ZWVEhoWWVsRkVjMU5UZURad1UwRXhVRGgxZG1VMU1uTTJOWHBpZGxWWmJ3cGpjVlUyTldkQlUzZHRXbnAwUlhweVEwcGFSamxVY0dKVWFHRnVMMWxJUW5wbVJsWlBZemxFTURKamRYVk9SRk5QZG1WWlJrMU1SWGRoUm05blpuUmhDbXBzU1VkUk9WWk5lR1FyVFhoVlNITlFVM05KVDA5bVFrZHRSMFF3ZFVRdmRURklablZ6VEUxNVpsbFBVRXN3UWpCRFpXWnpXa3RtY3pSMlNFZENSbGtLUWtKb1dtSm1halZJYmpCMVpuTmpiMkY1VGtaMFVEQnRORFpsWkVkdFVWZ3daRWhpYkRkR1FuRXpjWGhIYVVRemRFUktTVUZKVDJvd1NEWjJlbTgyZHdwSFdUTkROVzFpYVhWVFQzaE9LM05pTVcxalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVVWQmxkSFF4WkZJeWRVNVJaRkpqV0VKUVltRkdRMjlDTVd4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05YRllRM0pUUm1aS09FWlNNV2RITUhOdFMxaEdRVzVsWlRsQ1IyMUlPR2hMYlVKTlozcGxXVXQ0VGpod2NqSlpUUXB3UkZCTGJGRnVWMHBFY1hCVWIyOUJUSGRhVWxWYVVVUXpVVVY2TTBKSEwxUkNhV0pVUzJOQlRtTm5LMFJ3YnpOQ1FrTlVlazFGV2t4a2JFbFBlVlpyQ21wSlVGZHNTREZuWWxGVGJVRnpjVE14VUhGTE5sTk1ZbVJyYm5WaE5URnNMM1pzZG14a1JIRnVNMms0UkhJMlN6SXpNbVZGVVZSM01GRkxabUZSUVdJS2J6a3hkSHB0YUZjeFNXY3dLMmRKWjJWNVpUbGhkVEpIYkdJMVpHWTFhams0VUM4d1pXZDZXRmx4VG5kb1NXb3JWeTlJVVZBd1UwUnJhWEJ5WVZSTVdncGhTaXRoVFRKMU1VOW5hVXhCZDFoaVFWRkNOVTlNUkRkT2MxcDFWbEpRZFV0Slp6UnRUak5GY2l0NVVqUmpiREpuTjJORlpEaFlhVkYzUmpSUFlVOW9DbEZSWmxndlJHRjJNRzlxUVVoMFNsZFRkVlJ0VkV3M05uQllhMmRKYjJGdlpYVnNaZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTBiZDM5NWQtOTY0OC00N2I4LWE5N2EtYTA3ZTNjOThkZjBkLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHamhFbDB0MGV3VzFxTHJBSTZZNWVEcXIyRFJlTlE4cmJ1ZE5nbFJrWFkzUXhGMlBhRHhYaVZmWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -391,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa530d69-9426-4b38-ada2-fda9eddd1bf6
+      - 962946b2-4e55-4c9e-b9e1-7644afaadc23
     status: 200 OK
     code: 200
     duration: ""
@@ -412,10 +412,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c4ca902e-f3d1-4dff-826c-9f983b165319
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:51:12.824411Z","dhcp_enabled":true,"id":"c4ca902e-f3d1-4dff-826c-9f983b165319","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:51:12.824411Z","id":"12546c9a-0001-4298-afd9-20b1f2815cf7","subnet":"172.16.8.0/22","updated_at":"2023-11-13T13:51:12.824411Z"},{"created_at":"2023-11-13T13:51:12.824411Z","id":"c6526c83-49ad-4382-9b1a-988cdcde55bc","subnet":"fd68:d440:21c4:8e29::/64","updated_at":"2023-11-13T13:51:12.824411Z"}],"tags":[],"updated_at":"2023-11-13T13:51:12.824411Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "715"
@@ -424,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5672194b-a60b-4a77-835f-620ffaab755e
+      - fecff8cb-5f32-4e72-982e-edeb036f0b60
     status: 200 OK
     code: 200
     duration: ""
@@ -445,10 +445,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.044379Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:19.761117Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -457,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ed4c07c-4a54-4493-b455-bc38aaca768c
+      - 7341a4e7-d1ca-4cba-a34b-3d6a93b3022b
     status: 200 OK
     code: 200
     duration: ""
@@ -478,10 +478,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGg2Q2k5YUwyWnZVRnBtYnpreE1EWk1XRWN5YTNkMFpFRlJSbTR2Wm1FdllYUXhkbmxXUmxndmMyMVVVakJYTkZsYVJtaEpSMmszSzI1TFZWSkpkMHRDVEVrS2NHaFNabGRxVUhOS00wTmFRVXhWTVRRd2RUTmlTblowYUROVVdYWm9UV1ZWVEhoWWVsRkVjMU5UZURad1UwRXhVRGgxZG1VMU1uTTJOWHBpZGxWWmJ3cGpjVlUyTldkQlUzZHRXbnAwUlhweVEwcGFSamxVY0dKVWFHRnVMMWxJUW5wbVJsWlBZemxFTURKamRYVk9SRk5QZG1WWlJrMU1SWGRoUm05blpuUmhDbXBzU1VkUk9WWk5lR1FyVFhoVlNITlFVM05KVDA5bVFrZHRSMFF3ZFVRdmRURklablZ6VEUxNVpsbFBVRXN3UWpCRFpXWnpXa3RtY3pSMlNFZENSbGtLUWtKb1dtSm1halZJYmpCMVpuTmpiMkY1VGtaMFVEQnRORFpsWkVkdFVWZ3daRWhpYkRkR1FuRXpjWGhIYVVRemRFUktTVUZKVDJvd1NEWjJlbTgyZHdwSFdUTkROVzFpYVhWVFQzaE9LM05pTVcxalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVVWQmxkSFF4WkZJeWRVNVJaRkpqV0VKUVltRkdRMjlDTVd4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05YRllRM0pUUm1aS09FWlNNV2RITUhOdFMxaEdRVzVsWlRsQ1IyMUlPR2hMYlVKTlozcGxXVXQ0VGpod2NqSlpUUXB3UkZCTGJGRnVWMHBFY1hCVWIyOUJUSGRhVWxWYVVVUXpVVVY2TTBKSEwxUkNhV0pVUzJOQlRtTm5LMFJ3YnpOQ1FrTlVlazFGV2t4a2JFbFBlVlpyQ21wSlVGZHNTREZuWWxGVGJVRnpjVE14VUhGTE5sTk1ZbVJyYm5WaE5URnNMM1pzZG14a1JIRnVNMms0UkhJMlN6SXpNbVZGVVZSM01GRkxabUZSUVdJS2J6a3hkSHB0YUZjeFNXY3dLMmRKWjJWNVpUbGhkVEpIYkdJMVpHWTFhams0VUM4d1pXZDZXRmx4VG5kb1NXb3JWeTlJVVZBd1UwUnJhWEJ5WVZSTVdncGhTaXRoVFRKMU1VOW5hVXhCZDFoaVFWRkNOVTlNUkRkT2MxcDFWbEpRZFV0Slp6UnRUak5GY2l0NVVqUmpiREpuTjJORlpEaFlhVkYzUmpSUFlVOW9DbEZSWmxndlJHRjJNRzlxUVVoMFNsZFRkVlJ0VkV3M05uQllhMmRKYjJGdlpYVnNaZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTBiZDM5NWQtOTY0OC00N2I4LWE5N2EtYTA3ZTNjOThkZjBkLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHamhFbDB0MGV3VzFxTHJBSTZZNWVEcXIyRFJlTlE4cmJ1ZE5nbFJrWFkzUXhGMlBhRHhYaVZmWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -490,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ee01d90-87f4-4384-932a-8dd39019bc1a
+      - ee33e4e0-fa0a-49ab-9d0b-52ce28826400
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.261446827Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:25.420417541Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1520"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 093695d3-af6d-4e2f-a1da-581dc608d87b
+      - cf77cb86-8031-48ba-8cc7-07362993edf8
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.261447Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:25.420418Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1517"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54f91a08-21bd-4885-9dd7-d45b6cb910a3
+      - e459ef19-fb63-4aa5-a50c-dcbd331325ae
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.449571Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:26.584746Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1522"
@@ -591,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:51:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc099447-7b77-4924-ad90-ca33f413e3c4
+      - 4e291587-b7a8-435c-a014-b4cd25dd44ba
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.449571Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:26.584746Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1522"
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:51:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6ce6c61-dfe5-453e-ac63-88b501f30c7b
+      - 52e0d358-a8c6-42b7-85a5-602589b5bbd4
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGg2Q2k5YUwyWnZVRnBtYnpreE1EWk1XRWN5YTNkMFpFRlJSbTR2Wm1FdllYUXhkbmxXUmxndmMyMVVVakJYTkZsYVJtaEpSMmszSzI1TFZWSkpkMHRDVEVrS2NHaFNabGRxVUhOS00wTmFRVXhWTVRRd2RUTmlTblowYUROVVdYWm9UV1ZWVEhoWWVsRkVjMU5UZURad1UwRXhVRGgxZG1VMU1uTTJOWHBpZGxWWmJ3cGpjVlUyTldkQlUzZHRXbnAwUlhweVEwcGFSamxVY0dKVWFHRnVMMWxJUW5wbVJsWlBZemxFTURKamRYVk9SRk5QZG1WWlJrMU1SWGRoUm05blpuUmhDbXBzU1VkUk9WWk5lR1FyVFhoVlNITlFVM05KVDA5bVFrZHRSMFF3ZFVRdmRURklablZ6VEUxNVpsbFBVRXN3UWpCRFpXWnpXa3RtY3pSMlNFZENSbGtLUWtKb1dtSm1halZJYmpCMVpuTmpiMkY1VGtaMFVEQnRORFpsWkVkdFVWZ3daRWhpYkRkR1FuRXpjWGhIYVVRemRFUktTVUZKVDJvd1NEWjJlbTgyZHdwSFdUTkROVzFpYVhWVFQzaE9LM05pTVcxalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVVWQmxkSFF4WkZJeWRVNVJaRkpqV0VKUVltRkdRMjlDTVd4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05YRllRM0pUUm1aS09FWlNNV2RITUhOdFMxaEdRVzVsWlRsQ1IyMUlPR2hMYlVKTlozcGxXVXQ0VGpod2NqSlpUUXB3UkZCTGJGRnVWMHBFY1hCVWIyOUJUSGRhVWxWYVVVUXpVVVY2TTBKSEwxUkNhV0pVUzJOQlRtTm5LMFJ3YnpOQ1FrTlVlazFGV2t4a2JFbFBlVlpyQ21wSlVGZHNTREZuWWxGVGJVRnpjVE14VUhGTE5sTk1ZbVJyYm5WaE5URnNMM1pzZG14a1JIRnVNMms0UkhJMlN6SXpNbVZGVVZSM01GRkxabUZSUVdJS2J6a3hkSHB0YUZjeFNXY3dLMmRKWjJWNVpUbGhkVEpIYkdJMVpHWTFhams0VUM4d1pXZDZXRmx4VG5kb1NXb3JWeTlJVVZBd1UwUnJhWEJ5WVZSTVdncGhTaXRoVFRKMU1VOW5hVXhCZDFoaVFWRkNOVTlNUkRkT2MxcDFWbEpRZFV0Slp6UnRUak5GY2l0NVVqUmpiREpuTjJORlpEaFlhVkYzUmpSUFlVOW9DbEZSWmxndlJHRjJNRzlxUVVoMFNsZFRkVlJ0VkV3M05uQllhMmRKYjJGdlpYVnNaZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTBiZDM5NWQtOTY0OC00N2I4LWE5N2EtYTA3ZTNjOThkZjBkLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHamhFbDB0MGV3VzFxTHJBSTZZNWVEcXIyRFJlTlE4cmJ1ZE5nbFJrWFkzUXhGMlBhRHhYaVZmWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:51:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61755195-4035-4472-923e-b98f5facdb55
+      - 7001b986-5fe1-4c5d-a413-946c0d865f2f
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.449571Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:26.584746Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1522"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:51:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55b2a88d-a5b6-4601-9b2f-c09471ac3908
+      - 7a57d5ff-5117-4c0e-9b12-32056565721b
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c4ca902e-f3d1-4dff-826c-9f983b165319
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.362053Z","dhcp_enabled":true,"id":"3c161a30-867c-4716-836a-fa5bc167c926","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:16:56.362053Z","id":"0cb92c47-d431-48b1-9bdd-ffd856d95b48","subnet":"172.16.8.0/22","updated_at":"2023-11-10T13:16:56.362053Z"},{"created_at":"2023-11-10T13:16:56.362053Z","id":"d3b2df3a-cc2b-4afc-a009-bcf30b33d362","subnet":"fd68:d440:21c4:264e::/64","updated_at":"2023-11-10T13:16:56.362053Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.362053Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:51:12.824411Z","dhcp_enabled":true,"id":"c4ca902e-f3d1-4dff-826c-9f983b165319","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:51:12.824411Z","id":"12546c9a-0001-4298-afd9-20b1f2815cf7","subnet":"172.16.8.0/22","updated_at":"2023-11-13T13:51:12.824411Z"},{"created_at":"2023-11-13T13:51:12.824411Z","id":"c6526c83-49ad-4382-9b1a-988cdcde55bc","subnet":"fd68:d440:21c4:8e29::/64","updated_at":"2023-11-13T13:51:12.824411Z"}],"tags":[],"updated_at":"2023-11-13T13:51:12.824411Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "715"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:12 GMT
+      - Mon, 13 Nov 2023 13:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 730d1a6c-b4fa-42f2-9774-95127c8c712c
+      - 99dab88e-b0b5-4b76-a138-98186616975f
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.449571Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:26.584746Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1522"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:12 GMT
+      - Mon, 13 Nov 2023 13:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c211d7ee-0be9-4935-a814-cfc61373c4b4
+      - 3013705d-875c-4361-ae2b-1c267340f8ae
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURk4yQ21rMmFqVkVValpTVTJ0elkyeFFXbGxrV0ZKNlpuWnhTMjVqVmt3elRtMUNaMGM1UTB4YVFUTnFRbEJPZDJkSlRUTnJZMHBpV1RKSFR6RmFWMkpKYTBJS1dpOWhRWGQ2VFVzeGR6bDZkbGw1ZGtaR2VsRkhPRWxrU1VsSmFWQmFSV3RDTkdGNmVtdG1SRWRvTUhCaGJFaFZNRVJwTjI0MFRrVjRWRTVDSzJsMU1Rb3hjV3hqWW1ONGJHRndjMWh2YjJaT2MyTlNNMDlHVG01MlpHdG5RV2d3U3pkUWNDOXhVbkJwWldFM2JtcHlWV2N6UVU1cldHbDFiVmR1V1VwV1pYZHpDa2M1VkZwdVYwdFZkMFpKYUV0MmRVZDBWbkZ0T0VSbVJHdEdWVEJaTVVGUE1FMUtjVVF2VEVnMlZsbzJlbVIyVG14WlpWWlBWMWN3VGpBM05UaEdXalFLT1RWVFVYSjRRV3QxTjBnemFpOHZUVVUyV0ZkWFFWaGxWVXRCUldWeWRubDJkMWhpYVd4TEsxbzFNVGx6VjNSemRFWXpTM2sxWkZFemRtWkxhMGxTZFFwbVozVmpNR2h5VEdRd1ZIQTNWMDl6WnpoRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSFZYTkVPSGRZVHpOWU5rOHZTMGcwVEhrMU1ITXJhR3BFUnk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk1XNDVWVVZSWXpWT1FrOUdTVkowYzNwcmNtVk5jMlpMV1M5TU5IRllTRXAwTHpodEszcEpSRzE0YkVWMVR5OVpUd3BsZWtwRVZWcEtRa2xGUkhJeVJ6VnJVMUZxZDJGTGFWUjBjblZrTVdveFFqTkRTbGxLYnpnMVpuRmplRUk1V2twcGNqUm5jREExYmxWb1QwUkxaamxtQ25vME4zZDZXakpOUkc5NWRYUkJlVGczVjJSNGFsRjFTMmRpYzJSNlQwRjZZemhZTUVweFlrZzRhVXQ2TVRWVGQxcENiM05uZEhNNFdYZzBWekkxY1dzS1ZFdHpkVnBrZW5CRFZGWkpRemxhVEVaa1lVMUNNVkJ5UzNSRU0xaDJWWFJKUkRKYUwzVmljRVpDVW10MldHUnBaWEl4TmxaVk5HdEVXamhLVG1GWGFRcG5MMHQyY0hCU2VqbHlRekkwZWtkQk0yRktiVzFaTjNaVWFVZzFZMUJHT1dnd2NVSTVTVmcyVnpoVk5XVkNlRGhtU2xONmVGQkZPVVZNZGpGRVYySm1DamhhVUVrdlExTldZa2RKVFhSc2NtbDNRV0ZoZUZwVGRVUkdNV1pETVhReEt6TlpkQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRlZTczMWMtNDhlYS00YzMzLTkyNDYtNTAxOTM2MzIyY2Y4LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBUcGk3MUdWUmphQmNoOGNscTdRNVpaTlhsS1lRcEpvdnI5NVB6eVZXVWNHQXZ6Zkh5MEs3U0NaNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY0VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMGg2Q2k5YUwyWnZVRnBtYnpreE1EWk1XRWN5YTNkMFpFRlJSbTR2Wm1FdllYUXhkbmxXUmxndmMyMVVVakJYTkZsYVJtaEpSMmszSzI1TFZWSkpkMHRDVEVrS2NHaFNabGRxVUhOS00wTmFRVXhWTVRRd2RUTmlTblowYUROVVdYWm9UV1ZWVEhoWWVsRkVjMU5UZURad1UwRXhVRGgxZG1VMU1uTTJOWHBpZGxWWmJ3cGpjVlUyTldkQlUzZHRXbnAwUlhweVEwcGFSamxVY0dKVWFHRnVMMWxJUW5wbVJsWlBZemxFTURKamRYVk9SRk5QZG1WWlJrMU1SWGRoUm05blpuUmhDbXBzU1VkUk9WWk5lR1FyVFhoVlNITlFVM05KVDA5bVFrZHRSMFF3ZFVRdmRURklablZ6VEUxNVpsbFBVRXN3UWpCRFpXWnpXa3RtY3pSMlNFZENSbGtLUWtKb1dtSm1halZJYmpCMVpuTmpiMkY1VGtaMFVEQnRORFpsWkVkdFVWZ3daRWhpYkRkR1FuRXpjWGhIYVVRemRFUktTVUZKVDJvd1NEWjJlbTgyZHdwSFdUTkROVzFpYVhWVFQzaE9LM05pTVcxalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSVVWQmxkSFF4WkZJeWRVNVJaRkpqV0VKUVltRkdRMjlDTVd4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05YRllRM0pUUm1aS09FWlNNV2RITUhOdFMxaEdRVzVsWlRsQ1IyMUlPR2hMYlVKTlozcGxXVXQ0VGpod2NqSlpUUXB3UkZCTGJGRnVWMHBFY1hCVWIyOUJUSGRhVWxWYVVVUXpVVVY2TTBKSEwxUkNhV0pVUzJOQlRtTm5LMFJ3YnpOQ1FrTlVlazFGV2t4a2JFbFBlVlpyQ21wSlVGZHNTREZuWWxGVGJVRnpjVE14VUhGTE5sTk1ZbVJyYm5WaE5URnNMM1pzZG14a1JIRnVNMms0UkhJMlN6SXpNbVZGVVZSM01GRkxabUZSUVdJS2J6a3hkSHB0YUZjeFNXY3dLMmRKWjJWNVpUbGhkVEpIYkdJMVpHWTFhams0VUM4d1pXZDZXRmx4VG5kb1NXb3JWeTlJVVZBd1UwUnJhWEJ5WVZSTVdncGhTaXRoVFRKMU1VOW5hVXhCZDFoaVFWRkNOVTlNUkRkT2MxcDFWbEpRZFV0Slp6UnRUak5GY2l0NVVqUmpiREpuTjJORlpEaFlhVkYzUmpSUFlVOW9DbEZSWmxndlJHRjJNRzlxUVVoMFNsZFRkVlJ0VkV3M05uQllhMmRKYjJGdlpYVnNaZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTBiZDM5NWQtOTY0OC00N2I4LWE5N2EtYTA3ZTNjOThkZjBkLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHamhFbDB0MGV3VzFxTHJBSTZZNWVEcXIyRFJlTlE4cmJ1ZE5nbFJrWFkzUXhGMlBhRHhYaVZmWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:12 GMT
+      - Mon, 13 Nov 2023 13:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2a42eb5-0f03-4777-98c1-99d9473d6e5e
+      - 26c1135f-5e42-4f0b-9b9a-13552f732479
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.863077563Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:32.064753161Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1520"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:12 GMT
+      - Mon, 13 Nov 2023 13:51:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe042439-f5fb-4800-b616-9f57f8b6d459
+      - 7c777bcf-149c-413c-8a2d-98a112f1ece5
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.863078Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:32.064753Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1517"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:13 GMT
+      - Mon, 13 Nov 2023 13:51:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ac2c4eb-af87-455a-8f36-2ef66273e052
+      - f2e4bc89-40cc-487d-b3b9-fa7fcc5acf11
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://54ee731c-48ea-4c33-9246-501936322cf8.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.452738Z","created_at":"2023-11-10T13:16:58.452738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54ee731c-48ea-4c33-9246-501936322cf8.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"54ee731c-48ea-4c33-9246-501936322cf8","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"3c161a30-867c-4716-836a-fa5bc167c926","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.863078Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://50bd395d-9648-47b8-a97a-a07e3c98df0d.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.000671Z","created_at":"2023-11-13T13:51:18.000671Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50bd395d-9648-47b8-a97a-a07e3c98df0d.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-13T13:51:32.064753Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1517"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:18 GMT
+      - Mon, 13 Nov 2023 13:51:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f7046d6-f9db-4d5f-93cc-27e47532ad99
+      - ddbe49d7-4b9d-46d4-80d8-4a14f4d0ae0f
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"54ee731c-48ea-4c33-9246-501936322cf8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:23 GMT
+      - Mon, 13 Nov 2023 13:51:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8077108b-ef26-4f5b-90db-b2f5f11a488c
+      - 9e8c9e39-4e85-4bec-8972-3e8ded70ad1a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c4ca902e-f3d1-4dff-826c-9f983b165319
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3c161a30-867c-4716-836a-fa5bc167c926","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:23 GMT
+      - Mon, 13 Nov 2023 13:51:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4988f9b7-494f-4fc3-b281-f8af66f37ebe
+      - 22e7833b-8be2-4d1b-bd23-13f68610ccb0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -975,43 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3c161a30-867c-4716-836a-fa5bc167c926
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/50bd395d-9648-47b8-a97a-a07e3c98df0d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"3c161a30-867c-4716-836a-fa5bc167c926","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2ad1a4dc-f755-4461-9610-abab411f307e
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/54ee731c-48ea-4c33-9246-501936322cf8
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"54ee731c-48ea-4c33-9246-501936322cf8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"50bd395d-9648-47b8-a97a-a07e3c98df0d","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1020,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:23 GMT
+      - Mon, 13 Nov 2023 13:51:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +997,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a16e260-661e-4e0d-9566-ce2ada9151cc
+      - 72d1b730-8269-4ef2-bedd-2f25794ca710
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c4ca902e-f3d1-4dff-826c-9f983b165319
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"c4ca902e-f3d1-4dff-826c-9f983b165319","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:51:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae41040b-35f8-420c-9c40-4b7ba2fbf4b9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-basic.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c63ba6c6-5948-4995-8d3f-810c6703c4e4
+      - f460e344-1114-4fef-8301-325acb6053c5
     status: 200 OK
     code: 200
     duration: ""
@@ -61,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f92e699-690e-46dd-8201-858065c84f14
+      - 047c0833-b2dc-4c92-9669-96e9aa5b83d7
     status: 200 OK
     code: 200
     duration: ""
@@ -87,16 +87,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:43.091315Z","dhcp_enabled":true,"id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:43.091315Z","id":"6d4afa64-9bed-4210-a3b5-dcdae6503771","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:51:43.091315Z"},{"created_at":"2023-11-13T13:51:43.091315Z","id":"c95f05e0-b838-4fe3-820a-d79ce0fe9c25","subnet":"fd63:256c:45f7:c40b::/64","updated_at":"2023-11-13T13:51:43.091315Z"}],"tags":[],"updated_at":"2023-11-13T13:51:43.091315Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "712"
+      - "713"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -106,7 +106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 278a3af8-96ed-425b-aa91-dfa4eb0528dd
+      - 94ad51ed-6593-471f-8541-4d18c16f9809
     status: 200 OK
     code: 200
     duration: ""
@@ -117,19 +117,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ffba1c99-4cf3-4a48-9cf2-82769bb9a988
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:43.091315Z","dhcp_enabled":true,"id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:43.091315Z","id":"6d4afa64-9bed-4210-a3b5-dcdae6503771","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:51:43.091315Z"},{"created_at":"2023-11-13T13:51:43.091315Z","id":"c95f05e0-b838-4fe3-820a-d79ce0fe9c25","subnet":"fd63:256c:45f7:c40b::/64","updated_at":"2023-11-13T13:51:43.091315Z"}],"tags":[],"updated_at":"2023-11-13T13:51:43.091315Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "712"
+      - "713"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,12 +139,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f2f3e21-1929-4c00-b39d-f457a84c6379
+      - a67d5b53-24ea-4c2c-a669-3f9015b14f85
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988"}'
     form: {}
     headers:
       Content-Type:
@@ -155,7 +155,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162030Z","created_at":"2023-11-10T13:16:58.935162030Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.988451657Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039988674Z","created_at":"2023-11-13T13:51:50.039988674Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:50.190906559Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1503"
@@ -164,7 +164,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:59 GMT
+      - Mon, 13 Nov 2023 13:51:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -174,7 +174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1141be87-c7d1-4122-9c67-dcb310ea7b92
+      - 197d6143-149e-435c-b45e-cbd5393277dd
     status: 200 OK
     code: 200
     duration: ""
@@ -185,10 +185,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.988452Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:50.190907Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1494"
@@ -197,7 +197,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:59 GMT
+      - Mon, 13 Nov 2023 13:51:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73f7897f-c1a9-4cbc-96da-7076389921c2
+      - b49724cb-c5e7-41cf-86ed-05d9e0da93a2
     status: 200 OK
     code: 200
     duration: ""
@@ -218,10 +218,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:53.292741Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1499"
@@ -230,7 +230,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7e4ab59-6f44-4b53-bcf2-08b5f9c7db87
+      - d84979ca-5052-4716-b898-9fe74dde66f3
     status: 200 OK
     code: 200
     duration: ""
@@ -251,10 +251,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:53.292741Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1499"
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d0b4588-c215-49e3-b869-ecd1711a496d
+      - 1ee3ccc8-794c-45a3-81be-0a6223b06eab
     status: 200 OK
     code: 200
     duration: ""
@@ -284,10 +284,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZNVTFzYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVV4VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUaXROQ201c1pXbHBNazR5ZUVSTlFWSmhaM2R2VjB4RWJGZHJiVkZQUXpkR2FHMDNkRWxwVTB3MFpWbEpUME5WVjFjMVdISnlkVzB4YVdaRVpXdGlLMFpxVW1ZS2JVRTRkSEpDVlN0NVRHZHZWbmxYTDFoM1lpOTVWMFp1ZG1RMlVFbGtPRTkxTkdoU2JtVkVXRGRpTTB0aGVFMVBWbGhTWWt0aWJVRnVWRU5PWlVSRldBcHVibGd4UTJ4R2FUWjBSV053ZGxCdWVXSmFVM0pzUVdvNE4yNXdSM1Y0U0VwUGJXODNMMVZFTlZOQ00wSnRNakJpV0RsSGVtTjFkM2xCWlRWTVluWm9DbWhpVGxCdFEzSlhNVGM1TXpKc1pYRnRTVzU1VEV0UlYyWklabXhtYzBkeGFWVnNPVzFEV2xWT1RsZDVTV3AyWTFreVpFTkJOVTk0YVc5WU5XY3diQ3NLWVU5VlkxUXlZMk5uU2pKUGRURTJUV0ZtVjIxR1dVRTNaVGhCYVhOaGVVcDVWemRzUlRKT2FXTjNXVWgyZERCUGEzUkZPRGx3TlRVd1EweHNVVkF5UkFvMWNtWk1iekZVUlRsSmRESk9RazVtVjJ4RlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS09GSTNSbHBzZUdSWlNYSTJUbTlVVTNKcFJGY3hRa2MzUkRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREswOU5OR1ZaTVdaSmVtNVdSbmMxVTFKSFlYRnNWM0prUWtob1RXNTNXbE5xTkROQ01saHdNRWc0ZFVSWmFXcEhZd3BUY21sTGRYVm9PR1pIU1hReE9XbEVURUpJTVdRNE9HUXhNelExUzNGcFlXOVZSbGhQUjNKVVNqbE5TMk5yV0dZeU5tcGtSekpCVGxVd2F6ZFdSQzlYQ2xGaGFVUjFNMVpKTmtwTVJYaFplSGRRTkUxMFkyYzJZa2xyV1Vkc1RUWmtLMjV4Ym5oRmJYcFVhVzhyV1ZKblJFcExUSGhWYzI1MFJtSjFZVkJFVUhNS1JUSk1ZWEp4VlVSMWRXUkxTMko0ZGtSQ00zWXdTemMzTDJoMFFuZHFSWGQ2WlhsSGIxY3lVVEI1Wm5WelNWcHVNRk5ITUdjMWNUSmhVMkppT1hobU5ncERhbVl6TkVWb2NVaDBkSEZ1UTFoa2VrVndiRzExVlhSWGRISjFTa3B3TjNZMWFuaE5TRE5TZHpOQ09GaG1jRGREYkM5Qk1WQlFZa042V0dkUlRHdFdDakpSWkdGRmFtdEtXRWhyVm1GWmJHRTNaUzluTVhRelFqTlJlRVZqU25rM2JVOW9Od290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjI2ZWU2ZTEtM2JiMy00ZjNjLTgwZmMtZWI4MjRiZThkODQxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKaXNjdlcxYm9FNTNTN0lNT2x5S2h4aDNnQ1hqd0dJa0N3VUVjeXVmcFFFaENlQ3pQMXRlWXFWaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2590"
@@ -296,7 +296,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51d7765e-caeb-4f0c-a780-89189fdf3e60
+      - bdc62423-b1a7-46eb-9ce5-215158e4ceac
     status: 200 OK
     code: 200
     duration: ""
@@ -317,10 +317,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:53.292741Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1499"
@@ -329,7 +329,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d5ccb8a-4800-4914-8fa9-260d988cf0ad
+      - 10abdc3c-cacc-433b-a858-6eb12e90c3ba
     status: 200 OK
     code: 200
     duration: ""
@@ -350,19 +350,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ffba1c99-4cf3-4a48-9cf2-82769bb9a988
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:43.091315Z","dhcp_enabled":true,"id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:43.091315Z","id":"6d4afa64-9bed-4210-a3b5-dcdae6503771","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:51:43.091315Z"},{"created_at":"2023-11-13T13:51:43.091315Z","id":"c95f05e0-b838-4fe3-820a-d79ce0fe9c25","subnet":"fd63:256c:45f7:c40b::/64","updated_at":"2023-11-13T13:51:43.091315Z"}],"tags":[],"updated_at":"2023-11-13T13:51:43.091315Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "712"
+      - "713"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -372,7 +372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10cc02ac-c5b5-4c2f-b36f-0a9c43e6cd74
+      - e9c36252-3922-433d-9a07-57c24d6ed7d9
     status: 200 OK
     code: 200
     duration: ""
@@ -383,10 +383,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:53.292741Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1499"
@@ -395,7 +395,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -405,7 +405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f652153b-cc02-47ad-82b0-533a04dd9595
+      - 32a7c144-b9e7-4021-a717-12ff19aaa652
     status: 200 OK
     code: 200
     duration: ""
@@ -416,10 +416,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZNVTFzYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVV4VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUaXROQ201c1pXbHBNazR5ZUVSTlFWSmhaM2R2VjB4RWJGZHJiVkZQUXpkR2FHMDNkRWxwVTB3MFpWbEpUME5WVjFjMVdISnlkVzB4YVdaRVpXdGlLMFpxVW1ZS2JVRTRkSEpDVlN0NVRHZHZWbmxYTDFoM1lpOTVWMFp1ZG1RMlVFbGtPRTkxTkdoU2JtVkVXRGRpTTB0aGVFMVBWbGhTWWt0aWJVRnVWRU5PWlVSRldBcHVibGd4UTJ4R2FUWjBSV053ZGxCdWVXSmFVM0pzUVdvNE4yNXdSM1Y0U0VwUGJXODNMMVZFTlZOQ00wSnRNakJpV0RsSGVtTjFkM2xCWlRWTVluWm9DbWhpVGxCdFEzSlhNVGM1TXpKc1pYRnRTVzU1VEV0UlYyWklabXhtYzBkeGFWVnNPVzFEV2xWT1RsZDVTV3AyWTFreVpFTkJOVTk0YVc5WU5XY3diQ3NLWVU5VlkxUXlZMk5uU2pKUGRURTJUV0ZtVjIxR1dVRTNaVGhCYVhOaGVVcDVWemRzUlRKT2FXTjNXVWgyZERCUGEzUkZPRGx3TlRVd1EweHNVVkF5UkFvMWNtWk1iekZVUlRsSmRESk9RazVtVjJ4RlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS09GSTNSbHBzZUdSWlNYSTJUbTlVVTNKcFJGY3hRa2MzUkRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREswOU5OR1ZaTVdaSmVtNVdSbmMxVTFKSFlYRnNWM0prUWtob1RXNTNXbE5xTkROQ01saHdNRWc0ZFVSWmFXcEhZd3BUY21sTGRYVm9PR1pIU1hReE9XbEVURUpJTVdRNE9HUXhNelExUzNGcFlXOVZSbGhQUjNKVVNqbE5TMk5yV0dZeU5tcGtSekpCVGxVd2F6ZFdSQzlYQ2xGaGFVUjFNMVpKTmtwTVJYaFplSGRRTkUxMFkyYzJZa2xyV1Vkc1RUWmtLMjV4Ym5oRmJYcFVhVzhyV1ZKblJFcExUSGhWYzI1MFJtSjFZVkJFVUhNS1JUSk1ZWEp4VlVSMWRXUkxTMko0ZGtSQ00zWXdTemMzTDJoMFFuZHFSWGQ2WlhsSGIxY3lVVEI1Wm5WelNWcHVNRk5ITUdjMWNUSmhVMkppT1hobU5ncERhbVl6TkVWb2NVaDBkSEZ1UTFoa2VrVndiRzExVlhSWGRISjFTa3B3TjNZMWFuaE5TRE5TZHpOQ09GaG1jRGREYkM5Qk1WQlFZa042V0dkUlRHdFdDakpSWkdGRmFtdEtXRWhyVm1GWmJHRTNaUzluTVhRelFqTlJlRVZqU25rM2JVOW9Od290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjI2ZWU2ZTEtM2JiMy00ZjNjLTgwZmMtZWI4MjRiZThkODQxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKaXNjdlcxYm9FNTNTN0lNT2x5S2h4aDNnQ1hqd0dJa0N3VUVjeXVmcFFFaENlQ3pQMXRlWXFWaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2590"
@@ -428,7 +428,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -438,7 +438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6bb0d9a-72a4-45e2-8a29-3806090f339d
+      - a4b48f02-e86f-4748-bc21-44d2cb7cb372
     status: 200 OK
     code: 200
     duration: ""
@@ -449,19 +449,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ffba1c99-4cf3-4a48-9cf2-82769bb9a988
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:43.091315Z","dhcp_enabled":true,"id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:43.091315Z","id":"6d4afa64-9bed-4210-a3b5-dcdae6503771","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:51:43.091315Z"},{"created_at":"2023-11-13T13:51:43.091315Z","id":"c95f05e0-b838-4fe3-820a-d79ce0fe9c25","subnet":"fd63:256c:45f7:c40b::/64","updated_at":"2023-11-13T13:51:43.091315Z"}],"tags":[],"updated_at":"2023-11-13T13:51:43.091315Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "712"
+      - "713"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -471,7 +471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8388cbeb-009c-44a1-8268-89e093f852cd
+      - 303e86aa-b2ec-46c1-8d3c-5c1de5d319a3
     status: 200 OK
     code: 200
     duration: ""
@@ -482,10 +482,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:53.292741Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1499"
@@ -494,7 +494,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -504,7 +504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e002350d-0083-4a46-a9ac-c31ecc95e6f8
+      - 78b43964-a7d4-45f6-9bdc-01ecaccd773b
     status: 200 OK
     code: 200
     duration: ""
@@ -515,10 +515,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZNVTFzYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVV4VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUaXROQ201c1pXbHBNazR5ZUVSTlFWSmhaM2R2VjB4RWJGZHJiVkZQUXpkR2FHMDNkRWxwVTB3MFpWbEpUME5WVjFjMVdISnlkVzB4YVdaRVpXdGlLMFpxVW1ZS2JVRTRkSEpDVlN0NVRHZHZWbmxYTDFoM1lpOTVWMFp1ZG1RMlVFbGtPRTkxTkdoU2JtVkVXRGRpTTB0aGVFMVBWbGhTWWt0aWJVRnVWRU5PWlVSRldBcHVibGd4UTJ4R2FUWjBSV053ZGxCdWVXSmFVM0pzUVdvNE4yNXdSM1Y0U0VwUGJXODNMMVZFTlZOQ00wSnRNakJpV0RsSGVtTjFkM2xCWlRWTVluWm9DbWhpVGxCdFEzSlhNVGM1TXpKc1pYRnRTVzU1VEV0UlYyWklabXhtYzBkeGFWVnNPVzFEV2xWT1RsZDVTV3AyWTFreVpFTkJOVTk0YVc5WU5XY3diQ3NLWVU5VlkxUXlZMk5uU2pKUGRURTJUV0ZtVjIxR1dVRTNaVGhCYVhOaGVVcDVWemRzUlRKT2FXTjNXVWgyZERCUGEzUkZPRGx3TlRVd1EweHNVVkF5UkFvMWNtWk1iekZVUlRsSmRESk9RazVtVjJ4RlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS09GSTNSbHBzZUdSWlNYSTJUbTlVVTNKcFJGY3hRa2MzUkRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREswOU5OR1ZaTVdaSmVtNVdSbmMxVTFKSFlYRnNWM0prUWtob1RXNTNXbE5xTkROQ01saHdNRWc0ZFVSWmFXcEhZd3BUY21sTGRYVm9PR1pIU1hReE9XbEVURUpJTVdRNE9HUXhNelExUzNGcFlXOVZSbGhQUjNKVVNqbE5TMk5yV0dZeU5tcGtSekpCVGxVd2F6ZFdSQzlYQ2xGaGFVUjFNMVpKTmtwTVJYaFplSGRRTkUxMFkyYzJZa2xyV1Vkc1RUWmtLMjV4Ym5oRmJYcFVhVzhyV1ZKblJFcExUSGhWYzI1MFJtSjFZVkJFVUhNS1JUSk1ZWEp4VlVSMWRXUkxTMko0ZGtSQ00zWXdTemMzTDJoMFFuZHFSWGQ2WlhsSGIxY3lVVEI1Wm5WelNWcHVNRk5ITUdjMWNUSmhVMkppT1hobU5ncERhbVl6TkVWb2NVaDBkSEZ1UTFoa2VrVndiRzExVlhSWGRISjFTa3B3TjNZMWFuaE5TRE5TZHpOQ09GaG1jRGREYkM5Qk1WQlFZa042V0dkUlRHdFdDakpSWkdGRmFtdEtXRWhyVm1GWmJHRTNaUzluTVhRelFqTlJlRVZqU25rM2JVOW9Od290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjI2ZWU2ZTEtM2JiMy00ZjNjLTgwZmMtZWI4MjRiZThkODQxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKaXNjdlcxYm9FNTNTN0lNT2x5S2h4aDNnQ1hqd0dJa0N3VUVjeXVmcFFFaENlQ3pQMXRlWXFWaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2590"
@@ -527,7 +527,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 967c5f66-ed0a-4b64-a7ab-af9ac24226cd
+      - 921f98ba-68ed-49ab-a8b4-456a1c40b080
     status: 200 OK
     code: 200
     duration: ""
@@ -548,10 +548,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.263842Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:53.292741Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1499"
@@ -560,7 +560,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:51:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf6772cb-861d-4b85-bb0b-928b519b232c
+      - 5173682b-5e8c-46fb-bec8-0dbaf443aed0
     status: 200 OK
     code: 200
     duration: ""
@@ -583,10 +583,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.550394867Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:57.491993017Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1497"
@@ -595,7 +595,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:51:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a359c8d-28e6-4db3-9ca0-df30cf2b52ae
+      - 1234a6fb-80f9-401e-ab52-76a5b1d0bec5
     status: 200 OK
     code: 200
     duration: ""
@@ -616,10 +616,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.550395Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:57.491993Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
       - "1494"
@@ -628,7 +628,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:51:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c8c222e-ff9d-4097-902a-f4ff7b6b6415
+      - 56401ef5-8e2f-4fba-824d-043f9290d1f7
     status: 200 OK
     code: 200
     duration: ""
@@ -649,19 +649,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:07.682501Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:57.491993Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1494"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:52:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +671,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 679ddcfc-6c43-4113-a5d1-7f5893fb0b51
+      - 0c12131d-f23a-48bf-b8fb-4d69397d49c9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:04.011298Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1499"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:52:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b85bfb5-7e6e-47e2-87fe-59b71f856476
     status: 200 OK
     code: 200
     duration: ""
@@ -684,10 +717,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/upgrade
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841/upgrade
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.207907217Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:07.917700772Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1498"
@@ -696,7 +729,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:12 GMT
+      - Mon, 13 Nov 2023 13:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -706,7 +739,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37a8b1e9-3ab3-44f2-909f-13d6e4178f5f
+      - 7d6fcb19-033e-4761-884f-3fb7ae96bf19
     status: 200 OK
     code: 200
     duration: ""
@@ -717,10 +750,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.207907Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:07.917701Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1495"
@@ -729,7 +762,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:12 GMT
+      - Mon, 13 Nov 2023 13:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -739,7 +772,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3295de9c-6316-48f5-879d-2103c63b284e
+      - 5f96fd04-e81d-4d7d-b2c9-48409cd39af0
     status: 200 OK
     code: 200
     duration: ""
@@ -750,76 +783,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.207907Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1495"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b7083232-fc70-494d-9b18-662ad5893497
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:12.207907Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1495"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8831c5d4-d0f5-4765-a52f-f72d4243f9be
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.871779Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:09.055827Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -828,7 +795,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:28 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -838,7 +805,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5eeb6056-66a7-4b96-b927-d31c75f98a00
+      - a67b3e87-5f94-41bc-9fc0-e0fffbbc1a7f
     status: 200 OK
     code: 200
     duration: ""
@@ -849,10 +816,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.871779Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:09.055827Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -861,7 +828,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:28 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -871,7 +838,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e6564ce-f2c8-4d84-8991-4ce270ff90a5
+      - de7a73ee-97af-4da2-8864-c7edfb7794c4
     status: 200 OK
     code: 200
     duration: ""
@@ -882,10 +849,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZNVTFzYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVV4VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUaXROQ201c1pXbHBNazR5ZUVSTlFWSmhaM2R2VjB4RWJGZHJiVkZQUXpkR2FHMDNkRWxwVTB3MFpWbEpUME5WVjFjMVdISnlkVzB4YVdaRVpXdGlLMFpxVW1ZS2JVRTRkSEpDVlN0NVRHZHZWbmxYTDFoM1lpOTVWMFp1ZG1RMlVFbGtPRTkxTkdoU2JtVkVXRGRpTTB0aGVFMVBWbGhTWWt0aWJVRnVWRU5PWlVSRldBcHVibGd4UTJ4R2FUWjBSV053ZGxCdWVXSmFVM0pzUVdvNE4yNXdSM1Y0U0VwUGJXODNMMVZFTlZOQ00wSnRNakJpV0RsSGVtTjFkM2xCWlRWTVluWm9DbWhpVGxCdFEzSlhNVGM1TXpKc1pYRnRTVzU1VEV0UlYyWklabXhtYzBkeGFWVnNPVzFEV2xWT1RsZDVTV3AyWTFreVpFTkJOVTk0YVc5WU5XY3diQ3NLWVU5VlkxUXlZMk5uU2pKUGRURTJUV0ZtVjIxR1dVRTNaVGhCYVhOaGVVcDVWemRzUlRKT2FXTjNXVWgyZERCUGEzUkZPRGx3TlRVd1EweHNVVkF5UkFvMWNtWk1iekZVUlRsSmRESk9RazVtVjJ4RlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS09GSTNSbHBzZUdSWlNYSTJUbTlVVTNKcFJGY3hRa2MzUkRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREswOU5OR1ZaTVdaSmVtNVdSbmMxVTFKSFlYRnNWM0prUWtob1RXNTNXbE5xTkROQ01saHdNRWc0ZFVSWmFXcEhZd3BUY21sTGRYVm9PR1pIU1hReE9XbEVURUpJTVdRNE9HUXhNelExUzNGcFlXOVZSbGhQUjNKVVNqbE5TMk5yV0dZeU5tcGtSekpCVGxVd2F6ZFdSQzlYQ2xGaGFVUjFNMVpKTmtwTVJYaFplSGRRTkUxMFkyYzJZa2xyV1Vkc1RUWmtLMjV4Ym5oRmJYcFVhVzhyV1ZKblJFcExUSGhWYzI1MFJtSjFZVkJFVUhNS1JUSk1ZWEp4VlVSMWRXUkxTMko0ZGtSQ00zWXdTemMzTDJoMFFuZHFSWGQ2WlhsSGIxY3lVVEI1Wm5WelNWcHVNRk5ITUdjMWNUSmhVMkppT1hobU5ncERhbVl6TkVWb2NVaDBkSEZ1UTFoa2VrVndiRzExVlhSWGRISjFTa3B3TjNZMWFuaE5TRE5TZHpOQ09GaG1jRGREYkM5Qk1WQlFZa042V0dkUlRHdFdDakpSWkdGRmFtdEtXRWhyVm1GWmJHRTNaUzluTVhRelFqTlJlRVZqU25rM2JVOW9Od290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjI2ZWU2ZTEtM2JiMy00ZjNjLTgwZmMtZWI4MjRiZThkODQxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKaXNjdlcxYm9FNTNTN0lNT2x5S2h4aDNnQ1hqd0dJa0N3VUVjeXVmcFFFaENlQ3pQMXRlWXFWaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2590"
@@ -894,7 +861,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:28 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -904,7 +871,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efc233a6-69a8-40ae-af74-2a057e877c9b
+      - d82a6f16-5b33-4029-ab50-b9fd63937c76
     status: 200 OK
     code: 200
     duration: ""
@@ -915,10 +882,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.871779Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:09.055827Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -927,7 +894,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:28 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -937,7 +904,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffa8d1c5-6f14-427b-bb7d-0a00a3097c55
+      - c9a04882-e9b7-4de4-9754-2b2d1cf98233
     status: 200 OK
     code: 200
     duration: ""
@@ -948,19 +915,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ffba1c99-4cf3-4a48-9cf2-82769bb9a988
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.727685Z","dhcp_enabled":true,"id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.727685Z","id":"ca6d0b26-5eda-4747-bda0-b6645a71d403","subnet":"172.16.40.0/22","updated_at":"2023-11-10T13:16:56.727685Z"},{"created_at":"2023-11-10T13:16:56.727685Z","id":"68631d18-90a9-4417-8272-5341f9fa0691","subnet":"fd63:256c:45f7:8d8::/64","updated_at":"2023-11-10T13:16:56.727685Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.727685Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:43.091315Z","dhcp_enabled":true,"id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:43.091315Z","id":"6d4afa64-9bed-4210-a3b5-dcdae6503771","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:51:43.091315Z"},{"created_at":"2023-11-13T13:51:43.091315Z","id":"c95f05e0-b838-4fe3-820a-d79ce0fe9c25","subnet":"fd63:256c:45f7:c40b::/64","updated_at":"2023-11-13T13:51:43.091315Z"}],"tags":[],"updated_at":"2023-11-13T13:51:43.091315Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "712"
+      - "713"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:29 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -970,7 +937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b313a5c-f671-4d82-b8af-0544e8b39408
+      - e5791aea-6af5-415a-9b5e-cd161c0c38b0
     status: 200 OK
     code: 200
     duration: ""
@@ -981,10 +948,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.871779Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:09.055827Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -993,7 +960,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:29 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1003,7 +970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51bf5f71-d6d8-4b3d-a27b-1ba21f393a41
+      - cd04b857-2a5d-4e37-9289-0c2194de65b1
     status: 200 OK
     code: 200
     duration: ""
@@ -1014,10 +981,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDFHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURUZwQ21welRtYzFPRFlyZWpoSWVUaEhaMm80ZEZKckwyNTVkVlE1TjBKeGJFaHlObXRuT0doVVpVMUNhVWMxTjIxb1dHcFlabkpVYVhsdk4zQjJSbHBpTm5RS1ptcFdXV2xQZG0wemMwczBSMU56UTNJeVJXbzNVV2hqTUhJNFFrNWtRMGgwSzIwd0syVnljMUZ5Y0ZoNk0ySjZTR1phYlRod2NrTnJlazlNWTJVNVN3cG9jazFFTDNodWNVeDFhV0ptYXl0bWRDdEVPR0prT0RKd1QxcFdaWHBzUjA1RGMyNVhVelZUVEU1dVVuUkdiWFI2VFdaVFFYZHhiV0pNVTBoUGIwMUlDbHBYU0VWTlpVNURTMmwyY0dRdlRIQlllbk54Y2t3elV6SjBWa1JKTjJORmJXWmtTblpqVlU4NGVISXljblo1U2xBM1ZGQTNMMGs0V25nM1pYSnBhVTRLWmxwS1drYzNTbTlCYlU5S05VNW1kbE5sUTNZNWRURkxVR2xVTjFwUFVXbDBlblJzTm01eWJUTXdhakpYTDFFNVpETTFOSE5oZWpsdFZtaG9RbnBqWVFwWk9XOXNTRkV3ZEdZeWFIQmFZV056ZWl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUWMxQldOWGtyT1d0eldrcHFaa2h4YUdkYVRWbExhMlJzTlVkTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJFMXhXa05oUVhrNVdXaHpaSFpPUkZkUmNHNXJOemx2YlZOMFlsTlhhV2gwZEcxTWJuSkVURFpHUmxvM2JHNXdNQW8xVDB3d2NrNVVSV3RJZEhkck1IZHhTMDlQTVVvdlJ6azRTaXRtV0RCR05HZFpRM1phWWt4elpHZHhiakp5UmxKRldrbEpjREp2VG5GcFRWUTNaemhHQ2xaNlVYUTRaVXRPT0VkRlEwRnlTMDVLZVdsM2JsQnBTVTlyTldrNWRXTmxUamxzVm5KVlZVZHlMM1JrUWt4VmFGSldLekZIYzB0emIyeFhRa2c0VGs0S2RrTlVZVWszVDNNM1VFWmlXa3d5V2tsdVpFOHJWMlZMVTBSUmVtSlBNVWd6UTJWUk1rVkdhRVZqUjFSRk0yNXVRbEZCT0ZFemVITkViVGh2UzI5NWRRcHdNRTE0VlN0dVdIUTJNalZWV1haTFZtazRibkZrTHk4dlJsQnphR3AyYzFZMFEzcHhMMHhGVFRkaVVXeHRSR2RzT0hCQ1dGbGlaVzR6VjBSWVpGWndDbkp4ZVdSMlEwVjZRVFp1U1U5YWVrVkRUME01VDJWYVRtUm5LM1ZQWWtwbFFtdG1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzEwYjQwZDktYzRhMi00MThjLTliMjgtYTEzNzEyYTJjNWZlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA0ZEt3YkFDcHVJcmlFZXNjSlRnbDhLTmxoa2ZoM25DNUUwRnd6aHlHQVh6WXp4MmYzclhmcFFWNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZNVTFzYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVV4VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUaXROQ201c1pXbHBNazR5ZUVSTlFWSmhaM2R2VjB4RWJGZHJiVkZQUXpkR2FHMDNkRWxwVTB3MFpWbEpUME5WVjFjMVdISnlkVzB4YVdaRVpXdGlLMFpxVW1ZS2JVRTRkSEpDVlN0NVRHZHZWbmxYTDFoM1lpOTVWMFp1ZG1RMlVFbGtPRTkxTkdoU2JtVkVXRGRpTTB0aGVFMVBWbGhTWWt0aWJVRnVWRU5PWlVSRldBcHVibGd4UTJ4R2FUWjBSV053ZGxCdWVXSmFVM0pzUVdvNE4yNXdSM1Y0U0VwUGJXODNMMVZFTlZOQ00wSnRNakJpV0RsSGVtTjFkM2xCWlRWTVluWm9DbWhpVGxCdFEzSlhNVGM1TXpKc1pYRnRTVzU1VEV0UlYyWklabXhtYzBkeGFWVnNPVzFEV2xWT1RsZDVTV3AyWTFreVpFTkJOVTk0YVc5WU5XY3diQ3NLWVU5VlkxUXlZMk5uU2pKUGRURTJUV0ZtVjIxR1dVRTNaVGhCYVhOaGVVcDVWemRzUlRKT2FXTjNXVWgyZERCUGEzUkZPRGx3TlRVd1EweHNVVkF5UkFvMWNtWk1iekZVUlRsSmRESk9RazVtVjJ4RlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS09GSTNSbHBzZUdSWlNYSTJUbTlVVTNKcFJGY3hRa2MzUkRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGREswOU5OR1ZaTVdaSmVtNVdSbmMxVTFKSFlYRnNWM0prUWtob1RXNTNXbE5xTkROQ01saHdNRWc0ZFVSWmFXcEhZd3BUY21sTGRYVm9PR1pIU1hReE9XbEVURUpJTVdRNE9HUXhNelExUzNGcFlXOVZSbGhQUjNKVVNqbE5TMk5yV0dZeU5tcGtSekpCVGxVd2F6ZFdSQzlYQ2xGaGFVUjFNMVpKTmtwTVJYaFplSGRRTkUxMFkyYzJZa2xyV1Vkc1RUWmtLMjV4Ym5oRmJYcFVhVzhyV1ZKblJFcExUSGhWYzI1MFJtSjFZVkJFVUhNS1JUSk1ZWEp4VlVSMWRXUkxTMko0ZGtSQ00zWXdTemMzTDJoMFFuZHFSWGQ2WlhsSGIxY3lVVEI1Wm5WelNWcHVNRk5ITUdjMWNUSmhVMkppT1hobU5ncERhbVl6TkVWb2NVaDBkSEZ1UTFoa2VrVndiRzExVlhSWGRISjFTa3B3TjNZMWFuaE5TRE5TZHpOQ09GaG1jRGREYkM5Qk1WQlFZa042V0dkUlRHdFdDakpSWkdGRmFtdEtXRWhyVm1GWmJHRTNaUzluTVhRelFqTlJlRVZqU25rM2JVOW9Od290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjI2ZWU2ZTEtM2JiMy00ZjNjLTgwZmMtZWI4MjRiZThkODQxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKaXNjdlcxYm9FNTNTN0lNT2x5S2h4aDNnQ1hqd0dJa0N3VUVjeXVmcFFFaENlQ3pQMXRlWXFWaw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2590"
@@ -1026,7 +993,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:29 GMT
+      - Mon, 13 Nov 2023 13:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1036,7 +1003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5228289-e7e6-4c2b-b5fc-38d5450d87f5
+      - 83f75158-fff1-45fe-a395-57d305db587d
     status: 200 OK
     code: 200
     duration: ""
@@ -1047,10 +1014,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:30.608939028Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:18.133645593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1498"
@@ -1059,7 +1026,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:30 GMT
+      - Mon, 13 Nov 2023 13:52:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1069,7 +1036,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45a32447-b460-4cab-a8a4-3fcb2932ebc8
+      - 5b8ac402-c8d8-4bc3-8d92-c21047c27299
     status: 200 OK
     code: 200
     duration: ""
@@ -1080,10 +1047,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:30.608939Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:18.133646Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1495"
@@ -1092,7 +1059,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:31 GMT
+      - Mon, 13 Nov 2023 13:52:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1102,7 +1069,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c8aaece-e30c-42d6-a34c-4754d6c4ead0
+      - 3f383b31-24ae-4458-934f-a3f25827d2a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1113,10 +1080,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c10b40d9-c4a2-418c-9b28-a13712a2c5fe.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.935162Z","created_at":"2023-11-10T13:16:58.935162Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c10b40d9-c4a2-418c-9b28-a13712a2c5fe.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:30.608939Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:50.039989Z","created_at":"2023-11-13T13:51:50.039989Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b26ee6e1-3bb3-4f3c-80fc-eb824be8d841.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:52:18.133646Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1495"
@@ -1125,7 +1092,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:36 GMT
+      - Mon, 13 Nov 2023 13:52:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1135,7 +1102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ea8c89a-c391-43c8-b995-32622b7f73ba
+      - 532650d9-771b-4b30-b34f-b8a1a369dcd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1146,10 +1113,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1158,7 +1125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:41 GMT
+      - Mon, 13 Nov 2023 13:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1168,7 +1135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 648d3e15-a5e2-411c-932f-e060ea0f79fc
+      - 8dd09a1c-96f9-40c1-b012-844f1d256a45
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1179,10 +1146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ffba1c99-4cf3-4a48-9cf2-82769bb9a988
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1191,7 +1158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:41 GMT
+      - Mon, 13 Nov 2023 13:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1201,7 +1168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6f56ff4-2bbd-49da-b875-43afdd418d1b
+      - 0e0b8ee3-9efe-4d20-97b4-d9a870b96d8a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1212,43 +1179,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7390c1f-e070-4f5e-85a6-fcb355018d7e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b26ee6e1-3bb3-4f3c-80fc-eb824be8d841
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"e7390c1f-e070-4f5e-85a6-fcb355018d7e","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 332839a8-92aa-4b30-a9af-651f8cfb05f5
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c10b40d9-c4a2-418c-9b28-a13712a2c5fe
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"c10b40d9-c4a2-418c-9b28-a13712a2c5fe","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b26ee6e1-3bb3-4f3c-80fc-eb824be8d841","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1257,7 +1191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:41 GMT
+      - Mon, 13 Nov 2023 13:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1267,7 +1201,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - effa8cfc-a118-4afb-8a56-231e9e7f8dba
+      - 18a6ed8e-1818-4b3f-9beb-d66bc8d31896
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ffba1c99-4cf3-4a48-9cf2-82769bb9a988
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"ffba1c99-4cf3-4a48-9cf2-82769bb9a988","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:52:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ac1b43c6-b2c5-48df-95aa-466870c8dbc6
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-multicloud.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-multicloud.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b893b688-6359-455b-b22d-9cfe73c8c11c
+      - 5441cef2-9c99-4aef-bb82-ffd77b7402a2
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702468526Z","created_at":"2023-11-10T13:17:24.702468526Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622074Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735276Z","created_at":"2023-11-13T13:56:57.749735276Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762284850Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1423"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:25 GMT
+      - Mon, 13 Nov 2023 13:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f76e6912-3462-43a4-a274-840dca6d09db
+      - e13cca62-aa70-44d6-a714-b1df7855117c
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:25 GMT
+      - Mon, 13 Nov 2023 13:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef2c9dbe-d4a3-4d22-850f-a9bbcfd8de2d
+      - e6195575-4e53-4446-ae8b-5dee2b0e87ad
     status: 200 OK
     code: 200
     duration: ""
@@ -113,10 +113,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -125,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:30 GMT
+      - Mon, 13 Nov 2023 13:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3830c0d4-02c6-4a1a-b4b7-d065a65db2fc
+      - 67dd4f74-8b40-43db-ab0e-5e6347d00f84
     status: 200 OK
     code: 200
     duration: ""
@@ -146,10 +146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:35 GMT
+      - Mon, 13 Nov 2023 13:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de1c56e1-4395-4a37-b96b-a18b22e578a2
+      - 41000383-aa78-4101-91ae-099eb63334b7
     status: 200 OK
     code: 200
     duration: ""
@@ -179,10 +179,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -191,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:40 GMT
+      - Mon, 13 Nov 2023 13:57:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5b8fdca-1519-4f36-85f1-e26d594927ee
+      - 0e256630-13ef-424f-a004-1e907119b927
     status: 200 OK
     code: 200
     duration: ""
@@ -212,10 +212,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -224,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:45 GMT
+      - Mon, 13 Nov 2023 13:57:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ff4df96-ef46-492f-b081-e5a26e1fbfa5
+      - 1db4cab8-4246-4c07-8534-4e20e1402a08
     status: 200 OK
     code: 200
     duration: ""
@@ -245,10 +245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:50 GMT
+      - Mon, 13 Nov 2023 13:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8e092e6-598b-4f27-9b5f-447c8a72aa5d
+      - fada5e8e-ab67-4861-bc2e-0b379504300b
     status: 200 OK
     code: 200
     duration: ""
@@ -278,10 +278,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -290,7 +290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:55 GMT
+      - Mon, 13 Nov 2023 13:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38a5d5c4-35c8-4310-a605-4b517592e37b
+      - a9de70d1-effe-4206-948f-2a1298146708
     status: 200 OK
     code: 200
     duration: ""
@@ -311,10 +311,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -323,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:00 GMT
+      - Mon, 13 Nov 2023 13:57:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc123032-fd8d-41ef-ac24-6014798197c7
+      - b28e6c56-1a33-4757-b99d-28884c4a51ec
     status: 200 OK
     code: 200
     duration: ""
@@ -344,10 +344,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -356,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:05 GMT
+      - Mon, 13 Nov 2023 13:57:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a525d07-013b-4f67-bf56-891afeeb33ed
+      - 10d22137-2000-4ea6-acb3-7910e9a57446
     status: 200 OK
     code: 200
     duration: ""
@@ -377,10 +377,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -389,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:11 GMT
+      - Mon, 13 Nov 2023 13:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8d73092-36cb-42b1-9033-e398f0e10ec4
+      - f9a37d56-a0ae-4525-a41d-b5958b8e7081
     status: 200 OK
     code: 200
     duration: ""
@@ -410,10 +410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -422,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:16 GMT
+      - Mon, 13 Nov 2023 13:57:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29624ae8-b783-44b9-b15d-f45f8bb99500
+      - dc344366-884f-4215-b21e-4084acb96f69
     status: 200 OK
     code: 200
     duration: ""
@@ -443,10 +443,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -455,7 +455,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:21 GMT
+      - Mon, 13 Nov 2023 13:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09cb4e25-7be4-4603-975e-c61020bfc0fd
+      - e26d239b-2113-4243-a267-3a48cd3a68d3
     status: 200 OK
     code: 200
     duration: ""
@@ -476,10 +476,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -488,7 +488,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:26 GMT
+      - Mon, 13 Nov 2023 13:57:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15dc7b07-0b5c-44e7-8544-74864326db6b
+      - 407e9985-182e-4e68-9f3e-459109590786
     status: 200 OK
     code: 200
     duration: ""
@@ -509,10 +509,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:56:57.762285Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -521,7 +521,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:31 GMT
+      - Mon, 13 Nov 2023 13:58:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57601bfb-be5a-43b7-b8e1-7126073b9fc8
+      - 9bd5847b-bba1-45d0-81cd-a60213b93b4c
     status: 200 OK
     code: 200
     duration: ""
@@ -542,76 +542,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1414"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:18:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ecbc27b-2bd3-41a3-8a56-f3aecf95b038
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:17:24.833622Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1414"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:18:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6de82dc9-8294-4ca6-a611-a6c94c65f341
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:58:06.341379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1411"
@@ -620,7 +554,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:46 GMT
+      - Mon, 13 Nov 2023 13:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6416787-1bce-43fe-b363-3f5a93eb843e
+      - d1ba858b-3df8-4c1f-902b-f36682331565
     status: 200 OK
     code: 200
     duration: ""
@@ -641,10 +575,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:58:06.341379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1411"
@@ -653,7 +587,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:46 GMT
+      - Mon, 13 Nov 2023 13:58:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7a05b14-06d7-45ee-adb6-dddbf8171641
+      - 7644d85b-7432-4e86-a4cf-201fcf14c6bc
     status: 200 OK
     code: 200
     duration: ""
@@ -674,10 +608,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmplVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WR041VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVGRLQ2tSeVFXeHlablEwSzA1UWFHUlJjR2xFUVhkeldXZFRiVlYxV1dRMWJISk5TalV2WnpOQ1pFZEtUMFpXZFhZM09EVmlaSGxvTkhkMlExaEpiR3d2Y0dvS1oyVmpiblIzWjBKWVRVd3hRMDRyWkc5bFNVRlhkMHRKZGxGRlpWQnNhMVJsZGxoRk0yaGlObGRtWlZwNVFUSmxXSEl6Tkdvek5sWXJTalJtYVhCaFRRcDZORThyZFVodE9DOUVhWFpHTTBKSFRFbE5Ta1p2UkcxNlMwSTJSMmR4VHpoMGQybFhSMVJzU1RSSWRHMVZZVUUwYjBaaFRsZDFlbU41ZVVKd1VGTjJDbFpMUVhwYVJuZFlhVTExVEVaclkwaDNNamN4TjJneUwyZFBVV1pVV1ZGWFMySmtVV296YjJsQllrMWFUVXRrTlU5dGJsa3ZiMlJwYm1JMk0wbFNWekFLVEd3NFVESlRXVmQxTDAxWVRtcHBWVGx5YjNGR04weFdhVGxCVlVkRk5HbERkV3hSTHpZd04yWnhXWFpOT1ROaE1UVXlaMGR1Y200ME1sRmxaRTlaS3dwR1dXMDNNRXB0YTNsYVdtTmpSMlZpZDNnd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTGFYSXpSMjF6WjFCd2RuVm1SbmhFZGxKV1pGaFJabEpVTlVGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVEzYzJhR1o1VkVscGFFMVJUVmRKZEU1dFpIZE9SbTFhYjJGNWJrNWpVMDQzTTFKWGJWRldiak15ZUdKNWQxQkRWUXBOYzJzM1ozZDNTREF2Y1Raa1pscDZVbmRFTVhwamJuRm5WV2RuY2sxRGExWlFaSFpMSzAweU4yVlhjMkpuUWxOcWVsbDJRbUl6ZVdncmNta3piazF0Q2k4d04zSkxOR1pMUmxoYVNrOUpabWhEZUZsM1JVTm5aMDFoZDA1MFduWllNVEF6V0hKUFV6QlFlRTV3TkV0UVQyTlRjVnBJYUdaVlVtZGlLMXBPY1RnS2JWVnljM0pEWmxwbmJXSlJOWGRyZVRSVGVWbElTREpsU205MFp6SmxWVFZJU2pJNGQzcFFkMDF4Ykc5a1pHcGlhR0pRVEZvd1JFbFFaV3hpYmxSalF3cHBjV2xyVmxsamJtRXpUWFpyY3l0T1pXeHJaMnhNZVRSVFJYSXZSVmt2TjNRNVYxSnNLMmhvVEVwS1ZtTk5jRGxJVDBkbVkzSldUR0ZHTTBWVlkwRlRDbWhPYldkNWJsZHhUamd2Y3pJclpuVnlZMGswWW1OSWN6SkhaMEZLZEV4TldUQmxVQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTlkMGRlOTctMmMxYS00YWRjLWJhYjQtZTVlZjBhMjBmYTZiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRTGhnYkljMnl5MUJXeVNqNmtBR0FoeEtvZzBDcXE3NzBhSHN2aDJqd3RLYXNoRnBOQ1QzVkZxeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUlpNVTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVlJhQ2s5b1NGUXlkWFp6VTAxclNtOUhRM2RRVjJGcE1UQnNSbEZDYkhGWlRsaG5iVUl5YTNsWWVERlZWM1pNVmtGdmFVOUxkMXBOYTFaUU5tcE5WMlJ1WkRVS2JrSk9MMVZUWm01SVNtNWxaa2gwYmtaeFoxZDNaMlZPVnpaVkwwSjBjVWhSU2tkNVpsaGlUeXRqVW1SQ2RITXdUR1YyVkVSeVdUZHJNMmczZVVwWFJnbzNVVkF4TTNodVJHTnFZVWcxZDJOb09WRmpla1E0VFVSd1NrVmlPSGxhZUhKRGRrTTBVQ3QxU25SRk1GTm9kSEZLTHprM2FrRkZNbmQwYjBkWmNFSktDbXhKYTNaSFdEZDZWMWR4YzBZd2NsUkxaazloWVhWV2FrSlNibHBqVjNaRU0yZEJTVkJFTkhCQlIzTlBTMGRCWXpCaVFVTklTRGRaY0RGemNXTmtTbEVLY0RaTmNWUjBhMW9yZWt0WGVsWlNUWGR4UlZoTk4zQkVTMUozT0VsaVdtMVFjSFlyTlhVd1RFd3hjbGR0VXpsRWIycEJVM0ZWUVU5dVZHa3JVa0lyY2dveVJVOXdZbkZvWm14VGRXVmtTV1pQUlZFd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlpGWk5XRnBtUkVOalJVbDRhblZuYm1aMWFYcHRURkJUZFhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NYRnJRMDlPYUdoalVWUkVWa0p1UjNWeWRIRkRUa3RLVVZCeldIcGpha3RsVDFOTU9UTmFNbk5uZEhaMU16ZFpVZ3BSY0RSU04wcERSelEwYW1nM1ZVbERibVJ2YTJWaGFDOXZXVEpSYlVrd1VrZDZUV3BoTURWb01YSkdNRGhWWW5WVE1YSjZhQzl4VjNWMVkzVk5OekZrQ21sYWJWZGthSFF6U1dRMVltbzBXRzlJV1RNcldFNTVjR2RTWjNSRGVFMHJRMmxrWmpaclkwZFpTV1pVS3pkQmVEazVMM0pFUzBwNlJrazVhVVZoSzJzS09FbEZRbFZxVkdReVZWQldVRGx1TlZOQmNFeEhRVEJ5U2tsS1RHbDJVekJoU1hKd1JEZzRMemxJS3pCaVV6RXZWblpMUjFVdmJESTFLMUYyWW1sS1N3cHdZak53VjFaTVVWZFRkMFpRVkRWTk5EUXJkR0pKUjNaa2JFeEZVa2xPVFZSdmVXcEtiVVZxVUhSNllrWTFaRUY1TnpkelZXeEJiSGx5TlVWM2FVSllDbTluYUU5NVJIcGtZelpqUVRKRFlVUmlRM0YwVVRWTlZUUkdaMXBzTkUxd1IxSkZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOWQ1NzUzZTEtZTU2Zi00MThhLTkyZTMtOGEyNjRiNzFlNzNjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1SlJ2YmRtM21FTlJDRnVnamF0UVkzNVU5a2pId2Y4MFpVOGEzejNKZXBNZ2c2Q3JzNVluTDhSMw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2614"
@@ -686,7 +620,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:46 GMT
+      - Mon, 13 Nov 2023 13:58:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b69765d8-684c-4456-ba06-facf5ef88f68
+      - 7b957bf0-4009-453e-ad5a-09dbe2fe3083
     status: 200 OK
     code: 200
     duration: ""
@@ -707,10 +641,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:58:06.341379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1411"
@@ -719,7 +653,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:46 GMT
+      - Mon, 13 Nov 2023 13:58:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 690e9bd1-9543-4592-a169-c1967314a8df
+      - 3b594f31-332d-49e0-ae6d-27f207040698
     status: 200 OK
     code: 200
     duration: ""
@@ -742,10 +676,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274008Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521721997Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -754,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:46 GMT
+      - Mon, 13 Nov 2023 13:58:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -764,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e18e8ea-759a-4826-88a5-3f52b01de465
+      - 2ea3716e-4c8a-4ad3-aa8e-e0b520b28cbe
     status: 200 OK
     code: 200
     duration: ""
@@ -775,10 +709,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -787,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:46 GMT
+      - Mon, 13 Nov 2023 13:58:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -797,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 097c1717-7207-4e22-8795-bb74d134dc0c
+      - c0fc6401-6446-4943-b806-28149d56422d
     status: 200 OK
     code: 200
     duration: ""
@@ -808,10 +742,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -820,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:51 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -830,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cca0dc5b-9009-4262-90cd-c05734977347
+      - e318afe5-9324-43d1-88a4-16e114a3b9f6
     status: 200 OK
     code: 200
     duration: ""
@@ -841,10 +775,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -853,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:57 GMT
+      - Mon, 13 Nov 2023 13:58:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -863,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b345b6ff-e18f-4f3c-8467-59d62b0782e3
+      - 76a61d40-294e-4a93-ba80-a31e5e8a1510
     status: 200 OK
     code: 200
     duration: ""
@@ -874,10 +808,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -886,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:02 GMT
+      - Mon, 13 Nov 2023 13:58:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -896,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ad67bff-f94e-49d0-8182-3bc1bfb2718d
+      - 61decd27-dab3-4898-8d31-457b80761cac
     status: 200 OK
     code: 200
     duration: ""
@@ -907,10 +841,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -919,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:07 GMT
+      - Mon, 13 Nov 2023 13:58:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -929,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59db3c77-185f-426b-92a5-5acf1fe73113
+      - 33283414-47e8-4dd4-873a-c78f1549239b
     status: 200 OK
     code: 200
     duration: ""
@@ -940,10 +874,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -952,7 +886,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:12 GMT
+      - Mon, 13 Nov 2023 13:58:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -962,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c06ddf9-cc1b-4414-8507-e939d5d11e69
+      - f4c3ada2-3f6d-43d2-9f41-6e069fd4e9a6
     status: 200 OK
     code: 200
     duration: ""
@@ -973,10 +907,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -985,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:17 GMT
+      - Mon, 13 Nov 2023 13:58:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -995,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bc6b2f4-1d33-4fff-93ee-533d6c1d4392
+      - 711e98de-8525-47e6-aac6-4822a8716357
     status: 200 OK
     code: 200
     duration: ""
@@ -1006,10 +940,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1018,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:22 GMT
+      - Mon, 13 Nov 2023 13:58:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1028,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d63e55f-f06c-429f-9aba-0c5404dcd583
+      - c97bc235-dde8-4d77-a727-3bf1d55b3f5d
     status: 200 OK
     code: 200
     duration: ""
@@ -1039,10 +973,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1051,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:27 GMT
+      - Mon, 13 Nov 2023 13:58:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1061,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbd956de-c899-440d-9a87-9c13426c46f5
+      - a487a3b2-37c9-4518-8c03-0ddb52ad73f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1072,10 +1006,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1084,7 +1018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:32 GMT
+      - Mon, 13 Nov 2023 13:58:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1094,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1563bdac-3de1-4b36-acc4-a79153ce76ce
+      - 8d36fe55-9321-463d-8435-f2273bcb9a20
     status: 200 OK
     code: 200
     duration: ""
@@ -1105,10 +1039,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1117,7 +1051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:37 GMT
+      - Mon, 13 Nov 2023 13:59:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1127,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0c53df1-f614-4c52-bcd1-ad47882a85dd
+      - eb82d10e-f762-44bc-9cdc-044956414769
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,10 +1072,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1150,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:42 GMT
+      - Mon, 13 Nov 2023 13:59:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1160,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fabbefe7-85ce-407f-80c9-f6393d168e4f
+      - a2a5a998-616b-4a47-94b6-23771902235e
     status: 200 OK
     code: 200
     duration: ""
@@ -1171,10 +1105,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1183,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:47 GMT
+      - Mon, 13 Nov 2023 13:59:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1193,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e4c095d-13fa-4d9f-953d-fea5641abd42
+      - 8064b447-3bc1-43a1-a39f-f2a627ed8398
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,10 +1138,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1216,7 +1150,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:52 GMT
+      - Mon, 13 Nov 2023 13:59:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1226,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 772d7560-fde7-43be-9fa6-356aa25d3143
+      - 4410b20e-297c-456f-94b9-32741791afa7
     status: 200 OK
     code: 200
     duration: ""
@@ -1237,10 +1171,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1249,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:57 GMT
+      - Mon, 13 Nov 2023 13:59:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1259,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29df0d64-1cd9-442c-842c-18ab917f22e6
+      - 2ca34062-b2f1-4071-b31f-712602fa9be0
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,10 +1204,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1282,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:02 GMT
+      - Mon, 13 Nov 2023 13:59:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1292,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f333b96-7999-4810-b1b7-e835821419e0
+      - 5a9e3121-fd59-4023-8d8a-acb8daadad14
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,10 +1237,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1315,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:07 GMT
+      - Mon, 13 Nov 2023 13:59:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04c73fd8-575a-4f59-9b0d-5d92bbc43efe
+      - 4304fa3d-4475-4800-a479-5f651ca2d12c
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,10 +1270,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1348,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:12 GMT
+      - Mon, 13 Nov 2023 13:59:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12c1e19b-42cd-4a51-9a15-7070b9ccbd23
+      - 076f72fd-c5d4-43f6-b84a-0fe303808d9d
     status: 200 OK
     code: 200
     duration: ""
@@ -1369,10 +1303,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1381,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:17 GMT
+      - Mon, 13 Nov 2023 13:59:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fb45802-af82-4b9a-9eed-3172ccb894ff
+      - c22155a4-5460-423e-9508-0866444b04d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1402,10 +1336,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1414,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:22 GMT
+      - Mon, 13 Nov 2023 13:59:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31181a48-58ea-4d80-af45-da8c7841f94f
+      - 6fc1924a-eee5-47bd-95b4-9253ddccf0d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1435,10 +1369,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1447,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:28 GMT
+      - Mon, 13 Nov 2023 13:59:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1457,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8e1043d-678e-43e0-b948-0342b0c04571
+      - 01367821-a170-49b6-b7b4-49e6b3731063
     status: 200 OK
     code: 200
     duration: ""
@@ -1468,10 +1402,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1480,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:33 GMT
+      - Mon, 13 Nov 2023 13:59:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1490,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1d87b64-6151-4d03-a160-8211bb245e80
+      - df5aa39b-edac-408e-ba26-bfd8b95c2132
     status: 200 OK
     code: 200
     duration: ""
@@ -1501,10 +1435,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1513,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:38 GMT
+      - Mon, 13 Nov 2023 14:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1523,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08e47c63-f26c-47fc-9b1e-5a60ef18a4be
+      - 25a9b895-1f92-4108-9e33-69728f501098
     status: 200 OK
     code: 200
     duration: ""
@@ -1534,10 +1468,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1546,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:43 GMT
+      - Mon, 13 Nov 2023 14:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1556,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87f7b2d2-3522-4086-8632-a2fb2305aa89
+      - 3628bde3-163f-4fc7-b46b-ce3dd8518e7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1567,10 +1501,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1579,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:48 GMT
+      - Mon, 13 Nov 2023 14:00:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1589,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd937685-63b2-47d6-a1fb-cc9bb4d6e2cd
+      - fb5a4c17-f71f-456a-acaf-2fe0cd9d7180
     status: 200 OK
     code: 200
     duration: ""
@@ -1600,10 +1534,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1612,7 +1546,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:53 GMT
+      - Mon, 13 Nov 2023 14:00:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1622,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 279ff719-ac29-473a-ab69-8be6ed783b5d
+      - d67d6374-d247-45e0-8c98-86ddf6d5da4d
     status: 200 OK
     code: 200
     duration: ""
@@ -1633,10 +1567,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1645,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 14:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1655,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97672997-29a4-409a-bcfb-dfb176126cb0
+      - ee2a4869-7f32-45fc-8431-76b17974abf4
     status: 200 OK
     code: 200
     duration: ""
@@ -1666,10 +1600,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1678,7 +1612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:03 GMT
+      - Mon, 13 Nov 2023 14:00:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1688,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05b4efed-d658-4672-b9b2-3cce97c3df3c
+      - 514d4833-541f-46fa-be52-040dd7a5b85a
     status: 200 OK
     code: 200
     duration: ""
@@ -1699,10 +1633,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1711,7 +1645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:08 GMT
+      - Mon, 13 Nov 2023 14:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1721,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61e516fd-30c8-43f6-be0b-46cd3f6a5e50
+      - 1fd4719a-36a7-4a8e-b055-c87334114fe9
     status: 200 OK
     code: 200
     duration: ""
@@ -1732,10 +1666,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1744,7 +1678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:13 GMT
+      - Mon, 13 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1754,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3621fbc2-1df6-4730-9938-3cbf89e8f79d
+      - e016c802-ebbd-45c0-a1b5-135b3a6aab7c
     status: 200 OK
     code: 200
     duration: ""
@@ -1765,10 +1699,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1777,7 +1711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:18 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1787,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07e943b2-d2a5-44f4-87ee-8bf9b4f1de26
+      - 6e08d236-4713-4c00-ad47-ddf69ecaf301
     status: 200 OK
     code: 200
     duration: ""
@@ -1798,10 +1732,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:18:46.600274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1810,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:23 GMT
+      - Mon, 13 Nov 2023 14:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1820,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2409326-41b6-4b0c-94dc-f2d80897cbc6
+      - 95484bf8-25bc-4946-8ae7-0cbaee1e0dae
     status: 200 OK
     code: 200
     duration: ""
@@ -1831,10 +1765,1066 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:21:27.322472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:00:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4cdecd52-b3b0-4520-8ce3-9c93e82be610
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:00:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8bf9658d-34d8-4214-af74-f3ae106580e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a4e00efe-0cdc-411d-8798-1bf038e733db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbe6dabe-5e2d-4380-850b-84ba5ae7eff2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c8a4c05-73ad-407b-b50e-54dc11d45866
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1701d4bf-c17f-48c4-9258-6c2be4bd3acc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d8bc7657-735e-4180-ae30-f3f9a5fe30d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea14352c-40e3-4411-8773-4a4b17939da2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d03dc82e-22d5-47ef-b437-e6bb1dd3d712
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 262d0f70-fd97-4620-9152-4bc8815260bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9f2d4f4a-9287-4072-8317-aecd0276894e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11778a85-ed5d-451c-9d72-119d4506ca64
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a6171e1-ac90-4569-9920-e8a8f36b2377
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f257a811-8882-485f-a670-35e15e94da6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14ffce76-f23a-433c-b7c2-f50babea1514
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8cba8a61-55f6-4d7d-9dca-dd938678c9e2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 722e9c39-2d0c-4530-b776-a4338c0df0f6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57959404-3559-4975-b336-8d2d50b049e2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d93db1e6-4398-4f9f-8e52-0f63e35ae313
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9bc098e1-cc55-4c7b-bb47-358a233146d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bb2c49fb-4073-4d43-acee-eefefbd3fa2d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 769d64f4-fab1-4b11-ad7d-55beef053532
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b4f59ff9-27cc-4c24-9a76-e1c89fd3594a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0f1e72a-9e1e-4814-a83f-747cb2762f59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 65b0dd94-9db1-4baf-bc79-861d16da2a98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c2461c4a-0683-4ec9-a457-d2024d5ea2c0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f1e2fb66-2607-4095-aaba-02630f7d6c29
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0b09a6b0-b5e1-4726-9004-fb17e0cdf001
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 04a797dc-8722-42ad-8c6e-1d186953fbd9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c04a8dc-5dbe-4bc9-8573-22d960a8d729
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9633ab91-5c0e-4e49-ad98-f84e1dbc2b40
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:09.521722Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d920a02e-a94b-44a6-8819-03aaa470930c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:03:32.482424Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -1843,7 +2833,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:28 GMT
+      - Mon, 13 Nov 2023 14:03:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1853,7 +2843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1d9b7c5-9d36-4681-b2cd-2db0a8754189
+      - bdb143c6-5119-4934-b9c0-3b52d889fbac
     status: 200 OK
     code: 200
     duration: ""
@@ -1864,10 +2854,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:21:27.322472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:03:32.482424Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -1876,7 +2866,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:28 GMT
+      - Mon, 13 Nov 2023 14:03:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1886,7 +2876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8fe364c-001f-42f4-beee-83d467f3bdcc
+      - b060ab3b-db2a-49bc-85bf-72585e233258
     status: 200 OK
     code: 200
     duration: ""
@@ -1897,19 +2887,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/nodes?order_by=created_at_asc&page=1&pool_id=5e5090ef-8f8b-49ca-9a70-5745d4c73e64&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c/nodes?order_by=created_at_asc&page=1&pool_id=08a60501-a029-4538-bdc9-1e4c9d090746&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-10T13:18:47.010268Z","error_message":null,"id":"d8b762fa-0076-4fdc-a780-71680316da25","name":"scw-test-multicloud-test-multicloud-d8b762fa00","pool_id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","provider_id":"scaleway://instance/fr-par-1/f3fcb31c-19bb-4a6d-8d57-a74e3cc6a1ba","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:21:27.302280Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-13T14:00:44.407595Z","error_message":null,"id":"ccc6e7fc-334f-4c79-b647-11648974f0d9","name":"scw-test-multicloud-test-multicloud-ccc6e7fc33","pool_id":"08a60501-a029-4538-bdc9-1e4c9d090746","provider_id":"scaleway://instance/fr-par-1/5d0904e8-ce63-4f20-a298-9ab2f0e3c022","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:03:32.470625Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "621"
+      - "623"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:28 GMT
+      - Mon, 13 Nov 2023 14:03:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1919,7 +2909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aad245cf-b27c-4509-8472-df6ac699b67e
+      - 64318d59-5194-46a2-b981-83a6ce15a9ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1930,43 +2920,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1411"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:21:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 325edf3b-9692-4403-8411-390a3a6efa63
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:18:42.542405Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:58:06.341379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1411"
@@ -1975,7 +2932,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:29 GMT
+      - Mon, 13 Nov 2023 14:03:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1985,7 +2942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a57c1b0d-67bf-4858-8f5e-9d0c8c41afe9
+      - 19c65043-3021-4e7f-860a-8b0f0dbf0055
     status: 200 OK
     code: 200
     duration: ""
@@ -1996,10 +2953,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmplVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WR041VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVGRLQ2tSeVFXeHlablEwSzA1UWFHUlJjR2xFUVhkeldXZFRiVlYxV1dRMWJISk5TalV2WnpOQ1pFZEtUMFpXZFhZM09EVmlaSGxvTkhkMlExaEpiR3d2Y0dvS1oyVmpiblIzWjBKWVRVd3hRMDRyWkc5bFNVRlhkMHRKZGxGRlpWQnNhMVJsZGxoRk0yaGlObGRtWlZwNVFUSmxXSEl6Tkdvek5sWXJTalJtYVhCaFRRcDZORThyZFVodE9DOUVhWFpHTTBKSFRFbE5Ta1p2UkcxNlMwSTJSMmR4VHpoMGQybFhSMVJzU1RSSWRHMVZZVUUwYjBaaFRsZDFlbU41ZVVKd1VGTjJDbFpMUVhwYVJuZFlhVTExVEVaclkwaDNNamN4TjJneUwyZFBVV1pVV1ZGWFMySmtVV296YjJsQllrMWFUVXRrTlU5dGJsa3ZiMlJwYm1JMk0wbFNWekFLVEd3NFVESlRXVmQxTDAxWVRtcHBWVGx5YjNGR04weFdhVGxCVlVkRk5HbERkV3hSTHpZd04yWnhXWFpOT1ROaE1UVXlaMGR1Y200ME1sRmxaRTlaS3dwR1dXMDNNRXB0YTNsYVdtTmpSMlZpZDNnd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTGFYSXpSMjF6WjFCd2RuVm1SbmhFZGxKV1pGaFJabEpVTlVGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVEzYzJhR1o1VkVscGFFMVJUVmRKZEU1dFpIZE9SbTFhYjJGNWJrNWpVMDQzTTFKWGJWRldiak15ZUdKNWQxQkRWUXBOYzJzM1ozZDNTREF2Y1Raa1pscDZVbmRFTVhwamJuRm5WV2RuY2sxRGExWlFaSFpMSzAweU4yVlhjMkpuUWxOcWVsbDJRbUl6ZVdncmNta3piazF0Q2k4d04zSkxOR1pMUmxoYVNrOUpabWhEZUZsM1JVTm5aMDFoZDA1MFduWllNVEF6V0hKUFV6QlFlRTV3TkV0UVQyTlRjVnBJYUdaVlVtZGlLMXBPY1RnS2JWVnljM0pEWmxwbmJXSlJOWGRyZVRSVGVWbElTREpsU205MFp6SmxWVFZJU2pJNGQzcFFkMDF4Ykc5a1pHcGlhR0pRVEZvd1JFbFFaV3hpYmxSalF3cHBjV2xyVmxsamJtRXpUWFpyY3l0T1pXeHJaMnhNZVRSVFJYSXZSVmt2TjNRNVYxSnNLMmhvVEVwS1ZtTk5jRGxJVDBkbVkzSldUR0ZHTTBWVlkwRlRDbWhPYldkNWJsZHhUamd2Y3pJclpuVnlZMGswWW1OSWN6SkhaMEZLZEV4TldUQmxVQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTlkMGRlOTctMmMxYS00YWRjLWJhYjQtZTVlZjBhMjBmYTZiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRTGhnYkljMnl5MUJXeVNqNmtBR0FoeEtvZzBDcXE3NzBhSHN2aDJqd3RLYXNoRnBOQ1QzVkZxeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-13T13:58:06.341379Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1411"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a3eaf69d-7633-4704-bc72-add1b48ddfa6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUlpNVTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVlJhQ2s5b1NGUXlkWFp6VTAxclNtOUhRM2RRVjJGcE1UQnNSbEZDYkhGWlRsaG5iVUl5YTNsWWVERlZWM1pNVmtGdmFVOUxkMXBOYTFaUU5tcE5WMlJ1WkRVS2JrSk9MMVZUWm01SVNtNWxaa2gwYmtaeFoxZDNaMlZPVnpaVkwwSjBjVWhSU2tkNVpsaGlUeXRqVW1SQ2RITXdUR1YyVkVSeVdUZHJNMmczZVVwWFJnbzNVVkF4TTNodVJHTnFZVWcxZDJOb09WRmpla1E0VFVSd1NrVmlPSGxhZUhKRGRrTTBVQ3QxU25SRk1GTm9kSEZLTHprM2FrRkZNbmQwYjBkWmNFSktDbXhKYTNaSFdEZDZWMWR4YzBZd2NsUkxaazloWVhWV2FrSlNibHBqVjNaRU0yZEJTVkJFTkhCQlIzTlBTMGRCWXpCaVFVTklTRGRaY0RGemNXTmtTbEVLY0RaTmNWUjBhMW9yZWt0WGVsWlNUWGR4UlZoTk4zQkVTMUozT0VsaVdtMVFjSFlyTlhVd1RFd3hjbGR0VXpsRWIycEJVM0ZWUVU5dVZHa3JVa0lyY2dveVJVOXdZbkZvWm14VGRXVmtTV1pQUlZFd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlpGWk5XRnBtUkVOalJVbDRhblZuYm1aMWFYcHRURkJUZFhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NYRnJRMDlPYUdoalVWUkVWa0p1UjNWeWRIRkRUa3RLVVZCeldIcGpha3RsVDFOTU9UTmFNbk5uZEhaMU16ZFpVZ3BSY0RSU04wcERSelEwYW1nM1ZVbERibVJ2YTJWaGFDOXZXVEpSYlVrd1VrZDZUV3BoTURWb01YSkdNRGhWWW5WVE1YSjZhQzl4VjNWMVkzVk5OekZrQ21sYWJWZGthSFF6U1dRMVltbzBXRzlJV1RNcldFNTVjR2RTWjNSRGVFMHJRMmxrWmpaclkwZFpTV1pVS3pkQmVEazVMM0pFUzBwNlJrazVhVVZoSzJzS09FbEZRbFZxVkdReVZWQldVRGx1TlZOQmNFeEhRVEJ5U2tsS1RHbDJVekJoU1hKd1JEZzRMemxJS3pCaVV6RXZWblpMUjFVdmJESTFLMUYyWW1sS1N3cHdZak53VjFaTVVWZFRkMFpRVkRWTk5EUXJkR0pKUjNaa2JFeEZVa2xPVFZSdmVXcEtiVVZxVUhSNllrWTFaRUY1TnpkelZXeEJiSGx5TlVWM2FVSllDbTluYUU5NVJIcGtZelpqUVRKRFlVUmlRM0YwVVRWTlZUUkdaMXBzTkUxd1IxSkZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOWQ1NzUzZTEtZTU2Zi00MThhLTkyZTMtOGEyNjRiNzFlNzNjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1SlJ2YmRtM21FTlJDRnVnamF0UVkzNVU5a2pId2Y4MFpVOGEzejNKZXBNZ2c2Q3JzNVluTDhSMw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2614"
@@ -2008,7 +2998,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:29 GMT
+      - Mon, 13 Nov 2023 14:03:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2018,7 +3008,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edd68956-b1f9-4f8a-98e9-613650fa71cb
+      - 61830b10-ad1a-403f-a967-6e67539017c3
     status: 200 OK
     code: 200
     duration: ""
@@ -2029,10 +3019,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:21:27.322472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:03:32.482424Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -2041,7 +3031,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:29 GMT
+      - Mon, 13 Nov 2023 14:03:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2051,7 +3041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80b7c041-9ff1-4f16-be10-a6d0b42b00d7
+      - 58156101-3d24-4dcc-ac0a-945cd3d92aad
     status: 200 OK
     code: 200
     duration: ""
@@ -2062,19 +3052,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b/nodes?order_by=created_at_asc&page=1&pool_id=5e5090ef-8f8b-49ca-9a70-5745d4c73e64&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c/nodes?order_by=created_at_asc&page=1&pool_id=08a60501-a029-4538-bdc9-1e4c9d090746&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-10T13:18:47.010268Z","error_message":null,"id":"d8b762fa-0076-4fdc-a780-71680316da25","name":"scw-test-multicloud-test-multicloud-d8b762fa00","pool_id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","provider_id":"scaleway://instance/fr-par-1/f3fcb31c-19bb-4a6d-8d57-a74e3cc6a1ba","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:21:27.302280Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-13T14:00:44.407595Z","error_message":null,"id":"ccc6e7fc-334f-4c79-b647-11648974f0d9","name":"scw-test-multicloud-test-multicloud-ccc6e7fc33","pool_id":"08a60501-a029-4538-bdc9-1e4c9d090746","provider_id":"scaleway://instance/fr-par-1/5d0904e8-ce63-4f20-a298-9ab2f0e3c022","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:03:32.470625Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "621"
+      - "623"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:29 GMT
+      - Mon, 13 Nov 2023 14:03:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2084,7 +3074,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9a9ebf1-d0fa-4526-96e6-bccf1cb245e8
+      - 594e4379-d6ce-4100-97dc-9310443f27bc
     status: 200 OK
     code: 200
     duration: ""
@@ -2095,10 +3085,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333276Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:40.111614613Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "630"
@@ -2107,7 +3097,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:29 GMT
+      - Mon, 13 Nov 2023 14:03:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2117,7 +3107,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a213b420-3576-462a-8488-fa7dfa395eb7
+      - a24bb812-d24d-4c11-a712-a1599c8c3233
     status: 200 OK
     code: 200
     duration: ""
@@ -2128,10 +3118,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:40.111615Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2140,7 +3130,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:30 GMT
+      - Mon, 13 Nov 2023 14:03:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2150,7 +3140,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be00a1be-ea3f-4f3a-804a-c380694f7e05
+      - 25178837-0934-4074-ae67-25919b0ac82a
     status: 200 OK
     code: 200
     duration: ""
@@ -2161,10 +3151,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:40.111615Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2173,7 +3163,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:35 GMT
+      - Mon, 13 Nov 2023 14:03:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2183,7 +3173,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcee68f2-ee6f-4f96-bb0c-7321b3250ab5
+      - 81b29b84-5aad-46a6-ab1f-93f28599a8e1
     status: 200 OK
     code: 200
     duration: ""
@@ -2194,10 +3184,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:40.111615Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2206,7 +3196,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:40 GMT
+      - Mon, 13 Nov 2023 14:03:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2216,7 +3206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f2ece7e-8539-43f3-81d4-624e75d80dbc
+      - 867021fb-91cf-481f-87f3-4add2b976f87
     status: 200 OK
     code: 200
     duration: ""
@@ -2227,10 +3217,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:40.111615Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2239,7 +3229,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:45 GMT
+      - Mon, 13 Nov 2023 14:03:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2249,7 +3239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5ae4b0f-2f7e-48b7-a1a9-6779d223e1cb
+      - e2e0065a-c393-4860-b8d7-e8be769aa6b4
     status: 200 OK
     code: 200
     duration: ""
@@ -2260,10 +3250,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:40.111615Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2272,7 +3262,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:50 GMT
+      - Mon, 13 Nov 2023 14:04:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2282,7 +3272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb204dcc-f776-456e-a700-6e27e6ddc312
+      - f14fd5a0-e9c3-4924-afa1-7d8707c02ccd
     status: 200 OK
     code: 200
     duration: ""
@@ -2293,10 +3283,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:40.111615Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2305,7 +3295,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:55 GMT
+      - Mon, 13 Nov 2023 14:04:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2315,7 +3305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eda294f2-b029-4e7b-b674-b4047445c3e3
+      - 9d91785f-d1cc-4c66-b1d4-dfe93000ef90
     status: 200 OK
     code: 200
     duration: ""
@@ -2326,10 +3316,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","container_runtime":"containerd","created_at":"2023-11-13T13:58:09.496558Z","id":"08a60501-a029-4538-bdc9-1e4c9d090746","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:40.111615Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2338,7 +3328,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:00 GMT
+      - Mon, 13 Nov 2023 14:04:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2348,7 +3338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3453353-11a1-4894-b267-dd3b73d8f710
+      - 6f582ab8-175a-48ac-be54-df19dd46e22c
     status: 200 OK
     code: 200
     duration: ""
@@ -2359,43 +3349,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/08a60501-a029-4538-bdc9-1e4c9d090746
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","container_runtime":"containerd","created_at":"2023-11-10T13:18:46.590388Z","id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:21:29.945333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "627"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 004d0d62-fe95-4d2d-8b93-e4e63a096704
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5e5090ef-8f8b-49ca-9a70-5745d4c73e64
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"5e5090ef-8f8b-49ca-9a70-5745d4c73e64","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"08a60501-a029-4538-bdc9-1e4c9d090746","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2404,7 +3361,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:04:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2414,7 +3371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 028432e3-d4a7-4ac7-9ab2-c7665699a5c0
+      - 2b860094-6f6b-4c56-9d4d-6526059b2b72
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2425,10 +3382,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497064848Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378411Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1417"
@@ -2437,7 +3394,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:04:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2447,7 +3404,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4165f7bc-9314-4239-9bb6-3508f4823692
+      - eba0b072-5ba6-4231-b9e1-5fe407c8259d
     status: 200 OK
     code: 200
     duration: ""
@@ -2458,10 +3415,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2470,7 +3427,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:04:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2480,7 +3437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d57c21f-2607-41fc-a7f3-52e4338e91c1
+      - 86b6915e-455e-4820-bdfa-7db056b5e4a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2491,10 +3448,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2503,7 +3460,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:15 GMT
+      - Mon, 13 Nov 2023 14:04:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2513,7 +3470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 080b8077-971b-47fe-bc47-903d455086a1
+      - 0e7278d8-3891-4dfa-ab64-c17268fd9ce7
     status: 200 OK
     code: 200
     duration: ""
@@ -2524,10 +3481,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2536,7 +3493,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:20 GMT
+      - Mon, 13 Nov 2023 14:04:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2546,7 +3503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d20671f7-6b3b-4282-818f-3845e39f38ef
+      - c24d622c-277d-4511-b62f-e43a8fb8f3ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2557,10 +3514,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2569,7 +3526,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:25 GMT
+      - Mon, 13 Nov 2023 14:04:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2579,7 +3536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5d6b070-95d4-4222-a588-d972d71ea45c
+      - 893e74d0-556a-41f1-a953-cb29986362d3
     status: 200 OK
     code: 200
     duration: ""
@@ -2590,10 +3547,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2602,7 +3559,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:30 GMT
+      - Mon, 13 Nov 2023 14:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2612,7 +3569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3ec7036-1e3a-41d3-8ece-dd222f396455
+      - 2d43861f-e9c7-4dad-be04-8e0b6d49b1b2
     status: 200 OK
     code: 200
     duration: ""
@@ -2623,10 +3580,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2635,7 +3592,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:35 GMT
+      - Mon, 13 Nov 2023 14:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2645,7 +3602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7c247dc-69b9-4917-9f77-943327547577
+      - 55bbd345-ee41-4287-bca0-364868dc45bd
     status: 200 OK
     code: 200
     duration: ""
@@ -2656,10 +3613,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2668,7 +3625,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:40 GMT
+      - Mon, 13 Nov 2023 14:04:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2678,7 +3635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 126a53a8-0f1c-4374-a1d7-678199ecadbd
+      - 94035355-0425-4d05-839f-671ba489cc88
     status: 200 OK
     code: 200
     duration: ""
@@ -2689,10 +3646,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2701,7 +3658,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:45 GMT
+      - Mon, 13 Nov 2023 14:04:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2711,7 +3668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5d60d2b-28da-4644-9482-91f5336a5bc1
+      - 766f90f9-6b94-4ccf-b2b3-aef22fa7bce5
     status: 200 OK
     code: 200
     duration: ""
@@ -2722,10 +3679,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:17:24.702469Z","created_at":"2023-11-10T13:17:24.702469Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-10T13:22:10.497065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1414"
@@ -2734,7 +3691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 14:04:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2744,7 +3701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42950e1a-5314-4d97-b8c5-89b794b0a723
+      - 161111d1-202b-4a74-b911-52134cddb744
     status: 200 OK
     code: 200
     duration: ""
@@ -2755,10 +3712,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1414"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5af53954-2056-47da-bf06-48304c3e9930
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9d5753e1-e56f-418a-92e3-8a264b71e73c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T13:56:57.749735Z","created_at":"2023-11-13T13:56:57.749735Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9d5753e1-e56f-418a-92e3-8a264b71e73c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-13T14:04:16.293378Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1414"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d8c4ee35-ffbd-41c9-acd1-651b54284cfe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2767,7 +3790,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:56 GMT
+      - Mon, 13 Nov 2023 14:05:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2777,7 +3800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed1a08dd-6e02-49ee-9e11-80daa0873974
+      - 88378af5-c4f1-42d0-b3c4-e76b985438ae
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2788,10 +3811,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9d5753e1-e56f-418a-92e3-8a264b71e73c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"59d0de97-2c1a-4adc-bab4-e5ef0a20fa6b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"9d5753e1-e56f-418a-92e3-8a264b71e73c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2800,7 +3823,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:56 GMT
+      - Mon, 13 Nov 2023 14:05:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2810,7 +3833,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c301e144-fe24-464a-ac22-36be3cc55dd4
+      - 4a1ca3da-e3f1-4977-95ce-a6296e61d131
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-oidc.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-oidc.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fec77fa-2a71-4f46-9eba-6bc66e3a8526
+      - efc477bd-500e-466b-aadf-e8c7f55115e0
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:16.266750Z","dhcp_enabled":true,"id":"dadf30db-2843-472e-aef7-c79c0d109bce","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:16.266750Z","id":"ac8861bf-7715-45e7-92d9-478558855535","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:16.266750Z"},{"created_at":"2023-11-13T13:57:16.266750Z","id":"d1a8b3ef-18d2-453f-9cce-336476cfc9d7","subnet":"fd63:256c:45f7:8aa6::/64","updated_at":"2023-11-13T13:57:16.266750Z"}],"tags":[],"updated_at":"2023-11-13T13:57:16.266750Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "710"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:57 GMT
+      - Mon, 13 Nov 2023 13:57:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0b10d23-c4f6-4d45-a6ef-c14aa02d93c6
+      - d18727da-b7f7-4bf0-808a-162a2568ddaa
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dadf30db-2843-472e-aef7-c79c0d109bce
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:16.266750Z","dhcp_enabled":true,"id":"dadf30db-2843-472e-aef7-c79c0d109bce","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:16.266750Z","id":"ac8861bf-7715-45e7-92d9-478558855535","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:16.266750Z"},{"created_at":"2023-11-13T13:57:16.266750Z","id":"d1a8b3ef-18d2-453f-9cce-336476cfc9d7","subnet":"fd63:256c:45f7:8aa6::/64","updated_at":"2023-11-13T13:57:16.266750Z"}],"tags":[],"updated_at":"2023-11-13T13:57:16.266750Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "710"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 251760b1-d823-427d-9a33-e7cc1d14db02
+      - c2509a98-0f85-4c16-be3f-891ae8fe2f35
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-oidc","description":"","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":null,"groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":null},"apiserver_cert_sans":null,"private_network_id":"75b19688-d376-414a-ae89-26f0b815d552"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-oidc","description":"","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":null,"groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":null},"apiserver_cert_sans":null,"private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335320Z","created_at":"2023-11-10T13:16:58.492335320Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.501987724Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428957828Z","created_at":"2023-11-13T13:57:17.428957828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:17.448516742Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1566"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce6d48e8-d9a6-4b3a-9fa5-6dd6577678f8
+      - 8fc404f3-c646-4c61-85b0-ed5cca535e20
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.501988Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:17.448517Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1557"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 119c37fe-99ee-4ad5-8b71-8b5eb6cb250c
+      - 800f56f7-564e-439d-b3d1-5d746ab67feb
     status: 200 OK
     code: 200
     duration: ""
@@ -181,43 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.501988Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1557"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7c69278e-0600-470a-b244-8b627a1d613f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:20.213606Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1562"
@@ -226,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:08 GMT
+      - Mon, 13 Nov 2023 13:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 409ca66c-aaec-40db-8be2-2da897ca80b4
+      - 7accb93e-b602-4926-8735-8a081a730f2e
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:20.213606Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1562"
@@ -259,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:08 GMT
+      - Mon, 13 Nov 2023 13:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 871c4843-c48d-4a68-b75f-650bc2bd3f6c
+      - 6ec7a67c-60f9-4a1b-9097-f62e1c45f9b3
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUmplRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WR040VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkJ5Q205aGFpczNWV3RsTVVWUWFFMXJXWFZHTm13eVZ6ZHNRVFZ5ZVZoTFRXaFlNVEpaZFdsRVdIZ3hibEEzZVZkRU5uSTJkMFl4WjBOVGNYaE1Na2RNTTJnS2Qwb3phRlJ3YUV4SlZWTk9RUzl2TUZabFFVdE9UVVZWVW1ORFUxUnhaM0JEVVdRdmNuY3paVzVpTlZGdVFVWmpaMVZ1WlM5bU1XVXlVSHBFWlRSelR3cDVNR3RuWm1GYU4zZ3pOelZZU0UxaFdVbGxkbTlKU25ORlZEUnJSbFZ4Y0c1MWFXODFVbGxyTmtWc05rb3dlazEwTnpFcmFuSkhTQ3RLTHpZNWJtUlFDbGRKWVdFMWNuUmxjRXhsWldOT0wycGpXbmxaWWpNMlFtMVdhRVZFV25wR09GSlBUalphWmpKelZXWmtkVlpaTjJ0MWVVNVRjbVp0UTBoT2FUUllhVXdLTmtzMVpXeEhNWEU0ZWxwMmNGZGxVV3R0ZGpodE4wc3JaRUpTWmtKeFJsRTFha2Q2YTJ0VGNUZFBZbE5WVWtFd1V6WnZkazVTVFZacmFHbDBkSEJIWndwT1drRm5lRkIzYVdGU1EybEhUVE5RVDJvd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVdtNUNNMjVZTDNkS1VUbEdNSFpvT1dKNGNISkJLMk5JYTFWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlYyUlpkR1o2TWxSWVZHNUNka2N2VFhONk1YZHNVMEZHZEZVM1UyMTVabVFyTnpaWU9XbDJjRzlGTHpoT1QxQkJXZ3BGVEU1bGFYWkNPR3RNWnpsR016SlVSbkpKZUV0cVZGSjVWUzlrUVZaT01WWjVOV1Z0YmtRME9FTkZhWEJrVlZadlRVZzBSMk1yTjBKUFJYVlVhM00yQ2sxeFZYUnRiamRoWWxkT1VUWkJXa3cyWTFkUWNGVmhhRVZPTkhWM2NXWk5OeTlHYjBsWU1XdFpjRmRzUzBoMmRrMWlNVUZuVVhkTmJHcFFObTVMY0VzS1NsbHVUazh2YjJabksyaDZOalpDTUU5U1lucFNURXBxY0dSMFFYUlhiRlpZZDI1RGR6QmtRVmxQVjFkemNVbDRMMWg1YURCS09ESTJTbGxqWW5oeWJncENiM05QVlVWUGJIWjBiWEJqZGpoT1RTODNSV1JrTW1WYVIxQXZNMEo2T0hsUFkwOW5NV1pMTVZkVEt6ZFNhM050VTJ0MFNHMVBkR2hqZVhVemRFOW1DbXB2V1djeWNYSlBWVFZVV25oUGJGbHhOVTlOTjFVM1NubEJSWHBJTjNJeVQyVjJTd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDUxMWI3ZTgtMGY0Yy00NDY3LTkxYTktYTdjNWVjY2VmMDBjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPMmFZenJEZExES0FSQjV3SFNmYmNyNWxJU1dLUGJOT1VXQjhKUjZJbFdyV3ZDY0pwTUlWN1VUdw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2566"
@@ -292,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:09 GMT
+      - Mon, 13 Nov 2023 13:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dddfee2d-dff6-4153-805b-6f0f37f2d84c
+      - d37c63a3-4a14-4867-b04c-c6a65cce6f77
     status: 200 OK
     code: 200
     duration: ""
@@ -313,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:20.213606Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1562"
@@ -325,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:09 GMT
+      - Mon, 13 Nov 2023 13:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b97e573-3381-40e1-926f-fe705bd43ad5
+      - 2c54dc99-ccc3-4de3-9b15-56a9a60c122b
     status: 200 OK
     code: 200
     duration: ""
@@ -346,10 +313,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dadf30db-2843-472e-aef7-c79c0d109bce
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:16.266750Z","dhcp_enabled":true,"id":"dadf30db-2843-472e-aef7-c79c0d109bce","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:16.266750Z","id":"ac8861bf-7715-45e7-92d9-478558855535","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:16.266750Z"},{"created_at":"2023-11-13T13:57:16.266750Z","id":"d1a8b3ef-18d2-453f-9cce-336476cfc9d7","subnet":"fd63:256c:45f7:8aa6::/64","updated_at":"2023-11-13T13:57:16.266750Z"}],"tags":[],"updated_at":"2023-11-13T13:57:16.266750Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "710"
@@ -358,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:09 GMT
+      - Mon, 13 Nov 2023 13:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b0e7f0e-e0bc-4ec1-b832-fe2c87770b3b
+      - 52b4f4d2-426c-48ed-80b1-0f506bc8f06a
     status: 200 OK
     code: 200
     duration: ""
@@ -379,10 +346,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:20.213606Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1562"
@@ -391,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:09 GMT
+      - Mon, 13 Nov 2023 13:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27816e79-e6fd-430c-8e25-ade4229549e0
+      - 2e508360-25a2-499a-9adf-0cfaf388879b
     status: 200 OK
     code: 200
     duration: ""
@@ -412,10 +379,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUmplRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WR040VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkJ5Q205aGFpczNWV3RsTVVWUWFFMXJXWFZHTm13eVZ6ZHNRVFZ5ZVZoTFRXaFlNVEpaZFdsRVdIZ3hibEEzZVZkRU5uSTJkMFl4WjBOVGNYaE1Na2RNTTJnS2Qwb3phRlJ3YUV4SlZWTk9RUzl2TUZabFFVdE9UVVZWVW1ORFUxUnhaM0JEVVdRdmNuY3paVzVpTlZGdVFVWmpaMVZ1WlM5bU1XVXlVSHBFWlRSelR3cDVNR3RuWm1GYU4zZ3pOelZZU0UxaFdVbGxkbTlKU25ORlZEUnJSbFZ4Y0c1MWFXODFVbGxyTmtWc05rb3dlazEwTnpFcmFuSkhTQ3RLTHpZNWJtUlFDbGRKWVdFMWNuUmxjRXhsWldOT0wycGpXbmxaWWpNMlFtMVdhRVZFV25wR09GSlBUalphWmpKelZXWmtkVlpaTjJ0MWVVNVRjbVp0UTBoT2FUUllhVXdLTmtzMVpXeEhNWEU0ZWxwMmNGZGxVV3R0ZGpodE4wc3JaRUpTWmtKeFJsRTFha2Q2YTJ0VGNUZFBZbE5WVWtFd1V6WnZkazVTVFZacmFHbDBkSEJIWndwT1drRm5lRkIzYVdGU1EybEhUVE5RVDJvd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVdtNUNNMjVZTDNkS1VUbEdNSFpvT1dKNGNISkJLMk5JYTFWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlYyUlpkR1o2TWxSWVZHNUNka2N2VFhONk1YZHNVMEZHZEZVM1UyMTVabVFyTnpaWU9XbDJjRzlGTHpoT1QxQkJXZ3BGVEU1bGFYWkNPR3RNWnpsR016SlVSbkpKZUV0cVZGSjVWUzlrUVZaT01WWjVOV1Z0YmtRME9FTkZhWEJrVlZadlRVZzBSMk1yTjBKUFJYVlVhM00yQ2sxeFZYUnRiamRoWWxkT1VUWkJXa3cyWTFkUWNGVmhhRVZPTkhWM2NXWk5OeTlHYjBsWU1XdFpjRmRzUzBoMmRrMWlNVUZuVVhkTmJHcFFObTVMY0VzS1NsbHVUazh2YjJabksyaDZOalpDTUU5U1lucFNURXBxY0dSMFFYUlhiRlpZZDI1RGR6QmtRVmxQVjFkemNVbDRMMWg1YURCS09ESTJTbGxqWW5oeWJncENiM05QVlVWUGJIWjBiWEJqZGpoT1RTODNSV1JrTW1WYVIxQXZNMEo2T0hsUFkwOW5NV1pMTVZkVEt6ZFNhM050VTJ0MFNHMVBkR2hqZVhVemRFOW1DbXB2V1djeWNYSlBWVFZVV25oUGJGbHhOVTlOTjFVM1NubEJSWHBJTjNJeVQyVjJTd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDUxMWI3ZTgtMGY0Yy00NDY3LTkxYTktYTdjNWVjY2VmMDBjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPMmFZenJEZExES0FSQjV3SFNmYmNyNWxJU1dLUGJOT1VXQjhKUjZJbFdyV3ZDY0pwTUlWN1VUdw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2566"
@@ -424,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:10 GMT
+      - Mon, 13 Nov 2023 13:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d26cd1c5-561c-4ccc-856d-6748e4454c63
+      - c8cd527f-0000-4f16-bf25-838cbcecf462
     status: 200 OK
     code: 200
     duration: ""
@@ -445,10 +412,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dadf30db-2843-472e-aef7-c79c0d109bce
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:16.266750Z","dhcp_enabled":true,"id":"dadf30db-2843-472e-aef7-c79c0d109bce","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:16.266750Z","id":"ac8861bf-7715-45e7-92d9-478558855535","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:16.266750Z"},{"created_at":"2023-11-13T13:57:16.266750Z","id":"d1a8b3ef-18d2-453f-9cce-336476cfc9d7","subnet":"fd63:256c:45f7:8aa6::/64","updated_at":"2023-11-13T13:57:16.266750Z"}],"tags":[],"updated_at":"2023-11-13T13:57:16.266750Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "710"
@@ -457,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:10 GMT
+      - Mon, 13 Nov 2023 13:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e1fe35a-63ed-4373-b39f-112b503dcab7
+      - 0d5c9262-0ba6-47f8-ac45-58539e904737
     status: 200 OK
     code: 200
     duration: ""
@@ -478,10 +445,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:04.383085Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:20.213606Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1562"
@@ -490,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:10 GMT
+      - Mon, 13 Nov 2023 13:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf45cd41-8536-4a39-9d67-218c831aca8b
+      - 6fc7192a-9445-4afb-a92c-054d95e8b529
     status: 200 OK
     code: 200
     duration: ""
@@ -511,10 +478,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUmplRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WR040VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkJ5Q205aGFpczNWV3RsTVVWUWFFMXJXWFZHTm13eVZ6ZHNRVFZ5ZVZoTFRXaFlNVEpaZFdsRVdIZ3hibEEzZVZkRU5uSTJkMFl4WjBOVGNYaE1Na2RNTTJnS2Qwb3phRlJ3YUV4SlZWTk9RUzl2TUZabFFVdE9UVVZWVW1ORFUxUnhaM0JEVVdRdmNuY3paVzVpTlZGdVFVWmpaMVZ1WlM5bU1XVXlVSHBFWlRSelR3cDVNR3RuWm1GYU4zZ3pOelZZU0UxaFdVbGxkbTlKU25ORlZEUnJSbFZ4Y0c1MWFXODFVbGxyTmtWc05rb3dlazEwTnpFcmFuSkhTQ3RLTHpZNWJtUlFDbGRKWVdFMWNuUmxjRXhsWldOT0wycGpXbmxaWWpNMlFtMVdhRVZFV25wR09GSlBUalphWmpKelZXWmtkVlpaTjJ0MWVVNVRjbVp0UTBoT2FUUllhVXdLTmtzMVpXeEhNWEU0ZWxwMmNGZGxVV3R0ZGpodE4wc3JaRUpTWmtKeFJsRTFha2Q2YTJ0VGNUZFBZbE5WVWtFd1V6WnZkazVTVFZacmFHbDBkSEJIWndwT1drRm5lRkIzYVdGU1EybEhUVE5RVDJvd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVdtNUNNMjVZTDNkS1VUbEdNSFpvT1dKNGNISkJLMk5JYTFWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlYyUlpkR1o2TWxSWVZHNUNka2N2VFhONk1YZHNVMEZHZEZVM1UyMTVabVFyTnpaWU9XbDJjRzlGTHpoT1QxQkJXZ3BGVEU1bGFYWkNPR3RNWnpsR016SlVSbkpKZUV0cVZGSjVWUzlrUVZaT01WWjVOV1Z0YmtRME9FTkZhWEJrVlZadlRVZzBSMk1yTjBKUFJYVlVhM00yQ2sxeFZYUnRiamRoWWxkT1VUWkJXa3cyWTFkUWNGVmhhRVZPTkhWM2NXWk5OeTlHYjBsWU1XdFpjRmRzUzBoMmRrMWlNVUZuVVhkTmJHcFFObTVMY0VzS1NsbHVUazh2YjJabksyaDZOalpDTUU5U1lucFNURXBxY0dSMFFYUlhiRlpZZDI1RGR6QmtRVmxQVjFkemNVbDRMMWg1YURCS09ESTJTbGxqWW5oeWJncENiM05QVlVWUGJIWjBiWEJqZGpoT1RTODNSV1JrTW1WYVIxQXZNMEo2T0hsUFkwOW5NV1pMTVZkVEt6ZFNhM050VTJ0MFNHMVBkR2hqZVhVemRFOW1DbXB2V1djeWNYSlBWVFZVV25oUGJGbHhOVTlOTjFVM1NubEJSWHBJTjNJeVQyVjJTd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDUxMWI3ZTgtMGY0Yy00NDY3LTkxYTktYTdjNWVjY2VmMDBjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPMmFZenJEZExES0FSQjV3SFNmYmNyNWxJU1dLUGJOT1VXQjhKUjZJbFdyV3ZDY0pwTUlWN1VUdw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2566"
@@ -523,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -533,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc54d880-9385-4a7c-afcc-db43ce08f209
+      - 35980103-1cff-4f30-b546-5ed1d275628a
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:11.708006202Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:24.518197891Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1548"
@@ -558,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:57:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f95440b3-c117-40be-8f2d-0cdae7825d03
+      - 22f06764-fe48-46a4-bbe6-0a616fdb1fe8
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:11.708006Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:24.518198Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1545"
@@ -591,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:12 GMT
+      - Mon, 13 Nov 2023 13:57:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 292b5c1b-6755-435e-a755-8a8562a9c6b6
+      - 998671ec-78e3-492a-b268-03c98d117c12
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.419623Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:25.718116Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1550"
@@ -624,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:17 GMT
+      - Mon, 13 Nov 2023 13:57:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2583bd70-11ca-473f-a702-6b32ac5ac748
+      - 401a89be-3ac8-4fee-bdce-1828c202722a
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.419623Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:25.718116Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1550"
@@ -657,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:17 GMT
+      - Mon, 13 Nov 2023 13:57:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d11cead5-6382-44a6-8d75-aeaa5d9fef41
+      - b76d50ff-1117-432f-a5cd-09a853a1e964
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUmplRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WR040VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkJ5Q205aGFpczNWV3RsTVVWUWFFMXJXWFZHTm13eVZ6ZHNRVFZ5ZVZoTFRXaFlNVEpaZFdsRVdIZ3hibEEzZVZkRU5uSTJkMFl4WjBOVGNYaE1Na2RNTTJnS2Qwb3phRlJ3YUV4SlZWTk9RUzl2TUZabFFVdE9UVVZWVW1ORFUxUnhaM0JEVVdRdmNuY3paVzVpTlZGdVFVWmpaMVZ1WlM5bU1XVXlVSHBFWlRSelR3cDVNR3RuWm1GYU4zZ3pOelZZU0UxaFdVbGxkbTlKU25ORlZEUnJSbFZ4Y0c1MWFXODFVbGxyTmtWc05rb3dlazEwTnpFcmFuSkhTQ3RLTHpZNWJtUlFDbGRKWVdFMWNuUmxjRXhsWldOT0wycGpXbmxaWWpNMlFtMVdhRVZFV25wR09GSlBUalphWmpKelZXWmtkVlpaTjJ0MWVVNVRjbVp0UTBoT2FUUllhVXdLTmtzMVpXeEhNWEU0ZWxwMmNGZGxVV3R0ZGpodE4wc3JaRUpTWmtKeFJsRTFha2Q2YTJ0VGNUZFBZbE5WVWtFd1V6WnZkazVTVFZacmFHbDBkSEJIWndwT1drRm5lRkIzYVdGU1EybEhUVE5RVDJvd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVdtNUNNMjVZTDNkS1VUbEdNSFpvT1dKNGNISkJLMk5JYTFWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlYyUlpkR1o2TWxSWVZHNUNka2N2VFhONk1YZHNVMEZHZEZVM1UyMTVabVFyTnpaWU9XbDJjRzlGTHpoT1QxQkJXZ3BGVEU1bGFYWkNPR3RNWnpsR016SlVSbkpKZUV0cVZGSjVWUzlrUVZaT01WWjVOV1Z0YmtRME9FTkZhWEJrVlZadlRVZzBSMk1yTjBKUFJYVlVhM00yQ2sxeFZYUnRiamRoWWxkT1VUWkJXa3cyWTFkUWNGVmhhRVZPTkhWM2NXWk5OeTlHYjBsWU1XdFpjRmRzUzBoMmRrMWlNVUZuVVhkTmJHcFFObTVMY0VzS1NsbHVUazh2YjJabksyaDZOalpDTUU5U1lucFNURXBxY0dSMFFYUlhiRlpZZDI1RGR6QmtRVmxQVjFkemNVbDRMMWg1YURCS09ESTJTbGxqWW5oeWJncENiM05QVlVWUGJIWjBiWEJqZGpoT1RTODNSV1JrTW1WYVIxQXZNMEo2T0hsUFkwOW5NV1pMTVZkVEt6ZFNhM050VTJ0MFNHMVBkR2hqZVhVemRFOW1DbXB2V1djeWNYSlBWVFZVV25oUGJGbHhOVTlOTjFVM1NubEJSWHBJTjNJeVQyVjJTd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDUxMWI3ZTgtMGY0Yy00NDY3LTkxYTktYTdjNWVjY2VmMDBjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPMmFZenJEZExES0FSQjV3SFNmYmNyNWxJU1dLUGJOT1VXQjhKUjZJbFdyV3ZDY0pwTUlWN1VUdw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2566"
@@ -690,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:18 GMT
+      - Mon, 13 Nov 2023 13:57:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 970cd56d-1d6d-41ca-be77-9308a97b3447
+      - aa67c902-3ec2-4870-af08-dd6212d95d46
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.419623Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:25.718116Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1550"
@@ -723,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:18 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cd3fe39-835c-445a-8adf-277bc2304fd0
+      - 8aae3b64-c1a6-4bf1-a5e6-8bf8ce6dd841
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dadf30db-2843-472e-aef7-c79c0d109bce
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.270416Z","dhcp_enabled":true,"id":"75b19688-d376-414a-ae89-26f0b815d552","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.270416Z","id":"02a99b3d-5321-4d02-a594-6027349e404d","subnet":"172.16.12.0/22","updated_at":"2023-11-10T13:16:56.270416Z"},{"created_at":"2023-11-10T13:16:56.270416Z","id":"065d4a79-b944-4dc2-9d45-5ee25a7e2fdc","subnet":"fd63:256c:45f7:1fdf::/64","updated_at":"2023-11-10T13:16:56.270416Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.270416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:16.266750Z","dhcp_enabled":true,"id":"dadf30db-2843-472e-aef7-c79c0d109bce","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:16.266750Z","id":"ac8861bf-7715-45e7-92d9-478558855535","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:16.266750Z"},{"created_at":"2023-11-13T13:57:16.266750Z","id":"d1a8b3ef-18d2-453f-9cce-336476cfc9d7","subnet":"fd63:256c:45f7:8aa6::/64","updated_at":"2023-11-13T13:57:16.266750Z"}],"tags":[],"updated_at":"2023-11-13T13:57:16.266750Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "710"
@@ -756,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:18 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82c5446d-7dc6-446b-90e9-1d85e222f8e3
+      - a4275805-ce52-4416-ae71-5455b8d3179b
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.419623Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:25.718116Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1550"
@@ -789,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:18 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cb4f0a3-30d6-4896-bfcf-3917ca8ce3ed
+      - cb0492a2-a546-4195-9be3-fd731c12b313
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpkMDVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR04zVGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTa2hoQ2pKa2MxZzNhbk12WVRaR2JsaFdhU3MwYkRZcmVVMXBZMmhFZFZvd1ZHaFVVRnBSTW5SU055dHJZM0U0WmtsaU1FcE9VeTlLVTJaNlRHZFZiMVpxU25jS1pHTmtLMGR6VDFGd01GSTROMFpxVnpkbVJFTlljMVp2Um1WaFNFdGliM3B6TkVKdFQyOXlkRFJ2U2xSTFVqZzVPR0o2Y3k5MlZpdG1lVk5hTTAxQ0t3cFJhV3M1WkdaUmJFSlpOM053UlZWS2FWWXdUbEJKWnpOallWcDZPR1l2UTB3eFZrSjRZMXBwTkZSNFpuWmpTbnBpUVZsdVpucEROREJPVUZSTVN5dDFDbkJMWXk5RFVFNTFjMDU0VEVkWFRESXdWV2xtWWsxTVluQkZPWFl5WTNSM2FqWnJOVmxYZG5GWU9IbFpSMWNyWWtKa056Rm1UM0ZKZUVvNWFsaFVaV3dLUjIxMVNYWmhVemxaWTJzNFlsYzRaRTF4ZFZobVVFSnNWM0JFYVVOVlYyUjRWalJWZDNoR2NFbFVaRXRIUmxoeFZ6VkVTekpuT1RaMU1EWm5UMEZvWXdwelJXOVhSakJDTmxaa1JraHlZMWhTYWpKelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSlJtbG5ia0pPYkRkbFdsZzVORzVIWmxNNFF6Uk5OamREYmxOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlEwaGtNMFZLVVZvelJEWm1UVFkyY0hCYU0wVkxPSGRvVmxaaVJ6WXdlazE1TWsxWVNtTkRPVk5UYlZCRk5rOVVSZ3BsV0dkTFpGcGtOa281ZDNjNU9WVnRWak56YTFoYVQyRlBVbk12VTNCNU1qVk1WMWRDYURsQlJVUlJOVGxWY3l0bmNXVllTbXBTY0V4NU0wdzVURXQxQ2xjd09XUmliVmcwTVZCaWFrWXhTV1JxTVZWdU1pdFpVbnBPY0VkTVJYSlRkRXhzYlVGRmMxcE1jaXRvVHpGa1pWQnpkMlozTVROM01GaDVZMmRPZG5BS1drNWhVbTl5UzJjeVRYUk1lbXBIU0ZGVk9FZElTWFIyV1hZeE1scG5VbUpMVUVacVdubFFRMmc1VWk5ME1HWmlhVnA2TWk5MWFreGpTa05tYW5wb1VBcHJURTlFT1daWFkwSkhTR04zYTNndlZFZEdWekZ6YVRaU05WTnNNVnBTUkV4TVRubFpXRUZYT0c5NFdFeHJWellyVjJ0d1pWTjVNekpPUzJadVJGZ3ZDa0ZHYWxCRFRXVjVOVE16Y25GamN5dHZaa2RPZUdGVWQwODJMMHBGWVhscllsTkRad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzZiNDU3ZmYtOGY5OC00YzBjLWI2MzQtOTdkOTMzYmI3MjMxLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHMHdLSFhwYlpVU1dRWHZmSGFoeXRwTTIzYTlVR0RDd1NhWk1yRmlIUVpDRUNmdjk0Tk1NVFlSNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUmplRTlXYjFoRVZFMTZUVlJGZUUxcVJYcE9WR040VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVkJ5Q205aGFpczNWV3RsTVVWUWFFMXJXWFZHTm13eVZ6ZHNRVFZ5ZVZoTFRXaFlNVEpaZFdsRVdIZ3hibEEzZVZkRU5uSTJkMFl4WjBOVGNYaE1Na2RNTTJnS2Qwb3phRlJ3YUV4SlZWTk9RUzl2TUZabFFVdE9UVVZWVW1ORFUxUnhaM0JEVVdRdmNuY3paVzVpTlZGdVFVWmpaMVZ1WlM5bU1XVXlVSHBFWlRSelR3cDVNR3RuWm1GYU4zZ3pOelZZU0UxaFdVbGxkbTlKU25ORlZEUnJSbFZ4Y0c1MWFXODFVbGxyTmtWc05rb3dlazEwTnpFcmFuSkhTQ3RLTHpZNWJtUlFDbGRKWVdFMWNuUmxjRXhsWldOT0wycGpXbmxaWWpNMlFtMVdhRVZFV25wR09GSlBUalphWmpKelZXWmtkVlpaTjJ0MWVVNVRjbVp0UTBoT2FUUllhVXdLTmtzMVpXeEhNWEU0ZWxwMmNGZGxVV3R0ZGpodE4wc3JaRUpTWmtKeFJsRTFha2Q2YTJ0VGNUZFBZbE5WVWtFd1V6WnZkazVTVFZacmFHbDBkSEJIWndwT1drRm5lRkIzYVdGU1EybEhUVE5RVDJvd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRVdtNUNNMjVZTDNkS1VUbEdNSFpvT1dKNGNISkJLMk5JYTFWTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlYyUlpkR1o2TWxSWVZHNUNka2N2VFhONk1YZHNVMEZHZEZVM1UyMTVabVFyTnpaWU9XbDJjRzlGTHpoT1QxQkJXZ3BGVEU1bGFYWkNPR3RNWnpsR016SlVSbkpKZUV0cVZGSjVWUzlrUVZaT01WWjVOV1Z0YmtRME9FTkZhWEJrVlZadlRVZzBSMk1yTjBKUFJYVlVhM00yQ2sxeFZYUnRiamRoWWxkT1VUWkJXa3cyWTFkUWNGVmhhRVZPTkhWM2NXWk5OeTlHYjBsWU1XdFpjRmRzUzBoMmRrMWlNVUZuVVhkTmJHcFFObTVMY0VzS1NsbHVUazh2YjJabksyaDZOalpDTUU5U1lucFNURXBxY0dSMFFYUlhiRlpZZDI1RGR6QmtRVmxQVjFkemNVbDRMMWg1YURCS09ESTJTbGxqWW5oeWJncENiM05QVlVWUGJIWjBiWEJqZGpoT1RTODNSV1JrTW1WYVIxQXZNMEo2T0hsUFkwOW5NV1pMTVZkVEt6ZFNhM050VTJ0MFNHMVBkR2hqZVhVemRFOW1DbXB2V1djeWNYSlBWVFZVV25oUGJGbHhOVTlOTjFVM1NubEJSWHBJTjNJeVQyVjJTd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDUxMWI3ZTgtMGY0Yy00NDY3LTkxYTktYTdjNWVjY2VmMDBjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPMmFZenJEZExES0FSQjV3SFNmYmNyNWxJU1dLUGJOT1VXQjhKUjZJbFdyV3ZDY0pwTUlWN1VUdw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2566"
@@ -822,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:19 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41c301fd-37e2-4c15-99c4-5873008191b4
+      - 69537163-e4bf-4d19-87e1-b68144076ac2
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:19.899108689Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:31.311882461Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1548"
@@ -855,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:57:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 565e03d5-7c9c-450d-b2e8-00075843d6f8
+      - b5480b15-07fc-4cb7-a004-c5cd4f4f91d6
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:19.899109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:31.311882Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1545"
@@ -888,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:57:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10e8a8c1-691a-471a-9434-c9410854b6d7
+      - 15240bf2-8125-4ec3-9d06-4b3e48b8815b
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://36b457ff-8f98-4c0c-b634-97d933bb7231.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.492335Z","created_at":"2023-11-10T13:16:58.492335Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.36b457ff-8f98-4c0c-b634-97d933bb7231.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"36b457ff-8f98-4c0c-b634-97d933bb7231","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"75b19688-d376-414a-ae89-26f0b815d552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-10T13:17:19.899109Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4511b7e8-0f4c-4467-91a9-a7c5eccef00c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:17.428958Z","created_at":"2023-11-13T13:57:17.428958Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4511b7e8-0f4c-4467-91a9-a7c5eccef00c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dadf30db-2843-472e-aef7-c79c0d109bce","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-13T13:57:31.311882Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1545"
@@ -921,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:25 GMT
+      - Mon, 13 Nov 2023 13:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67418668-edaa-4cf4-af7f-25448c5ae7e8
+      - 053a8cf8-4e5a-48d9-a422-dbbf676b8165
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"36b457ff-8f98-4c0c-b634-97d933bb7231","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -954,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:30 GMT
+      - Mon, 13 Nov 2023 13:57:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abc57616-21e4-4252-961c-a0e2540866b6
+      - 45e82601-4d40-4dfa-ad0c-25ab3a4e44be
     status: 404 Not Found
     code: 404
     duration: ""
@@ -975,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dadf30db-2843-472e-aef7-c79c0d109bce
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"75b19688-d376-414a-ae89-26f0b815d552","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"dadf30db-2843-472e-aef7-c79c0d109bce","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -987,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:30 GMT
+      - Mon, 13 Nov 2023 13:57:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b66c5fdf-0675-46dd-98a2-38cfed3541f3
+      - 74b39d69-d6c3-4589-bc7a-b0fb023fcfa0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1008,43 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/75b19688-d376-414a-ae89-26f0b815d552
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4511b7e8-0f4c-4467-91a9-a7c5eccef00c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"75b19688-d376-414a-ae89-26f0b815d552","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b34ef129-06a7-48e0-8bac-b4cebc465811
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/36b457ff-8f98-4c0c-b634-97d933bb7231
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"36b457ff-8f98-4c0c-b634-97d933bb7231","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4511b7e8-0f4c-4467-91a9-a7c5eccef00c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1053,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:30 GMT
+      - Mon, 13 Nov 2023 13:57:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +997,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c15761ce-1f51-448a-a934-aae30cd189ec
+      - 6a8dd3d8-27b7-4293-82bc-268cd44ff51a
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dadf30db-2843-472e-aef7-c79c0d109bce
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"dadf30db-2843-472e-aef7-c79c0d109bce","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f240fb3e-45aa-4574-aed8-06639f474977
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-basic.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:17 GMT
+      - Mon, 13 Nov 2023 14:03:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e0562de-3bb3-43d9-b98b-79477751cf98
+      - 1c894128-db10-4807-9a16-7e708364af63
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:03:53.790183Z","dhcp_enabled":true,"id":"94774739-2f9f-4f34-8d2c-d537441e63b2","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:03:53.790183Z","id":"38026d64-6d2e-41e6-bd22-09f7e16be9fa","subnet":"172.16.32.0/22","updated_at":"2023-11-13T14:03:53.790183Z"},{"created_at":"2023-11-13T14:03:53.790183Z","id":"8cb23878-11bd-438d-b928-97b7bb1f4732","subnet":"fd63:256c:45f7:2a19::/64","updated_at":"2023-11-13T14:03:53.790183Z"}],"tags":[],"updated_at":"2023-11-13T14:03:53.790183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:18 GMT
+      - Mon, 13 Nov 2023 14:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b314080a-47b8-41c9-bbf6-bf23c29fde4f
+      - 818cc06c-ec5b-4edd-9efc-e7a286c4206d
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/94774739-2f9f-4f34-8d2c-d537441e63b2
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:03:53.790183Z","dhcp_enabled":true,"id":"94774739-2f9f-4f34-8d2c-d537441e63b2","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:03:53.790183Z","id":"38026d64-6d2e-41e6-bd22-09f7e16be9fa","subnet":"172.16.32.0/22","updated_at":"2023-11-13T14:03:53.790183Z"},{"created_at":"2023-11-13T14:03:53.790183Z","id":"8cb23878-11bd-438d-b928-97b7bb1f4732","subnet":"fd63:256c:45f7:2a19::/64","updated_at":"2023-11-13T14:03:53.790183Z"}],"tags":[],"updated_at":"2023-11-13T14:03:53.790183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:19 GMT
+      - Mon, 13 Nov 2023 14:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ce36cd6-51c9-4aaa-8ba2-32d4c1823fb4
+      - 642d0da8-41ba-432c-a208-e3470da3b57a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667384Z","created_at":"2023-11-10T13:53:19.364667384Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:19.376319005Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977894979Z","created_at":"2023-11-13T14:04:02.977894979Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:04:02.997883984Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1509"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:19 GMT
+      - Mon, 13 Nov 2023 14:04:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44a7531b-a267-476c-8419-381147aba260
+      - 4c352026-5edb-4e9e-9ac2-04d335a842e5
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:19.376319Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:04:02.997884Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:19 GMT
+      - Mon, 13 Nov 2023 14:04:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 949cb28c-a0a1-4f95-8c94-8a597ca6f61d
+      - b855d19c-0cdf-4f69-851b-47034ddec560
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:20.815633Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:04:04.699204Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1505"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:24 GMT
+      - Mon, 13 Nov 2023 14:04:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db1edc51-03b9-4e82-b710-83573322fd0e
+      - 6f5d8756-af14-49a6-9d0a-67412074490b
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:20.815633Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:04:04.699204Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1505"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:24 GMT
+      - Mon, 13 Nov 2023 14:04:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d358e946-cb5a-4e33-850b-d418a93d9f4d
+      - c78372e7-f68d-477a-a93e-bcf2e292dec0
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSUmQwNUdiMWhFVkUxNlRWUkZlRTFxUlRCTlJGRjNUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRpdG9Da1JtV1hWRE1WTnRkME5ZWlRCeWVGRjZNRWREYWxCd1ZWRlplRlJ4WTBka1lYVjZhSE0yT1RCVlkzWnpabWRUVDJsdGJHVkRjbmRVVm5aS1pYTklURlFLY21GclpFa3JkRTVQWmtOMlkzQnFNbVZQUkZSUFlXNVZjVzFvYjBJNVQzcGtVbnBwZGxaaGJUTTJhMkZJYjFGeU1HRlZjbXhaTUZvdllTOURLMDkzYWdwa1VscDFUMEpFVmpBdmVsWklVR2haV0hwbWFYSlNVR0pJTHpOWlJrMU5ia0ZpZFRRMGJHNTVSRFJGTUVscVZXWm1kSHBKTDJ4VVZXZFpOV1pTVkRrMENtNUpSR3d4V1UwMVEyOW5SVkpuVVVOdmRXY3lia1EwWTFCUVpFcEZRa3BIVDNOellWaFpkM3B1UVVKc1NWUXpURnBrU1N0MWVpOXFTSGhyVHpWcmVWWUthWGRPUTFNeGFVdzJUR0UwVHpsWVdWSXZiSGxTWkRSbFMxRTNPV1J3ZGtOQ1NHUndlRzVGUXpKR2FYRXdNRGNyZVZkbmRtUXJaV3c0T1VNcldXSnZXUXBXVHpoMWJ6TnNSRTAxWlZCellUaFVPRkJWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRTlZwVFJ6SnpNVTh4V1N0MVMzWnpXRkJMUVZrM1ZtWllORUpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYlU5R05HUkRieTlWU2tWR2RubGFUVzlLVmt4TFRraGlWemh0VTFwdmJqRk5kRWN5Y0V4c01UQnNUVm81VkdwRE1ncE1jV2RsTWpkNlRYUmtPSEZ1U1M5U2VUbG9UekJrWTJkWU9ETm1jMVV5YlZaNGRHb3dZamxYVURGMGFrdzBTbkJ4ZFVGblNFODBhbVZzZG1WV1kyZGpDbFZNV1ZabmVGUmFLMVEzTlZGTlluZHVjRmREVHpRdllXUklaaXRzVEZGUmNVZFNLMFJpWnl0NlUyTTBObGx4WlZOQkwydFVOemx3ZFcxa1MyRmxVRkFLVTB4elpWZENUVGxaWW1WYU1FSmtTSHBCV0c1bVFYSlZXVEpXZW10d1Fua3JZemRTYjB4Q2IyWmhVR015VFhWRWFXOUNibnBYWlc0NVEyOVZLMWhYVEFwUGFpdERXbVJWU0hkclMyZzNTR3A1U2pSd2RXZDRRMFUwZHpKVWJ5dE1SR1Z4UVU5UlVtbFNhVEJ4ZGtGNlNIZ3ZWRVpvYlV4Q1R6VlVUV1o1TlhFMkNrRlhVbkJ0WkdNeFNXVjBkbVpYWTNaalNEVkVhRkJOV0VNcmVEQlhhazU0YlVWTmNnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82OTk4NTY5NS0wNmM3LTQ2NGEtODMzYy0zZDM5NjVjYWZhYTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYYll5dk9xWEdZclJ2NmdFTHViRG82ZVo3UkF6VUY1MTNMdFBwTkhMeHpsNkZQZEdGc3owcGdKag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:24 GMT
+      - Mon, 13 Nov 2023 14:04:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0e89944-06f5-4db1-bfcb-767507cad3b5
+      - 2db4ca99-cf6d-44c5-aa1b-19d6398695ed
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:53:20.815633Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:04:04.699204Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1505"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:24 GMT
+      - Mon, 13 Nov 2023 14:04:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99af0b99-4d90-4e96-8a16-8c0a3174d070
+      - 0a56a236-ce80-4dc2-b1ef-4ff2975a908a
     status: 200 OK
     code: 200
     duration: ""
@@ -315,10 +315,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910159Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720483Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "681"
@@ -327,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:25 GMT
+      - Mon, 13 Nov 2023 14:04:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56dfcb50-7acd-4c10-9137-46fdd9d380c6
+      - f2d156e0-aaa9-42c5-b7af-a2df69b31095
     status: 200 OK
     code: 200
     duration: ""
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -360,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:25 GMT
+      - Mon, 13 Nov 2023 14:04:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4832da43-3aa8-474f-b335-4e54d7ef8645
+      - 0457209d-2f55-49d3-87e3-c3fed66d519b
     status: 200 OK
     code: 200
     duration: ""
@@ -381,10 +381,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -393,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:30 GMT
+      - Mon, 13 Nov 2023 14:04:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d92c32ac-f4c6-42ad-814d-7f410fdc3af8
+      - 243e4c93-60a7-4116-8ec7-8d804ae78b2e
     status: 200 OK
     code: 200
     duration: ""
@@ -414,10 +414,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -426,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:35 GMT
+      - Mon, 13 Nov 2023 14:04:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - beaf30b5-2389-4832-8de2-48130e5fff42
+      - 04510260-aac1-4fd4-8dc5-5a456ad76cf2
     status: 200 OK
     code: 200
     duration: ""
@@ -447,10 +447,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -459,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:40 GMT
+      - Mon, 13 Nov 2023 14:04:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdf7fd96-d1a3-4fe6-a273-1898b4ed3ebe
+      - 78dc48c9-0d78-491e-9ca0-4d7fd108dcd2
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -492,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:45 GMT
+      - Mon, 13 Nov 2023 14:04:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0582dd31-42ab-4b23-b7a0-4976250a31ab
+      - 7da7734d-7a8b-49a1-9e32-1025b4c716ed
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:50 GMT
+      - Mon, 13 Nov 2023 14:04:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5278eab3-f18f-4bb4-beb1-bcd8624e08e6
+      - ea57b71f-9c91-4908-ac64-b4824c6dc81c
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:53:55 GMT
+      - Mon, 13 Nov 2023 14:04:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68480433-84de-452e-a842-fa414fb4e30e
+      - 3c7fcdf4-af01-46d5-a345-c988edb8cded
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -591,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:00 GMT
+      - Mon, 13 Nov 2023 14:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 820be7be-6788-4d26-a385-316637bb24c8
+      - 8db586f4-e3ee-4106-b673-9f0a0f43b7e3
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:05 GMT
+      - Mon, 13 Nov 2023 14:04:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1a50d6d-5777-410a-a2ba-9ccf6ee6baad
+      - d1fbf654-9b18-4db2-888c-ab9de81690c2
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:10 GMT
+      - Mon, 13 Nov 2023 14:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87216dbc-4396-4c75-8d4f-e9b844480177
+      - 7ef4258d-03c2-40ef-8f47-de7829ad8b9e
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:15 GMT
+      - Mon, 13 Nov 2023 14:04:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7175a3d-6b83-41a5-8918-7aee44a3a11d
+      - 993fa765-7536-4799-b421-fb281531a203
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:20 GMT
+      - Mon, 13 Nov 2023 14:05:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0335f989-71a9-445d-bb73-e2b3e36f72df
+      - 7bbff841-f9bf-4088-94b6-a70887858686
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:25 GMT
+      - Mon, 13 Nov 2023 14:05:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4d3d888-10b1-4236-9cc0-6d86a1f9dac3
+      - eae65c80-27a2-4a33-abef-450f067d1c1f
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:30 GMT
+      - Mon, 13 Nov 2023 14:05:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ebed78c-30d9-4037-934f-943589fcaee3
+      - 9734e0ab-20eb-45d6-a374-f1aaab8e4f21
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:35 GMT
+      - Mon, 13 Nov 2023 14:05:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27825292-d076-4952-93c6-a58c7999c420
+      - 871d62b2-afd2-44ac-b81d-b67e2d7105ca
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:40 GMT
+      - Mon, 13 Nov 2023 14:05:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8a506e7-a617-437b-a551-6470a3f9e61c
+      - c8bdb496-c90d-4f62-9056-8ac2d140f4bf
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:45 GMT
+      - Mon, 13 Nov 2023 14:05:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df7f509c-820f-4a39-a24c-cd7d3672c548
+      - c8ea2241-0ffb-4280-baec-e58d92772d2a
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:51 GMT
+      - Mon, 13 Nov 2023 14:05:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bd215f9-cf50-45f8-a6ac-d5a6ecbb322d
+      - efaf597d-3770-44ae-9637-254d3a2cb445
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:54:56 GMT
+      - Mon, 13 Nov 2023 14:05:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 791f09ca-ea00-4eb9-abc2-b4e223b6c8ff
+      - 60b3e7ef-3979-4c02-8a30-746fb9c351b2
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:01 GMT
+      - Mon, 13 Nov 2023 14:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70f9ee08-5d47-4f93-9554-a96eadf7be45
+      - a4c085f5-bdc5-47b7-87b8-7a1e0f1b980e
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1020,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:06 GMT
+      - Mon, 13 Nov 2023 14:05:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38d04b14-8bfa-4153-89d8-c3cbd1ae0d58
+      - 4119f00d-3410-4c0e-810b-1f68aaeb1f72
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1053,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:11 GMT
+      - Mon, 13 Nov 2023 14:05:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e416376f-729c-472e-b7de-592e017be395
+      - f5c3f67e-c34d-42d1-a491-001a8bbc1d80
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1086,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:16 GMT
+      - Mon, 13 Nov 2023 14:06:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e79749fd-0a2a-4429-9a41-18857f4dfe10
+      - a3635b65-885d-4067-87da-920ec1c4fd2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1119,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:21 GMT
+      - Mon, 13 Nov 2023 14:06:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd67142f-f373-45cd-88b3-b61bf8664049
+      - 179e2eee-3920-4482-9af7-0a25b76672ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1152,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:26 GMT
+      - Mon, 13 Nov 2023 14:06:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbf6261b-7ed5-4a41-bc04-cb15f1a1ff01
+      - 46761e87-6b7e-4b82-8c8c-0e9c4ec0c6a7
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1185,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:31 GMT
+      - Mon, 13 Nov 2023 14:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0db538b-b380-4b37-83ce-366b8888daa6
+      - ce461ea6-3bab-4f66-964c-b278b2068839
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1218,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:37 GMT
+      - Mon, 13 Nov 2023 14:06:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df676c69-d45f-4222-a65f-06d4757b92c4
+      - 02e30df9-9379-4edb-a6d6-408152c47743
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1251,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:42 GMT
+      - Mon, 13 Nov 2023 14:06:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe86561d-d8d5-45f4-9c07-1428be80e716
+      - 7d10df4a-c88e-4be6-be62-7098cbf8fa7a
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:47 GMT
+      - Mon, 13 Nov 2023 14:06:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30c1258a-88a3-4fb7-ac64-f7441e9eaf69
+      - 095dbfef-d08a-446a-a095-bfe0f3ca8b39
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1317,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:52 GMT
+      - Mon, 13 Nov 2023 14:06:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99a9cf27-4e86-41bb-ac6e-615d9e67ceb8
+      - 45961c1a-ec70-478b-81b4-ecdbd867697f
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1350,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:55:57 GMT
+      - Mon, 13 Nov 2023 14:06:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22185d57-2fe4-4537-b7ad-37bc157a590a
+      - ee5a8a67-f229-44ed-bae5-69df93c23a6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1383,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:02 GMT
+      - Mon, 13 Nov 2023 14:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b709a2d2-5f15-4d97-aa09-d2912f562d69
+      - fba68daa-ce95-41e4-b7e8-20a0ee9adc03
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1416,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:07 GMT
+      - Mon, 13 Nov 2023 14:06:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edbe1229-e32c-4df9-911c-b83d405950f3
+      - eaad233a-fdbc-4fb7-86e1-5f50e3dbc82c
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1449,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:12 GMT
+      - Mon, 13 Nov 2023 14:06:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb3211c8-c169-40cf-a491-670f362f2fc3
+      - aff549f5-c8b2-459c-b924-e18e03a3e480
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1482,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:17 GMT
+      - Mon, 13 Nov 2023 14:07:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6eba8e19-e1c4-40ee-bf9c-34151ac84852
+      - d02e3158-f0b7-404e-bf9c-f78ce5581543
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1515,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:22 GMT
+      - Mon, 13 Nov 2023 14:07:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73202415-27d1-4e3d-a150-80680c12baaa
+      - 5e5ecb72-8f64-4c65-bff4-0725b793d16a
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1548,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:28 GMT
+      - Mon, 13 Nov 2023 14:07:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de76df04-56c4-46fa-abed-560cd87c7189
+      - f3eb68d5-3aa6-4a44-96f0-2e8ae4368580
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1581,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:33 GMT
+      - Mon, 13 Nov 2023 14:07:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3eeb0a3c-6266-4e4f-a793-09fa52e3b56b
+      - 051ac4b9-6ba8-4d23-8660-51703c604704
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1614,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:38 GMT
+      - Mon, 13 Nov 2023 14:07:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6d53f91-d95b-47f0-b504-6a63bfc5176b
+      - c2361441-3d52-4167-924c-eba7cb74d13e
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1647,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:43 GMT
+      - Mon, 13 Nov 2023 14:07:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f808fe1-1b4f-43e0-baba-a9281b989df2
+      - dbd37742-f76b-493a-8387-4f962d190591
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1680,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:48 GMT
+      - Mon, 13 Nov 2023 14:07:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f335fc4-b1a7-4109-a1bd-eee00c8c699a
+      - ed9f7fc4-d170-4f77-bf58-9cba2b21f948
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1713,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:54 GMT
+      - Mon, 13 Nov 2023 14:07:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6250f6e9-1267-424e-ac43-9b43395afe28
+      - 644dddf3-4831-4270-84c1-3394286f1a82
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1746,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:56:59 GMT
+      - Mon, 13 Nov 2023 14:07:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4d2a682-df13-4fad-b496-7fc0496806b4
+      - 99877c3d-6bb8-4f9f-ae2d-b9fe53c18763
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1779,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:04 GMT
+      - Mon, 13 Nov 2023 14:07:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0de28af9-a435-4343-b10e-f3a29bbaa22b
+      - 02c80ca0-9833-4b2e-b930-8f5b5735716a
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1812,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:09 GMT
+      - Mon, 13 Nov 2023 14:07:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94c368dc-1699-4e19-b232-db4b8ee341f8
+      - 324e6a2b-aa25-41c2-afb3-ab789ee17f6e
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1845,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:14 GMT
+      - Mon, 13 Nov 2023 14:07:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d268c6c5-1e3e-4b7a-8b80-53cfce30333d
+      - fe673bf9-ad0b-4e93-a1ea-ec452daf82cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1878,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:19 GMT
+      - Mon, 13 Nov 2023 14:08:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd5db71a-2d98-4a87-8400-1930e4911274
+      - 61b6fe9f-64f5-4982-88ca-9f185242a603
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1911,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:24 GMT
+      - Mon, 13 Nov 2023 14:08:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9367c3c5-b0a2-4e5e-992c-3bfeef53c527
+      - af83417b-69ca-45b9-9697-cb281293d1a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1944,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:29 GMT
+      - Mon, 13 Nov 2023 14:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb83b3e2-51c9-491e-b3a5-fe697c31299d
+      - ce7f18d6-7f29-4e1f-92f8-c9c7f5da8ed0
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -1977,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:35 GMT
+      - Mon, 13 Nov 2023 14:08:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 674630f5-f4f3-4ca2-8cd8-fff408dcca7a
+      - 1497d641-14e6-43b3-bc84-e3db7cb40531
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -2010,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:40 GMT
+      - Mon, 13 Nov 2023 14:08:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45e88f48-1491-40d1-94dc-2321a73eee3b
+      - 9335077e-7054-4f6c-853d-3336a036630a
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -2043,7 +2043,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:45 GMT
+      - Mon, 13 Nov 2023 14:08:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59039427-7c20-4616-8d79-4e117afe6ea7
+      - 5a2d08d4-c2bb-4284-a19b-a490b9569237
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,10 +2064,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:53:24.816910Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -2076,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:50 GMT
+      - Mon, 13 Nov 2023 14:08:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64ed7c7f-692b-47b6-84c1-b4a09dd4b4b2
+      - 91a92da2-889d-42f7-85cd-63087c2b5c80
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,10 +2097,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "678"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a0d2c38-f008-4bc1-ad36-3dd018e7cb7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:04:08.620720Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "678"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6632915f-1930-4405-9deb-ee301cba0b6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "676"
@@ -2109,7 +2175,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:55 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdce6f44-b992-46bf-9334-c8aedf7a9bd0
+      - 9babb750-4f7f-4955-8215-32c273faa438
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,10 +2196,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -2142,7 +2208,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:55 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 059ea1c0-5810-41b3-a346-8b61b0b87e3b
+      - 66de6ea3-adf6-4a4f-8caf-75a310d437c1
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,10 +2229,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "676"
@@ -2175,7 +2241,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:55 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce59da59-e75a-4a8e-8cef-051a3b10776e
+      - 8eee218e-4035-4b22-bc35-2688599b711c
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:57:50.671884Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:08:48.018318Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:55 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78ca7618-efbd-4613-bfe8-08ede38f9889
+      - aec3e8f6-7407-4158-94ab-6a1658b7b519
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,10 +2295,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -2241,7 +2307,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:55 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0158707c-e895-43d2-bcf1-5114ecb60395
+      - f0eae52d-242d-430e-8bfd-79e4a2018eba
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,10 +2328,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "676"
@@ -2274,7 +2340,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:55 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf9a2883-1ba6-4a13-bb82-e0418ab725d2
+      - 1e82f101-3f5e-4f5b-9c80-a27b4b8ed8df
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2361,80 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:08:48.018318Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "658"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd782f87-e67f-40f1-8526-e04b3532756e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5290ccc5-bdec-4b47-b79a-123f4a8ef928
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-13T14:06:16.374422+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-pool-minimal-test-pool-minimal-74fccf","id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:4754:201::1","gateway":"2001:bc8:4754:201::","netmask":"64"},"location":{"cluster_id":"6","hypervisor_id":"201","node_id":"2","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2d:51:37","maintenances":[],"modification_date":"2023-11-13T14:06:33.031322+00:00","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.12.178.131","private_nics":[{"creation_date":"2023-11-13T14:06:17.095910+00:00","id":"d016aa45-64a2-4808-8d5b-dce86d659105","mac_address":"02:00:00:14:bd:a6","modification_date":"2023-11-13T14:06:18.027408+00:00","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","server_id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.158.79.120","dynamic":true,"family":"inet","gateway":null,"id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.79.120","dynamic":true,"family":"inet","gateway":null,"id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"0faeb0d5-b545-40e4-a78d-4744d30c1548","name":"kubernetes
+      69985695-06c7-464a-833c-3d3965cafaa9"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=69985695-06c7-464a-833c-3d3965cafaa9","pool=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","pool-name=test-pool-minimal","runtime=containerd","managed=true","terraform-test","scaleway_k8s_cluster","default","node=74fccfea-180b-4591-8619-7825e8a1b485"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-13T14:06:16.374422+00:00","export_uri":null,"id":"5cba8c86-a940-4811-a912-8d2071e8519b","modification_date":"2023-11-13T14:06:16.374422+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","name":"scw-test-pool-minimal-test-pool-minimal-74fccf"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "4018"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee0d7518-f330-44c5-b2b1-13c725d30f16
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/94774739-2f9f-4f34-8d2c-d537441e63b2
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-13T14:03:53.790183Z","dhcp_enabled":true,"id":"94774739-2f9f-4f34-8d2c-d537441e63b2","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:03:53.790183Z","id":"38026d64-6d2e-41e6-bd22-09f7e16be9fa","subnet":"172.16.32.0/22","updated_at":"2023-11-13T14:03:53.790183Z"},{"created_at":"2023-11-13T14:03:53.790183Z","id":"8cb23878-11bd-438d-b928-97b7bb1f4732","subnet":"fd63:256c:45f7:2a19::/64","updated_at":"2023-11-13T14:03:53.790183Z"}],"tags":[],"updated_at":"2023-11-13T14:03:53.790183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -2307,7 +2443,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:56 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd90b977-cd0d-4f00-ac87-db5247cf904d
+      - 2fb75cb3-c7da-43fb-9bb0-bab88a32f334
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,10 +2464,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -2340,7 +2476,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:56 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4a299ec-452c-4f69-b939-472177aca652
+      - 1d703572-fa47-42ff-b3d9-330a8514061d
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,10 +2497,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSUmQwNUdiMWhFVkUxNlRWUkZlRTFxUlRCTlJGRjNUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRpdG9Da1JtV1hWRE1WTnRkME5ZWlRCeWVGRjZNRWREYWxCd1ZWRlplRlJ4WTBka1lYVjZhSE0yT1RCVlkzWnpabWRUVDJsdGJHVkRjbmRVVm5aS1pYTklURlFLY21GclpFa3JkRTVQWmtOMlkzQnFNbVZQUkZSUFlXNVZjVzFvYjBJNVQzcGtVbnBwZGxaaGJUTTJhMkZJYjFGeU1HRlZjbXhaTUZvdllTOURLMDkzYWdwa1VscDFUMEpFVmpBdmVsWklVR2haV0hwbWFYSlNVR0pJTHpOWlJrMU5ia0ZpZFRRMGJHNTVSRFJGTUVscVZXWm1kSHBKTDJ4VVZXZFpOV1pTVkRrMENtNUpSR3d4V1UwMVEyOW5SVkpuVVVOdmRXY3lia1EwWTFCUVpFcEZRa3BIVDNOellWaFpkM3B1UVVKc1NWUXpURnBrU1N0MWVpOXFTSGhyVHpWcmVWWUthWGRPUTFNeGFVdzJUR0UwVHpsWVdWSXZiSGxTWkRSbFMxRTNPV1J3ZGtOQ1NHUndlRzVGUXpKR2FYRXdNRGNyZVZkbmRtUXJaV3c0T1VNcldXSnZXUXBXVHpoMWJ6TnNSRTAxWlZCellUaFVPRkJWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRTlZwVFJ6SnpNVTh4V1N0MVMzWnpXRkJMUVZrM1ZtWllORUpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYlU5R05HUkRieTlWU2tWR2RubGFUVzlLVmt4TFRraGlWemh0VTFwdmJqRk5kRWN5Y0V4c01UQnNUVm81VkdwRE1ncE1jV2RsTWpkNlRYUmtPSEZ1U1M5U2VUbG9UekJrWTJkWU9ETm1jMVV5YlZaNGRHb3dZamxYVURGMGFrdzBTbkJ4ZFVGblNFODBhbVZzZG1WV1kyZGpDbFZNV1ZabmVGUmFLMVEzTlZGTlluZHVjRmREVHpRdllXUklaaXRzVEZGUmNVZFNLMFJpWnl0NlUyTTBObGx4WlZOQkwydFVOemx3ZFcxa1MyRmxVRkFLVTB4elpWZENUVGxaWW1WYU1FSmtTSHBCV0c1bVFYSlZXVEpXZW10d1Fua3JZemRTYjB4Q2IyWmhVR015VFhWRWFXOUNibnBYWlc0NVEyOVZLMWhYVEFwUGFpdERXbVJWU0hkclMyZzNTR3A1U2pSd2RXZDRRMFUwZHpKVWJ5dE1SR1Z4UVU5UlVtbFNhVEJ4ZGtGNlNIZ3ZWRVpvYlV4Q1R6VlVUV1o1TlhFMkNrRlhVbkJ0WkdNeFNXVjBkbVpYWTNaalNEVkVhRkJOV0VNcmVEQlhhazU0YlVWTmNnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82OTk4NTY5NS0wNmM3LTQ2NGEtODMzYy0zZDM5NjVjYWZhYTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYYll5dk9xWEdZclJ2NmdFTHViRG82ZVo3UkF6VUY1MTNMdFBwTkhMeHpsNkZQZEdGc3owcGdKag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2373,7 +2509,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:56 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 136b6bc8-1cf4-4195-a182-e860d3421c0f
+      - 65433c6d-1e36-4c47-96ae-bc6f773edb7a
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,10 +2530,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "676"
@@ -2406,7 +2542,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:56 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f13eeea0-171b-42b9-92d7-c3ace9122e54
+      - 085efb93-7beb-45b4-8d8d-056ec0786bcc
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2563,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:57:50.671884Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:08:48.018318Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:56 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9fd42f8-1e26-406f-a4a2-bfc183d9ec05
+      - 5c182fd1-6ecf-49da-989a-f6553ca067b8
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,10 +2596,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/94774739-2f9f-4f34-8d2c-d537441e63b2
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:03:53.790183Z","dhcp_enabled":true,"id":"94774739-2f9f-4f34-8d2c-d537441e63b2","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:03:53.790183Z","id":"38026d64-6d2e-41e6-bd22-09f7e16be9fa","subnet":"172.16.32.0/22","updated_at":"2023-11-13T14:03:53.790183Z"},{"created_at":"2023-11-13T14:03:53.790183Z","id":"8cb23878-11bd-438d-b928-97b7bb1f4732","subnet":"fd63:256c:45f7:2a19::/64","updated_at":"2023-11-13T14:03:53.790183Z"}],"tags":[],"updated_at":"2023-11-13T14:03:53.790183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -2472,7 +2608,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:56 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e54f3cab-5714-4edf-9c9f-955232c06eae
+      - d7c13d60-1b4e-49a8-bc9b-65c582d95810
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,10 +2629,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -2505,7 +2641,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:56 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89373571-f4da-49e8-9c4a-e52926810aeb
+      - db682381-51ae-45b7-bd56-f0a3a5e841c1
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,10 +2662,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSUmQwNUdiMWhFVkUxNlRWUkZlRTFxUlRCTlJGRjNUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRpdG9Da1JtV1hWRE1WTnRkME5ZWlRCeWVGRjZNRWREYWxCd1ZWRlplRlJ4WTBka1lYVjZhSE0yT1RCVlkzWnpabWRUVDJsdGJHVkRjbmRVVm5aS1pYTklURlFLY21GclpFa3JkRTVQWmtOMlkzQnFNbVZQUkZSUFlXNVZjVzFvYjBJNVQzcGtVbnBwZGxaaGJUTTJhMkZJYjFGeU1HRlZjbXhaTUZvdllTOURLMDkzYWdwa1VscDFUMEpFVmpBdmVsWklVR2haV0hwbWFYSlNVR0pJTHpOWlJrMU5ia0ZpZFRRMGJHNTVSRFJGTUVscVZXWm1kSHBKTDJ4VVZXZFpOV1pTVkRrMENtNUpSR3d4V1UwMVEyOW5SVkpuVVVOdmRXY3lia1EwWTFCUVpFcEZRa3BIVDNOellWaFpkM3B1UVVKc1NWUXpURnBrU1N0MWVpOXFTSGhyVHpWcmVWWUthWGRPUTFNeGFVdzJUR0UwVHpsWVdWSXZiSGxTWkRSbFMxRTNPV1J3ZGtOQ1NHUndlRzVGUXpKR2FYRXdNRGNyZVZkbmRtUXJaV3c0T1VNcldXSnZXUXBXVHpoMWJ6TnNSRTAxWlZCellUaFVPRkJWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRTlZwVFJ6SnpNVTh4V1N0MVMzWnpXRkJMUVZrM1ZtWllORUpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYlU5R05HUkRieTlWU2tWR2RubGFUVzlLVmt4TFRraGlWemh0VTFwdmJqRk5kRWN5Y0V4c01UQnNUVm81VkdwRE1ncE1jV2RsTWpkNlRYUmtPSEZ1U1M5U2VUbG9UekJrWTJkWU9ETm1jMVV5YlZaNGRHb3dZamxYVURGMGFrdzBTbkJ4ZFVGblNFODBhbVZzZG1WV1kyZGpDbFZNV1ZabmVGUmFLMVEzTlZGTlluZHVjRmREVHpRdllXUklaaXRzVEZGUmNVZFNLMFJpWnl0NlUyTTBObGx4WlZOQkwydFVOemx3ZFcxa1MyRmxVRkFLVTB4elpWZENUVGxaWW1WYU1FSmtTSHBCV0c1bVFYSlZXVEpXZW10d1Fua3JZemRTYjB4Q2IyWmhVR015VFhWRWFXOUNibnBYWlc0NVEyOVZLMWhYVEFwUGFpdERXbVJWU0hkclMyZzNTR3A1U2pSd2RXZDRRMFUwZHpKVWJ5dE1SR1Z4UVU5UlVtbFNhVEJ4ZGtGNlNIZ3ZWRVpvYlV4Q1R6VlVUV1o1TlhFMkNrRlhVbkJ0WkdNeFNXVjBkbVpYWTNaalNEVkVhRkJOV0VNcmVEQlhhazU0YlVWTmNnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82OTk4NTY5NS0wNmM3LTQ2NGEtODMzYy0zZDM5NjVjYWZhYTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYYll5dk9xWEdZclJ2NmdFTHViRG82ZVo3UkF6VUY1MTNMdFBwTkhMeHpsNkZQZEdGc3owcGdKag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -2538,7 +2674,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:56 GMT
+      - Mon, 13 Nov 2023 14:08:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e66614d4-803a-41a1-a277-68d490d154e2
+      - 5b60edf6-0383-41e3-a158-9dc115e4e559
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,10 +2695,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "676"
@@ -2571,7 +2707,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:57 GMT
+      - Mon, 13 Nov 2023 14:08:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcec536b-a394-4fff-bf67-950882e28087
+      - d885b9d7-40df-41f8-9d08-02be5e7f33dd
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +2728,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:57:50.671884Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:08:48.018318Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:57 GMT
+      - Mon, 13 Nov 2023 14:08:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37ba134c-ed38-4314-9bf9-14f404f012ac
+      - 04cc0f70-ed56-4986-98b8-d8f64e289426
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,10 +2761,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -2637,7 +2773,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:57 GMT
+      - Mon, 13 Nov 2023 14:08:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 062a65e8-b8a1-4c9e-811c-98d010526a41
+      - 11254e67-9abf-4319-ad61-6a4ad572cff4
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,10 +2796,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030121Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317420Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "683"
@@ -2672,7 +2808,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:58 GMT
+      - Mon, 13 Nov 2023 14:08:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2682,7 +2818,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f068075-6914-4fb2-ad23-2dd4eb38a859
+      - 5979c9f1-66d5-4de0-ad58-480e0b928cce
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,10 +2829,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2705,7 +2841,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:57:58 GMT
+      - Mon, 13 Nov 2023 14:08:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2715,7 +2851,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8e6512f-6a02-43b6-bd64-71fbd6b12ef2
+      - 9cf26335-e24e-4161-aa11-de0d5fcdf637
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,10 +2862,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2738,7 +2874,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:03 GMT
+      - Mon, 13 Nov 2023 14:08:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +2884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b9c11d6-5b5d-4b6d-8c5b-7ef7147c3863
+      - 792caa36-eace-4f7d-937a-f9a36c1d453a
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,10 +2895,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2771,7 +2907,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:08 GMT
+      - Mon, 13 Nov 2023 14:09:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2781,7 +2917,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e632a333-f5ac-4b6f-a4ab-8912adebbeca
+      - f343558a-1f99-41b7-bf9a-e431c3b50668
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,10 +2928,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2804,7 +2940,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:13 GMT
+      - Mon, 13 Nov 2023 14:09:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +2950,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34018653-2fec-4432-9af7-23ca6a07203d
+      - f59f9264-50f2-4673-9fd4-85726f0c72fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,10 +2961,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2837,7 +2973,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:18 GMT
+      - Mon, 13 Nov 2023 14:09:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +2983,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68fb90ca-5964-4f0d-bc2d-f684f59d4c85
+      - a832dae7-7bd4-49e2-96b0-3075b81dcefa
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,10 +2994,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2870,7 +3006,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:23 GMT
+      - Mon, 13 Nov 2023 14:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +3016,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf055a07-0e6a-441a-9365-741eaa1e2e9f
+      - 3bffea91-661b-40ef-9681-78c19ab24971
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,10 +3027,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2903,7 +3039,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:29 GMT
+      - Mon, 13 Nov 2023 14:09:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +3049,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf2d25fa-283a-4df9-94f2-9e3ec6582b5f
+      - 9d6ae572-cf1c-4087-8378-5af597af05d4
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,10 +3060,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2936,7 +3072,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:34 GMT
+      - Mon, 13 Nov 2023 14:09:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +3082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69151ac1-4473-45a0-bb05-bc0f8283ca36
+      - f639c7d4-8778-4a65-a51e-0259a26886ee
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,10 +3093,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -2969,7 +3105,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:39 GMT
+      - Mon, 13 Nov 2023 14:09:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +3115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8260134e-085e-4f7f-9ca0-84848632c22a
+      - 327ae6c7-ad05-4fe9-9c66-76259825c0e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,10 +3126,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3002,7 +3138,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:44 GMT
+      - Mon, 13 Nov 2023 14:09:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +3148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01dd5dd2-0ec4-4b9b-bc93-a5845bbc38fd
+      - 9101c252-7000-4174-862c-5a3f4227a741
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,10 +3159,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3035,7 +3171,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:49 GMT
+      - Mon, 13 Nov 2023 14:09:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +3181,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f2a31dd-897d-4ffa-a59e-3d0f0f876f78
+      - 28c00e2a-f3c6-40fc-8fd9-56c555b184b7
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,10 +3192,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3068,7 +3204,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:54 GMT
+      - Mon, 13 Nov 2023 14:09:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +3214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae84bd45-88fa-4bc9-9fec-ae32967f868c
+      - 5d4e387e-41b0-4478-8fc3-2967f2c74ae5
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,10 +3225,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3101,7 +3237,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:58:59 GMT
+      - Mon, 13 Nov 2023 14:09:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +3247,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b982ba9-0247-4cd3-b357-3df2fb7ea273
+      - 3978c0d5-6d44-41cf-b821-6e716fa13340
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,10 +3258,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3134,7 +3270,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:04 GMT
+      - Mon, 13 Nov 2023 14:09:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +3280,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab4c6ed5-c8ce-4053-8c27-4e3825ef48d9
+      - ffc88169-bf7f-4a74-b555-986134309261
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,10 +3291,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3167,7 +3303,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:10 GMT
+      - Mon, 13 Nov 2023 14:10:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +3313,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66b02432-b021-4123-89c6-2052e2e5d9ee
+      - cbe29768-4b1a-4e23-a3ca-75fe9a46eeb5
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,10 +3324,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3200,7 +3336,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:15 GMT
+      - Mon, 13 Nov 2023 14:10:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3210,7 +3346,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c07d044-2d55-4eb0-b1fc-ea5f84b12f67
+      - d5cc6a3c-5e00-4d1b-9eba-611fb6d40173
     status: 200 OK
     code: 200
     duration: ""
@@ -3221,10 +3357,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3233,7 +3369,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:20 GMT
+      - Mon, 13 Nov 2023 14:10:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3243,7 +3379,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52704ca6-aab7-4ebb-b2c4-2ceaf6461723
+      - 7361f7c2-35b8-4eea-912e-b4ba38c3a773
     status: 200 OK
     code: 200
     duration: ""
@@ -3254,10 +3390,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3266,7 +3402,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:25 GMT
+      - Mon, 13 Nov 2023 14:10:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +3412,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1b383a1-27b3-4ddd-b284-331097286970
+      - 1b02ba1e-57af-49f4-ae99-1c5374fd49d7
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,10 +3423,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3299,7 +3435,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:30 GMT
+      - Mon, 13 Nov 2023 14:10:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3445,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e31d729-b970-49ea-a982-bbf8bcc487ec
+      - 1e93b95f-e4cf-485d-ab56-b0955d212f2f
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,10 +3456,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3332,7 +3468,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:35 GMT
+      - Mon, 13 Nov 2023 14:10:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7690326b-1cfc-4963-b35e-9220d5d7fb2d
+      - 32e36379-fd50-4ec8-9090-e906e8412c0b
     status: 200 OK
     code: 200
     duration: ""
@@ -3353,10 +3489,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3365,7 +3501,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:40 GMT
+      - Mon, 13 Nov 2023 14:10:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +3511,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d337fa6d-76d5-4ce4-a35c-ce5015645b98
+      - 7f9d827f-1c36-44c0-8556-663facf60b8c
     status: 200 OK
     code: 200
     duration: ""
@@ -3386,10 +3522,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3398,7 +3534,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:45 GMT
+      - Mon, 13 Nov 2023 14:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +3544,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b343d31c-52d3-49a0-97b9-d135a198771d
+      - 4057678c-02d1-4254-92fe-ef3a0775519a
     status: 200 OK
     code: 200
     duration: ""
@@ -3419,10 +3555,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3431,7 +3567,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:50 GMT
+      - Mon, 13 Nov 2023 14:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3441,7 +3577,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a63b9761-2eb8-43ea-8d8a-2af17eb716a3
+      - 83b908d3-503b-43e6-9605-29366913e7de
     status: 200 OK
     code: 200
     duration: ""
@@ -3452,10 +3588,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3464,7 +3600,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:59:55 GMT
+      - Mon, 13 Nov 2023 14:10:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3474,7 +3610,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 380b601f-13b7-49aa-bc61-8f953fe3ddd2
+      - 1ec21fe3-c099-4488-9f6d-d70430ceccbf
     status: 200 OK
     code: 200
     duration: ""
@@ -3485,10 +3621,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3497,7 +3633,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:00 GMT
+      - Mon, 13 Nov 2023 14:10:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +3643,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e890ec4-1f6a-42fc-856b-78078ea53514
+      - 5111ab4d-3720-46f2-b952-1bb0a4f649f0
     status: 200 OK
     code: 200
     duration: ""
@@ -3518,10 +3654,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3530,7 +3666,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:05 GMT
+      - Mon, 13 Nov 2023 14:11:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +3676,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cbb5c4f-dcc0-4a14-89cb-13ab870165eb
+      - 340c0ca4-5efb-4edc-8dac-a7edca84794b
     status: 200 OK
     code: 200
     duration: ""
@@ -3551,10 +3687,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3563,7 +3699,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:10 GMT
+      - Mon, 13 Nov 2023 14:11:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3573,7 +3709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41fdfa45-f152-4dab-a3ca-01ee4b961834
+      - 91aa3da7-ffcb-4cb9-ad8e-9498441034fe
     status: 200 OK
     code: 200
     duration: ""
@@ -3584,10 +3720,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3596,7 +3732,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:15 GMT
+      - Mon, 13 Nov 2023 14:11:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3606,7 +3742,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 898a97e6-e565-4587-acd2-93ad5894ed02
+      - 1df02f7d-7bfe-4ec6-a82f-c1cdaa847184
     status: 200 OK
     code: 200
     duration: ""
@@ -3617,10 +3753,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3629,7 +3765,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:20 GMT
+      - Mon, 13 Nov 2023 14:11:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3639,7 +3775,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d568c7de-b0e2-4f14-bb03-d48568889180
+      - 91d946be-5f5b-44cb-9294-67c1f537fadb
     status: 200 OK
     code: 200
     duration: ""
@@ -3650,10 +3786,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3662,7 +3798,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:25 GMT
+      - Mon, 13 Nov 2023 14:11:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +3808,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0e3d3a6-27ec-4d0e-9dcc-1652f3036173
+      - 640d1f8c-241c-4f93-889f-64fc79d7f4d8
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,10 +3819,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T13:57:57.997030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "680"
@@ -3695,7 +3831,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:30 GMT
+      - Mon, 13 Nov 2023 14:11:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +3841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a11091a-1ea8-4db0-9fa1-bf15368f4aba
+      - 42ec2237-2018-4ea9-b240-fda0959555a7
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,10 +3852,274 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:11:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e70e9172-88b6-4d85-8bdd-601dc6db1972
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:11:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ece9556-708a-4d60-b06d-4776b5e5bcf8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:11:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8bd3e5f-60d0-4058-953c-c7d9d045ef90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:11:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c2a52141-81d0-45fe-8d5a-ef983b9bfc5e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:11:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a2ea02ef-8fa3-4f12-b28a-592a275f2a62
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:11:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e59c8ee2-8d80-4f49-ac1e-bd5759714c4d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b211441a-fe04-4a8e-8751-9bc7c851e9d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:08:52.889317Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "680"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6791dc8a-ff62-456d-8a2d-14a2038bc726
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:12:10.387892Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -3728,7 +4128,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:35 GMT
+      - Mon, 13 Nov 2023 14:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3738,7 +4138,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b131b979-4672-4082-9068-8ba712183f41
+      - 37a87d0f-a251-43fe-9e02-6a73f99ec049
     status: 200 OK
     code: 200
     duration: ""
@@ -3749,10 +4149,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:12:10.387892Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -3761,7 +4161,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:35 GMT
+      - Mon, 13 Nov 2023 14:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3771,7 +4171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd5a374c-a855-4b06-a9cb-0a419fb43ba6
+      - ffd6bc4d-f244-473e-9a57-7e0ba0c22fa4
     status: 200 OK
     code: 200
     duration: ""
@@ -3782,19 +4182,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=2be86807-4c94-4d5d-bdeb-cadadb871e8d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=a0734c69-8a2a-4733-afc5-cdfa822f77da&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:57:58.466407Z","error_message":null,"id":"a8534723-0059-4ce4-bab7-94b2fd63f18e","name":"scw-test-pool-minima-test-pool-minimal--a85347","pool_id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","provider_id":"scaleway://instance/fr-par-1/bf44b64f-d36e-4437-b58b-6a19e0ce23fc","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.399886Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:08:53.432293Z","error_message":null,"id":"9502f642-a1c8-48cc-ba6d-c29ca6617128","name":"scw-test-pool-minima-test-pool-minimal--9502f6","pool_id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","provider_id":"scaleway://instance/fr-par-1/22d63a61-0107-4d62-86e8-36c158a8ab23","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:10.373088Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "658"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:36 GMT
+      - Mon, 13 Nov 2023 14:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +4204,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45a9ca64-23ec-41a3-8e62-fa9841dd119b
+      - 9ba16934-550e-4977-acaf-62a1243d592c
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,10 +4215,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -3827,7 +4227,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:36 GMT
+      - Mon, 13 Nov 2023 14:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +4237,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4689023a-06d7-49c4-bed2-f4d72c2c75b3
+      - 36d24b96-ad40-42f3-9724-6585e1497004
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,10 +4248,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:12:10.387892Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -3860,7 +4260,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:36 GMT
+      - Mon, 13 Nov 2023 14:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3870,7 +4270,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13ba8156-ab12-4cee-961d-9684ed1b064a
+      - 975c9f3e-2849-41ad-929f-3bdf07e8371d
     status: 200 OK
     code: 200
     duration: ""
@@ -3881,10 +4281,150 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:10.412685Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "688"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c558f042-abb9-4c17-86f5-dd9f81d85ead
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5290ccc5-bdec-4b47-b79a-123f4a8ef928
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-13T14:06:16.374422+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-pool-minimal-test-pool-minimal-74fccf","id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:4754:201::1","gateway":"2001:bc8:4754:201::","netmask":"64"},"location":{"cluster_id":"6","hypervisor_id":"201","node_id":"2","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2d:51:37","maintenances":[],"modification_date":"2023-11-13T14:06:33.031322+00:00","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.12.178.131","private_nics":[{"creation_date":"2023-11-13T14:06:17.095910+00:00","id":"d016aa45-64a2-4808-8d5b-dce86d659105","mac_address":"02:00:00:14:bd:a6","modification_date":"2023-11-13T14:06:18.027408+00:00","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","server_id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.158.79.120","dynamic":true,"family":"inet","gateway":null,"id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.79.120","dynamic":true,"family":"inet","gateway":null,"id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"0faeb0d5-b545-40e4-a78d-4744d30c1548","name":"kubernetes
+      69985695-06c7-464a-833c-3d3965cafaa9"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=69985695-06c7-464a-833c-3d3965cafaa9","pool=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","pool-name=test-pool-minimal","runtime=containerd","managed=true","terraform-test","scaleway_k8s_cluster","default","node=74fccfea-180b-4591-8619-7825e8a1b485"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-13T14:06:16.374422+00:00","export_uri":null,"id":"5cba8c86-a940-4811-a912-8d2071e8519b","modification_date":"2023-11-13T14:06:16.374422+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","name":"scw-test-pool-minimal-test-pool-minimal-74fccf"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "4018"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e52991b-7d08-40da-ba5d-142cd6fb6059
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&pool_id=a0734c69-8a2a-4733-afc5-cdfa822f77da&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:08:53.432293Z","error_message":null,"id":"9502f642-a1c8-48cc-ba6d-c29ca6617128","name":"scw-test-pool-minima-test-pool-minimal--9502f6","pool_id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","provider_id":"scaleway://instance/fr-par-1/22d63a61-0107-4d62-86e8-36c158a8ab23","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:10.373088Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "660"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 48130b79-6000-4d82-a6af-6ca7351fc8e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/22d63a61-0107-4d62-86e8-36c158a8ab23
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-13T14:08:53.856876+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-pool-minima-test-pool-minimal--9502f6","id":"22d63a61-0107-4d62-86e8-36c158a8ab23","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:610:8702::1","gateway":"2001:bc8:610:8702::","netmask":"64"},"location":{"cluster_id":"52","hypervisor_id":"501","node_id":"3","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2d:51:4b","maintenances":[],"modification_date":"2023-11-13T14:09:11.178846+00:00","name":"scw-test-pool-minima-test-pool-minimal--9502f6","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.194.88.133","private_nics":[{"creation_date":"2023-11-13T14:08:54.567203+00:00","id":"5b25e5d8-805f-4538-ac5c-960d7f438a0a","mac_address":"02:00:00:14:bd:a8","modification_date":"2023-11-13T14:08:55.475916+00:00","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","server_id":"22d63a61-0107-4d62-86e8-36c158a8ab23","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"163.172.149.194","dynamic":true,"family":"inet","gateway":null,"id":"de3de4a0-04c5-44f6-9251-b27fa180ea9c","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.149.194","dynamic":true,"family":"inet","gateway":null,"id":"de3de4a0-04c5-44f6-9251-b27fa180ea9c","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"0faeb0d5-b545-40e4-a78d-4744d30c1548","name":"kubernetes
+      69985695-06c7-464a-833c-3d3965cafaa9"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=69985695-06c7-464a-833c-3d3965cafaa9","pool=a0734c69-8a2a-4733-afc5-cdfa822f77da","pool-name=test-pool-minimal-2","runtime=containerd","managed=true","terraform-test","scaleway_k8s_cluster","minimal","node=9502f642-a1c8-48cc-ba6d-c29ca6617128"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-13T14:08:53.856876+00:00","export_uri":null,"id":"02f3c986-bfee-4d89-8d40-475aad0abd04","modification_date":"2023-11-13T14:08:53.856876+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"22d63a61-0107-4d62-86e8-36c158a8ab23","name":"scw-test-pool-minima-test-pool-minimal--9502f6"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "4025"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aab5dacb-3a56-4061-8267-55199424a8ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/94774739-2f9f-4f34-8d2c-d537441e63b2
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-13T14:03:53.790183Z","dhcp_enabled":true,"id":"94774739-2f9f-4f34-8d2c-d537441e63b2","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:03:53.790183Z","id":"38026d64-6d2e-41e6-bd22-09f7e16be9fa","subnet":"172.16.32.0/22","updated_at":"2023-11-13T14:03:53.790183Z"},{"created_at":"2023-11-13T14:03:53.790183Z","id":"8cb23878-11bd-438d-b928-97b7bb1f4732","subnet":"fd63:256c:45f7:2a19::/64","updated_at":"2023-11-13T14:03:53.790183Z"}],"tags":[],"updated_at":"2023-11-13T14:03:53.790183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -3893,7 +4433,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:37 GMT
+      - Mon, 13 Nov 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +4443,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15fdafee-9942-4e04-a242-13864f26dfdd
+      - 9fcf05ea-7df8-4d65-a54c-61fe2c91c2b1
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,10 +4454,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -3926,7 +4466,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:38 GMT
+      - Mon, 13 Nov 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +4476,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00eb91a5-2464-48c6-a992-ed43b71bce9e
+      - 5889325a-ff36-4cf5-a1be-9a5a9c8103af
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,10 +4487,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSUmQwNUdiMWhFVkUxNlRWUkZlRTFxUlRCTlJGRjNUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRpdG9Da1JtV1hWRE1WTnRkME5ZWlRCeWVGRjZNRWREYWxCd1ZWRlplRlJ4WTBka1lYVjZhSE0yT1RCVlkzWnpabWRUVDJsdGJHVkRjbmRVVm5aS1pYTklURlFLY21GclpFa3JkRTVQWmtOMlkzQnFNbVZQUkZSUFlXNVZjVzFvYjBJNVQzcGtVbnBwZGxaaGJUTTJhMkZJYjFGeU1HRlZjbXhaTUZvdllTOURLMDkzYWdwa1VscDFUMEpFVmpBdmVsWklVR2haV0hwbWFYSlNVR0pJTHpOWlJrMU5ia0ZpZFRRMGJHNTVSRFJGTUVscVZXWm1kSHBKTDJ4VVZXZFpOV1pTVkRrMENtNUpSR3d4V1UwMVEyOW5SVkpuVVVOdmRXY3lia1EwWTFCUVpFcEZRa3BIVDNOellWaFpkM3B1UVVKc1NWUXpURnBrU1N0MWVpOXFTSGhyVHpWcmVWWUthWGRPUTFNeGFVdzJUR0UwVHpsWVdWSXZiSGxTWkRSbFMxRTNPV1J3ZGtOQ1NHUndlRzVGUXpKR2FYRXdNRGNyZVZkbmRtUXJaV3c0T1VNcldXSnZXUXBXVHpoMWJ6TnNSRTAxWlZCellUaFVPRkJWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRTlZwVFJ6SnpNVTh4V1N0MVMzWnpXRkJMUVZrM1ZtWllORUpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYlU5R05HUkRieTlWU2tWR2RubGFUVzlLVmt4TFRraGlWemh0VTFwdmJqRk5kRWN5Y0V4c01UQnNUVm81VkdwRE1ncE1jV2RsTWpkNlRYUmtPSEZ1U1M5U2VUbG9UekJrWTJkWU9ETm1jMVV5YlZaNGRHb3dZamxYVURGMGFrdzBTbkJ4ZFVGblNFODBhbVZzZG1WV1kyZGpDbFZNV1ZabmVGUmFLMVEzTlZGTlluZHVjRmREVHpRdllXUklaaXRzVEZGUmNVZFNLMFJpWnl0NlUyTTBObGx4WlZOQkwydFVOemx3ZFcxa1MyRmxVRkFLVTB4elpWZENUVGxaWW1WYU1FSmtTSHBCV0c1bVFYSlZXVEpXZW10d1Fua3JZemRTYjB4Q2IyWmhVR015VFhWRWFXOUNibnBYWlc0NVEyOVZLMWhYVEFwUGFpdERXbVJWU0hkclMyZzNTR3A1U2pSd2RXZDRRMFUwZHpKVWJ5dE1SR1Z4UVU5UlVtbFNhVEJ4ZGtGNlNIZ3ZWRVpvYlV4Q1R6VlVUV1o1TlhFMkNrRlhVbkJ0WkdNeFNXVjBkbVpYWTNaalNEVkVhRkJOV0VNcmVEQlhhazU0YlVWTmNnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82OTk4NTY5NS0wNmM3LTQ2NGEtODMzYy0zZDM5NjVjYWZhYTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYYll5dk9xWEdZclJ2NmdFTHViRG82ZVo3UkF6VUY1MTNMdFBwTkhMeHpsNkZQZEdGc3owcGdKag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -3959,7 +4499,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:38 GMT
+      - Mon, 13 Nov 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +4509,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15804155-5704-4288-8c9b-9ce3d902c61e
+      - b5911938-6cbb-461c-ba24-36d251442212
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,10 +4520,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "676"
@@ -3992,7 +4532,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:38 GMT
+      - Mon, 13 Nov 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +4542,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99c52baa-3802-44b3-875e-e7fcb8676f8d
+      - ef61e982-6b4b-4c87-8fb8-cb0f13b751be
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,10 +4553,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:12:10.387892Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "678"
@@ -4025,7 +4565,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:38 GMT
+      - Mon, 13 Nov 2023 14:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4035,7 +4575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47798042-c1b6-4e6e-8f65-ff802529eb51
+      - 00e59d26-b95a-4fb7-bc2d-0806b05488f5
     status: 200 OK
     code: 200
     duration: ""
@@ -4046,19 +4586,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.458668Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:10.412685Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "690"
+      - "688"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:38 GMT
+      - Mon, 13 Nov 2023 14:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4068,7 +4608,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b006236-e160-4147-abd3-170cedcb6f00
+      - 7dbd4b01-331d-4be4-91ce-101f5e56df03
     status: 200 OK
     code: 200
     duration: ""
@@ -4079,19 +4619,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=2be86807-4c94-4d5d-bdeb-cadadb871e8d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=a0734c69-8a2a-4733-afc5-cdfa822f77da&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:57:58.466407Z","error_message":null,"id":"a8534723-0059-4ce4-bab7-94b2fd63f18e","name":"scw-test-pool-minima-test-pool-minimal--a85347","pool_id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","provider_id":"scaleway://instance/fr-par-1/bf44b64f-d36e-4437-b58b-6a19e0ce23fc","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.399886Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:08:53.432293Z","error_message":null,"id":"9502f642-a1c8-48cc-ba6d-c29ca6617128","name":"scw-test-pool-minima-test-pool-minimal--9502f6","pool_id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","provider_id":"scaleway://instance/fr-par-1/22d63a61-0107-4d62-86e8-36c158a8ab23","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:10.373088Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "658"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:38 GMT
+      - Mon, 13 Nov 2023 14:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4101,7 +4641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23845016-f2ad-44e3-b810-216a401e6f76
+      - 691b8ff7-a9dc-4bf7-a59a-4395354d8bfe
     status: 200 OK
     code: 200
     duration: ""
@@ -4112,43 +4652,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/94774739-2f9f-4f34-8d2c-d537441e63b2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:33.422196Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 14:00:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 12243361-a64d-405e-b749-02a2488f550f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T14:03:53.790183Z","dhcp_enabled":true,"id":"94774739-2f9f-4f34-8d2c-d537441e63b2","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:03:53.790183Z","id":"38026d64-6d2e-41e6-bd22-09f7e16be9fa","subnet":"172.16.32.0/22","updated_at":"2023-11-13T14:03:53.790183Z"},{"created_at":"2023-11-13T14:03:53.790183Z","id":"8cb23878-11bd-438d-b928-97b7bb1f4732","subnet":"fd63:256c:45f7:2a19::/64","updated_at":"2023-11-13T14:03:53.790183Z"}],"tags":[],"updated_at":"2023-11-13T14:03:53.790183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "718"
@@ -4157,7 +4664,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:40 GMT
+      - Mon, 13 Nov 2023 14:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4167,7 +4674,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c09a62c-f077-451c-b664-d7fbd1c4093b
+      - 21f2b1b4-ea74-44b0-ab10-2b3e78ab7654
     status: 200 OK
     code: 200
     duration: ""
@@ -4178,10 +4685,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:12:10.387892Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "678"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f53ea2ff-74d9-4b16-8193-bd6c6330096a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -4190,7 +4730,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:40 GMT
+      - Mon, 13 Nov 2023 14:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4200,7 +4740,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f204aee1-5324-4603-b501-b20c71d0dc68
+      - 5fc033e3-e1b9-495e-af51-979fe04af468
     status: 200 OK
     code: 200
     duration: ""
@@ -4211,19 +4751,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=2be86807-4c94-4d5d-bdeb-cadadb871e8d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=a0734c69-8a2a-4733-afc5-cdfa822f77da&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:57:58.466407Z","error_message":null,"id":"a8534723-0059-4ce4-bab7-94b2fd63f18e","name":"scw-test-pool-minima-test-pool-minimal--a85347","pool_id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","provider_id":"scaleway://instance/fr-par-1/bf44b64f-d36e-4437-b58b-6a19e0ce23fc","public_ip_v4":"51.158.124.49","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.399886Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:08:53.432293Z","error_message":null,"id":"9502f642-a1c8-48cc-ba6d-c29ca6617128","name":"scw-test-pool-minima-test-pool-minimal--9502f6","pool_id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","provider_id":"scaleway://instance/fr-par-1/22d63a61-0107-4d62-86e8-36c158a8ab23","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:10.373088Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "658"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:40 GMT
+      - Mon, 13 Nov 2023 14:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +4773,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cbb8ae3-2951-4372-aa86-1b85036ef653
+      - 4e3ffa7e-64f5-4c67-b7c1-5ed2c40a2c24
     status: 200 OK
     code: 200
     duration: ""
@@ -4244,10 +4784,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSUmQwNUdiMWhFVkUxNlRWUkZlRTFxUlRCTlJGRjNUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRpdG9Da1JtV1hWRE1WTnRkME5ZWlRCeWVGRjZNRWREYWxCd1ZWRlplRlJ4WTBka1lYVjZhSE0yT1RCVlkzWnpabWRUVDJsdGJHVkRjbmRVVm5aS1pYTklURlFLY21GclpFa3JkRTVQWmtOMlkzQnFNbVZQUkZSUFlXNVZjVzFvYjBJNVQzcGtVbnBwZGxaaGJUTTJhMkZJYjFGeU1HRlZjbXhaTUZvdllTOURLMDkzYWdwa1VscDFUMEpFVmpBdmVsWklVR2haV0hwbWFYSlNVR0pJTHpOWlJrMU5ia0ZpZFRRMGJHNTVSRFJGTUVscVZXWm1kSHBKTDJ4VVZXZFpOV1pTVkRrMENtNUpSR3d4V1UwMVEyOW5SVkpuVVVOdmRXY3lia1EwWTFCUVpFcEZRa3BIVDNOellWaFpkM3B1UVVKc1NWUXpURnBrU1N0MWVpOXFTSGhyVHpWcmVWWUthWGRPUTFNeGFVdzJUR0UwVHpsWVdWSXZiSGxTWkRSbFMxRTNPV1J3ZGtOQ1NHUndlRzVGUXpKR2FYRXdNRGNyZVZkbmRtUXJaV3c0T1VNcldXSnZXUXBXVHpoMWJ6TnNSRTAxWlZCellUaFVPRkJWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRTlZwVFJ6SnpNVTh4V1N0MVMzWnpXRkJMUVZrM1ZtWllORUpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYlU5R05HUkRieTlWU2tWR2RubGFUVzlLVmt4TFRraGlWemh0VTFwdmJqRk5kRWN5Y0V4c01UQnNUVm81VkdwRE1ncE1jV2RsTWpkNlRYUmtPSEZ1U1M5U2VUbG9UekJrWTJkWU9ETm1jMVV5YlZaNGRHb3dZamxYVURGMGFrdzBTbkJ4ZFVGblNFODBhbVZzZG1WV1kyZGpDbFZNV1ZabmVGUmFLMVEzTlZGTlluZHVjRmREVHpRdllXUklaaXRzVEZGUmNVZFNLMFJpWnl0NlUyTTBObGx4WlZOQkwydFVOemx3ZFcxa1MyRmxVRkFLVTB4elpWZENUVGxaWW1WYU1FSmtTSHBCV0c1bVFYSlZXVEpXZW10d1Fua3JZemRTYjB4Q2IyWmhVR015VFhWRWFXOUNibnBYWlc0NVEyOVZLMWhYVEFwUGFpdERXbVJWU0hkclMyZzNTR3A1U2pSd2RXZDRRMFUwZHpKVWJ5dE1SR1Z4UVU5UlVtbFNhVEJ4ZGtGNlNIZ3ZWRVpvYlV4Q1R6VlVUV1o1TlhFMkNrRlhVbkJ0WkdNeFNXVjBkbVpYWTNaalNEVkVhRkJOV0VNcmVEQlhhazU0YlVWTmNnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82OTk4NTY5NS0wNmM3LTQ2NGEtODMzYy0zZDM5NjVjYWZhYTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYYll5dk9xWEdZclJ2NmdFTHViRG82ZVo3UkF6VUY1MTNMdFBwTkhMeHpsNkZQZEdGc3owcGdKag==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2630"
@@ -4256,7 +4796,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:40 GMT
+      - Mon, 13 Nov 2023 14:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4266,7 +4806,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b795e98-1d51-4c20-982c-b56628abf88a
+      - 0fe9b1ea-9f5d-452a-b638-a4d3c244c50a
     status: 200 OK
     code: 200
     duration: ""
@@ -4277,10 +4817,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "676"
@@ -4289,7 +4829,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:40 GMT
+      - Mon, 13 Nov 2023 14:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4299,7 +4839,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf29439a-f2bc-4d37-82d3-efdf936a5575
+      - 291a3a73-d8da-4190-9b0a-de89b5914c50
     status: 200 OK
     code: 200
     duration: ""
@@ -4310,19 +4850,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:33.458668Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:10.412685Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "690"
+      - "688"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:40 GMT
+      - Mon, 13 Nov 2023 14:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4332,7 +4872,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab1503ea-a95b-45ff-91c1-ee996f3ee45b
+      - 39e97451-3169-4a3d-bb69-8f95acb25ad1
     status: 200 OK
     code: 200
     duration: ""
@@ -4343,10 +4883,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606860708Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:12:14.390077546Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "684"
@@ -4355,7 +4895,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:41 GMT
+      - Mon, 13 Nov 2023 14:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +4905,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4414dc09-8b42-4f4d-a7c4-7b8865ec7af4
+      - e71977c3-0d96-4545-bc24-5da7a13fc33b
     status: 200 OK
     code: 200
     duration: ""
@@ -4376,10 +4916,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:12:14.390078Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "681"
@@ -4388,7 +4928,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:41 GMT
+      - Mon, 13 Nov 2023 14:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +4938,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8059c8d6-f264-4037-9567-588777418994
+      - ff4d2a0f-e839-41ce-8900-cdedd14bee08
     status: 200 OK
     code: 200
     duration: ""
@@ -4409,10 +4949,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:08:52.879572Z","id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-13T14:12:14.390078Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "681"
@@ -4421,7 +4961,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:00:46 GMT
+      - Mon, 13 Nov 2023 14:12:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +4971,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8594f127-7e8e-407d-afd2-8e63b025a72d
+      - affdd48d-2f87-460d-9758-401c05ffdbd8
     status: 200 OK
     code: 200
     duration: ""
@@ -4442,76 +4982,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a0734c69-8a2a-4733-afc5-cdfa822f77da
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "681"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 14:00:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b4480d28-ec51-41b3-a0c9-9402b4419321
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:57:57.989273Z","id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-10T14:00:41.606861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "681"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 14:00:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad2382dd-d4b3-4014-a219-39d8e72b8516
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2be86807-4c94-4d5d-bdeb-cadadb871e8d
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"2be86807-4c94-4d5d-bdeb-cadadb871e8d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"a0734c69-8a2a-4733-afc5-cdfa822f77da","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4520,7 +4994,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:01 GMT
+      - Mon, 13 Nov 2023 14:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4530,7 +5004,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56306c2e-5c4a-4f68-9f5f-8b7cbc898f15
+      - c208525f-bca9-4439-90db-62dc6b3e3b17
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4541,10 +5015,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -4553,7 +5027,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:02 GMT
+      - Mon, 13 Nov 2023 14:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4563,7 +5037,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 275d6764-5da3-4a82-8b22-d0c83edfa62a
+      - 8848dd23-3576-44a8-a502-f1e47692d4fe
     status: 200 OK
     code: 200
     duration: ""
@@ -4574,109 +5048,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:53:18.051579Z","dhcp_enabled":true,"id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:53:18.051579Z","id":"bc3412da-f1a7-4940-bf6b-ca6b63c608c7","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:53:18.051579Z"},{"created_at":"2023-11-10T13:53:18.051579Z","id":"b3d19310-b8a5-458c-9f85-93089e16399a","subnet":"fd63:256c:45f7:2af2::/64","updated_at":"2023-11-10T13:53:18.051579Z"}],"tags":[],"updated_at":"2023-11-10T13:53:18.051579Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "718"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 14:01:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 13e7cfc8-6bec-43f2-8e3e-29b882a33563
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:54:52.421980Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 14:01:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aedb6313-0a4f-4c6c-98ea-6c8cf57911a1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VGxSTmVVMUdiMWhFVkUxNlRWUkZkMDlVUlhwT1ZFMTVUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRGVnJDbWwwTVZCV0syOHhjbXBTVVRacWFqQjVWbXRSY2tsNllVbG9WRmc0TUhCNE5YRnpTV3RKYVdaVGVXeHdkRVYyV0hkVU5YZHlUemhRUzFWSUwwdGhjRFFLTkdaUWFGbGxOR053ZEhjeGNFbFBWSEEzV1ZaVGVYRmlPSGRDU0d4alRHOHdNVGN2Vm1OV1IwNTBhbVV2UXpaelkzUnVSSG8ySzJnMGRUZDFkR2Q1TUFwT01VOXpZbFpSTjBSaFdIQmFWbGsyYUVaUFoxTmxXamx4V0ZJdlpFMWxOMUpaY1U5VlQxWkpiREJhZUVKalEwZDNaazFxUVVaaFFYaDBkMGxITms1cUNubHhjekp6TjFWYVFVWTVXazEzVW13M2RIaERkVVJtUW5SdmJrTjBkR2xJU0RVNU0zaGpUaXRWU1dWUGJIWnphekZwUjJNMmFtWkdka0pvWkhCT2RHb0tSRlJpWlVKa1UzUkdWazFqVjJSRVdERlBOaXRTVTJKRVQxVlZPVTU0UVhaUlVUWklObVF3V1VVNU4wWXhUVFV3TjIxU2JGbzJSM3BIYTJKUVJWTm5XQXBzVURGRlNVNUdkemhNU21NMFZGQnVRa1pWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGZEhSMFJsaFpNMHB6ZW0xemFESk1jMjU0ZVhaSVpteFRha0pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDVnpBeWQzaEZibVZrTTFaV2JVVm5kVkp0TjBsUmFtTmhLMnRxTkdwSEswTTFUV2xYTjBOcGVFeG5jMUJ4T0hRNWNnb3dibEl4YWt4cGNreFRXVlpCWVVOU1dYZFhPREZPWkdwS1pFcHBlRVJNVW1SNWEybFNNVzQ0Y1hJeGEwOUpibTlSV2pCU2NYUTFSRlJJTXpGRU5VVk5DbEZVWjBsdFIzSndjemRPVVVwSU4zWnNhamRDU2tOek1HdEZOalE0WkVWRFFUSkxhR3hQVVU5UVJqYzVRa1ZYUmpCWVVpc3dVMjRyTVhWaWJGWklLMFVLU0hwaWEwMUplVEZyYVhCUmJFWmllbTAxWkVaSVkwcDBVa2MyTjI5dGVHMWFZV3BVYjNaMFV6aEJaMUU0TTNWWllrRnJTbTEyZDFveVRYTlRkMnRSZUFwblpFVkpjMEowY3pNNE1UZzJRVGd2ZEM5eU9YVXZTbXhxUzBVNGQxTjJkVkV3TkVsQk5FZGpSVEZuUkZCcGNrRlVXazFIUm5aRFNsTkhPVmN4Ykd0dENsSktOVGxvYkVaRlpsRkpiRTlvTVdOSWIzcFZZbkpaTlU5WU0yUnhOa1oyYTFaVGFBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9iZGI0NGU4Ny01NTAzLTQ5ZmYtOTNhYS1lODE5MWNjNjJjNGEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzNTMxU1BCVmFCWndvaURhdU56dXI5NXhxMTZON3dFaUVhT0Nya0xsNlpoNkphZERURG5OekIydg==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 14:01:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ddbf340-2486-4e33-a4f3-1e922f83aaff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T13:57:50.684332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "676"
@@ -4685,7 +5060,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:03 GMT
+      - Mon, 13 Nov 2023 14:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4695,7 +5070,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee3f72e3-312d-4120-9e78-8925bc77fda0
+      - dd259b3e-1400-43cc-80b1-6300f87d232d
     status: 200 OK
     code: 200
     duration: ""
@@ -4706,19 +5081,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a/nodes?order_by=created_at_asc&page=1&pool_id=a471334c-2d46-4ed2-a998-a3d358adf83a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:55:20.272209Z","error_message":null,"id":"39d2ad00-21ab-4a69-af57-a9d707f0b727","name":"scw-test-pool-minimal-test-pool-minimal-39d2ad","pool_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","provider_id":"scaleway://instance/fr-par-1/c8f6e508-64c0-48b8-a92b-dbd2027826da","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T14:00:42.064169Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:14.852447Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "690"
+      - "688"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:03 GMT
+      - Mon, 13 Nov 2023 14:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4728,7 +5103,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76d82457-23bb-40f7-9289-b3d2a37cfb0e
+      - e15c8020-059d-4841-8644-e68cd2082a6d
     status: 200 OK
     code: 200
     duration: ""
@@ -4739,10 +5114,212 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5290ccc5-bdec-4b47-b79a-123f4a8ef928
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-13T14:06:16.374422+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-pool-minimal-test-pool-minimal-74fccf","id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:4754:201::1","gateway":"2001:bc8:4754:201::","netmask":"64"},"location":{"cluster_id":"6","hypervisor_id":"201","node_id":"2","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2d:51:37","maintenances":[],"modification_date":"2023-11-13T14:06:33.031322+00:00","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.12.178.131","private_nics":[{"creation_date":"2023-11-13T14:06:17.095910+00:00","id":"d016aa45-64a2-4808-8d5b-dce86d659105","mac_address":"02:00:00:14:bd:a6","modification_date":"2023-11-13T14:06:18.027408+00:00","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","server_id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.158.79.120","dynamic":true,"family":"inet","gateway":null,"id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.79.120","dynamic":true,"family":"inet","gateway":null,"id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"0faeb0d5-b545-40e4-a78d-4744d30c1548","name":"kubernetes
+      69985695-06c7-464a-833c-3d3965cafaa9"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=69985695-06c7-464a-833c-3d3965cafaa9","pool=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","pool-name=test-pool-minimal","runtime=containerd","managed=true","terraform-test","scaleway_k8s_cluster","default","node=74fccfea-180b-4591-8619-7825e8a1b485"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-13T14:06:16.374422+00:00","export_uri":null,"id":"5cba8c86-a940-4811-a912-8d2071e8519b","modification_date":"2023-11-13T14:06:16.374422+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"5290ccc5-bdec-4b47-b79a-123f4a8ef928","name":"scw-test-pool-minimal-test-pool-minimal-74fccf"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "4018"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d6878db5-cba7-4534-828e-9446e6148ca3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/94774739-2f9f-4f34-8d2c-d537441e63b2
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-13T14:03:53.790183Z","dhcp_enabled":true,"id":"94774739-2f9f-4f34-8d2c-d537441e63b2","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T14:03:53.790183Z","id":"38026d64-6d2e-41e6-bd22-09f7e16be9fa","subnet":"172.16.32.0/22","updated_at":"2023-11-13T14:03:53.790183Z"},{"created_at":"2023-11-13T14:03:53.790183Z","id":"8cb23878-11bd-438d-b928-97b7bb1f4732","subnet":"fd63:256c:45f7:2a19::/64","updated_at":"2023-11-13T14:03:53.790183Z"}],"tags":[],"updated_at":"2023-11-13T14:03:53.790183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d6a77bf3-6b42-407f-b815-762457e8c510
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:06:05.361280Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1497"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 877a6b2e-b1ab-4127-81d3-7f4baf2b8b49
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1V3VFVSUmQwNUdiMWhFVkUxNlRWUkZlRTFxUlRCTlJGRjNUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRpdG9Da1JtV1hWRE1WTnRkME5ZWlRCeWVGRjZNRWREYWxCd1ZWRlplRlJ4WTBka1lYVjZhSE0yT1RCVlkzWnpabWRUVDJsdGJHVkRjbmRVVm5aS1pYTklURlFLY21GclpFa3JkRTVQWmtOMlkzQnFNbVZQUkZSUFlXNVZjVzFvYjBJNVQzcGtVbnBwZGxaaGJUTTJhMkZJYjFGeU1HRlZjbXhaTUZvdllTOURLMDkzYWdwa1VscDFUMEpFVmpBdmVsWklVR2haV0hwbWFYSlNVR0pJTHpOWlJrMU5ia0ZpZFRRMGJHNTVSRFJGTUVscVZXWm1kSHBKTDJ4VVZXZFpOV1pTVkRrMENtNUpSR3d4V1UwMVEyOW5SVkpuVVVOdmRXY3lia1EwWTFCUVpFcEZRa3BIVDNOellWaFpkM3B1UVVKc1NWUXpURnBrU1N0MWVpOXFTSGhyVHpWcmVWWUthWGRPUTFNeGFVdzJUR0UwVHpsWVdWSXZiSGxTWkRSbFMxRTNPV1J3ZGtOQ1NHUndlRzVGUXpKR2FYRXdNRGNyZVZkbmRtUXJaV3c0T1VNcldXSnZXUXBXVHpoMWJ6TnNSRTAxWlZCellUaFVPRkJWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpRTlZwVFJ6SnpNVTh4V1N0MVMzWnpXRkJMUVZrM1ZtWllORUpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYlU5R05HUkRieTlWU2tWR2RubGFUVzlLVmt4TFRraGlWemh0VTFwdmJqRk5kRWN5Y0V4c01UQnNUVm81VkdwRE1ncE1jV2RsTWpkNlRYUmtPSEZ1U1M5U2VUbG9UekJrWTJkWU9ETm1jMVV5YlZaNGRHb3dZamxYVURGMGFrdzBTbkJ4ZFVGblNFODBhbVZzZG1WV1kyZGpDbFZNV1ZabmVGUmFLMVEzTlZGTlluZHVjRmREVHpRdllXUklaaXRzVEZGUmNVZFNLMFJpWnl0NlUyTTBObGx4WlZOQkwydFVOemx3ZFcxa1MyRmxVRkFLVTB4elpWZENUVGxaWW1WYU1FSmtTSHBCV0c1bVFYSlZXVEpXZW10d1Fua3JZemRTYjB4Q2IyWmhVR015VFhWRWFXOUNibnBYWlc0NVEyOVZLMWhYVEFwUGFpdERXbVJWU0hkclMyZzNTR3A1U2pSd2RXZDRRMFUwZHpKVWJ5dE1SR1Z4UVU5UlVtbFNhVEJ4ZGtGNlNIZ3ZWRVpvYlV4Q1R6VlVUV1o1TlhFMkNrRlhVbkJ0WkdNeFNXVjBkbVpYWTNaalNEVkVhRkJOV0VNcmVEQlhhazU0YlVWTmNnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly82OTk4NTY5NS0wNmM3LTQ2NGEtODMzYy0zZDM5NjVjYWZhYTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYYll5dk9xWEdZclJ2NmdFTHViRG82ZVo3UkF6VUY1MTNMdFBwTkhMeHpsNkZQZEdGc3owcGdKag==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2630"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b83ae06-128b-4892-acc2-a8541fe03730
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:08:48.035045Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "676"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4323194a-69cc-4efd-a1fd-ccd5609f4300
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9/nodes?order_by=created_at_asc&page=1&pool_id=aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:06:15.795199Z","error_message":null,"id":"74fccfea-180b-4591-8619-7825e8a1b485","name":"scw-test-pool-minimal-test-pool-minimal-74fccf","pool_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","provider_id":"scaleway://instance/fr-par-1/5290ccc5-bdec-4b47-b79a-123f4a8ef928","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:12:14.852447Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "688"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:12:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 75f0bb67-2347-4bd2-98c5-776c61a9d793
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874123Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:12:26.310016594Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "682"
@@ -4751,7 +5328,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:04 GMT
+      - Mon, 13 Nov 2023 14:12:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4761,7 +5338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4add914e-20d8-4a70-ba0e-40e32b0ef8c6
+      - 22e8151d-a19d-41f8-97e8-ff9976bcf4af
     status: 200 OK
     code: 200
     duration: ""
@@ -4772,10 +5349,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:12:26.310017Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "679"
@@ -4784,7 +5361,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:04 GMT
+      - Mon, 13 Nov 2023 14:12:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4794,7 +5371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29bdbe93-eb7c-4c69-96d5-aad4cb834fa5
+      - 9df8842d-58e8-479d-8f82-8f6ab5ea579e
     status: 200 OK
     code: 200
     duration: ""
@@ -4805,10 +5382,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:12:26.310017Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "679"
@@ -4817,7 +5394,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:09 GMT
+      - Mon, 13 Nov 2023 14:12:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4827,7 +5404,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 714d2fd6-7a7c-4334-a291-7ab49ab56a5c
+      - 7b5cbc4f-8e63-471a-ad3f-b4b4a56a62ae
     status: 200 OK
     code: 200
     duration: ""
@@ -4838,10 +5415,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:12:26.310017Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "679"
@@ -4850,7 +5427,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:14 GMT
+      - Mon, 13 Nov 2023 14:12:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4860,7 +5437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fcb9e18-687a-4422-bbf9-6343e09a7742
+      - 40054846-8dac-425f-b343-d3d261c36cba
     status: 200 OK
     code: 200
     duration: ""
@@ -4871,10 +5448,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:12:26.310017Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "679"
@@ -4883,7 +5460,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:19 GMT
+      - Mon, 13 Nov 2023 14:12:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4893,7 +5470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa1be589-4962-4d03-b823-d23b2ff13949
+      - 9bf9e880-83df-4817-a893-9da37b118a91
     status: 200 OK
     code: 200
     duration: ""
@@ -4904,10 +5481,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:12:26.310017Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "679"
@@ -4916,7 +5493,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:24 GMT
+      - Mon, 13 Nov 2023 14:12:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4926,7 +5503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c81d4ae3-9653-4c86-bb6f-2e593ee4a6bf
+      - 5f0b548e-feca-47e6-8030-e8b50f04ea88
     status: 200 OK
     code: 200
     duration: ""
@@ -4937,10 +5514,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:12:26.310017Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "679"
@@ -4949,7 +5526,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:30 GMT
+      - Mon, 13 Nov 2023 14:12:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4959,7 +5536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc6ccffb-efd8-40fc-bc23-cdf412a5160d
+      - c5aa584f-31c9-456b-8e0b-0ea93ba101ec
     status: 200 OK
     code: 200
     duration: ""
@@ -4970,10 +5547,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","container_runtime":"containerd","created_at":"2023-11-10T13:53:24.808828Z","id":"a471334c-2d46-4ed2-a998-a3d358adf83a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-10T14:01:04.658874Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"69985695-06c7-464a-833c-3d3965cafaa9","container_runtime":"containerd","created_at":"2023-11-13T14:04:08.610242Z","id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-13T14:12:26.310017Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "679"
@@ -4982,7 +5559,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:35 GMT
+      - Mon, 13 Nov 2023 14:12:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4992,7 +5569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ba34b29-7f30-4127-acfd-0e9698ea5d55
+      - b945bc13-e9a4-4d75-986d-aceae2262b72
     status: 200 OK
     code: 200
     duration: ""
@@ -5003,10 +5580,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -5015,7 +5592,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:40 GMT
+      - Mon, 13 Nov 2023 14:13:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5025,7 +5602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 428802b3-b475-4260-b318-472298675f53
+      - c8e162d4-58ec-4e9a-9b43-b2f7b3a985eb
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5036,10 +5613,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T14:01:40.171922548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:13:01.826500029Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -5048,7 +5625,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:40 GMT
+      - Mon, 13 Nov 2023 14:13:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5058,7 +5635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d931f037-4154-46c6-ae32-345c37d20ed2
+      - a78eabf5-2707-41a1-b675-542b6a9284c4
     status: 200 OK
     code: 200
     duration: ""
@@ -5069,10 +5646,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T14:01:40.171923Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:13:01.826500Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -5081,7 +5658,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:40 GMT
+      - Mon, 13 Nov 2023 14:13:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5091,7 +5668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1d87467-e23d-42e8-ab00-a4d4195828f4
+      - 11e3ec7d-a4c9-4d2d-8e27-ee66df75d6ce
     status: 200 OK
     code: 200
     duration: ""
@@ -5102,10 +5679,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://bdb44e87-5503-49ff-93aa-e8191cc62c4a.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:53:19.364667Z","created_at":"2023-11-10T13:53:19.364667Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.bdb44e87-5503-49ff-93aa-e8191cc62c4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T14:01:40.171923Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://69985695-06c7-464a-833c-3d3965cafaa9.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T14:04:02.977895Z","created_at":"2023-11-13T14:04:02.977895Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.69985695-06c7-464a-833c-3d3965cafaa9.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"69985695-06c7-464a-833c-3d3965cafaa9","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:13:01.826500Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -5114,7 +5691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:45 GMT
+      - Mon, 13 Nov 2023 14:13:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5124,7 +5701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1ccd22f-e653-4c98-8420-9cd12adc266e
+      - 417aecdd-c9fe-469d-a2f5-71d88d53fd52
     status: 200 OK
     code: 200
     duration: ""
@@ -5135,10 +5712,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"69985695-06c7-464a-833c-3d3965cafaa9","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -5147,7 +5724,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:50 GMT
+      - Mon, 13 Nov 2023 14:13:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5157,7 +5734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea2363f1-d576-443b-9501-e87a281df09e
+      - 538abb77-d19c-4631-bacf-0b2c77762006
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5168,10 +5745,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/94774739-2f9f-4f34-8d2c-d537441e63b2
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -5180,7 +5757,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:50 GMT
+      - Mon, 13 Nov 2023 14:13:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5190,7 +5767,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f04be90-796b-4ed9-9bce-fa10e873cdc0
+      - b193748e-c8ba-4587-bfa6-9b30c41a1438
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5201,76 +5778,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fa75dbc2-3cce-4d36-a8ad-473f8ec346e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"fa75dbc2-3cce-4d36-a8ad-473f8ec346e0","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 14:01:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9cf2a2eb-4ed6-4270-946d-e3308dc85c03
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/bdb44e87-5503-49ff-93aa-e8191cc62c4a
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"bdb44e87-5503-49ff-93aa-e8191cc62c4a","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 14:01:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dc3b8c00-0544-4896-8724-a9cbfc469b8f
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a471334c-2d46-4ed2-a998-a3d358adf83a
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"a471334c-2d46-4ed2-a998-a3d358adf83a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"aec43605-2d8e-4bf5-bcfe-37c7af1ff7e6","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -5279,7 +5790,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 14:01:50 GMT
+      - Mon, 13 Nov 2023 14:13:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5289,7 +5800,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 296c407e-26d9-4ec0-8a98-89807e01b2b1
+      - 6088157b-c7ef-4adb-b1d9-282c2f746d8f
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/69985695-06c7-464a-833c-3d3965cafaa9
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"69985695-06c7-464a-833c-3d3965cafaa9","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:13:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 881a3bc7-c5f1-4146-a365-8b63a59fcb84
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/94774739-2f9f-4f34-8d2c-d537441e63b2
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"94774739-2f9f-4f34-8d2c-d537441e63b2","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:13:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b60438e4-078d-4e45-ad69-c1aff03d5cac
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-kubelet-args.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-kubelet-args.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a9232ba-7a1a-4f9b-b51c-41648639dbd0
+      - cb5eeeb8-5340-4fd9-830d-4a57627d7222
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.727465Z","dhcp_enabled":true,"id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.727465Z","id":"488240ba-5d41-4d09-b1b6-b2d469032b08","subnet":"172.16.20.0/22","updated_at":"2023-11-13T13:51:13.727465Z"},{"created_at":"2023-11-13T13:51:13.727465Z","id":"939c821c-e485-4b6a-a237-421d27ff4bb9","subnet":"fd63:256c:45f7:94cd::/64","updated_at":"2023-11-13T13:51:13.727465Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.727465Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "723"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:54 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14478ebd-97fc-44fc-8417-fbda0994e380
+      - 7169d981-deca-4eac-8dc0-aeae8d01d2dd
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/511ca9f5-fe23-4f59-b44a-7d1f5d2d202e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.727465Z","dhcp_enabled":true,"id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.727465Z","id":"488240ba-5d41-4d09-b1b6-b2d469032b08","subnet":"172.16.20.0/22","updated_at":"2023-11-13T13:51:13.727465Z"},{"created_at":"2023-11-13T13:51:13.727465Z","id":"939c821c-e485-4b6a-a237-421d27ff4bb9","subnet":"fd63:256c:45f7:94cd::/64","updated_at":"2023-11-13T13:51:13.727465Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.727465Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "723"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:54 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90e9a7c9-2832-4114-a10a-6b351319eb81
+      - 3b4ede35-9f60-466f-923e-b87e10449e72
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-kubelet-args","description":"","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-kubelet-args","description":"","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947290Z","created_at":"2023-11-10T13:23:54.823947290Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.901948315Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399723932Z","created_at":"2023-11-13T13:51:18.399723932Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.415878104Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1519"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:55 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dceebdcc-60a1-467c-9335-185343e686b9
+      - 32277a31-d14d-43dd-885c-780729a10a08
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:54.901948Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.415878Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:55 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b615e59-cf2c-4ff3-81d9-27083acf75af
+      - 421a0f09-ea70-4c23-9504-46bbf64416b4
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:57.224459Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.207669Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:00 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f780b04-67b8-413b-853e-18ba7c999c63
+      - 499d549a-ddbe-44a7-8271-8039614d6cd2
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:57.224459Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.207669Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:00 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83b21218-e352-460f-a3e2-7e86630f12ff
+      - 909c1692-aaba-40f2-a801-d67ce98accb3
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BOTVU1c2IxaEVWRTE2VFZSRmQwOVVSWHBOYWsweFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVwckNtUm9NbGRHVjBzeUwycHhNWE50ZFRZdmEzVnVTamRpTUZScFRtSm9UMnB5UWxwaWFFVlJhR05tUjJ0R1QzbEZWblpEUVVobFV6aEtkV2RzUms5RlowOEtkamhEY0RkM2FtbzNaRWhoZEc5MlJIRkJSRGhYUlRGR1IwRnRaR1ZGVm1Vdkt6QXZhVlpDU2tKU1FqWnVNR2N2YUd0dE5EWnNZbHBVYzBobVVFTkdSZ3BZVkZoQlpXSnRUMnBYVWtKWmVrZG5SQ3RHZG5kb05rUktiMmxtVlU1RFFWcE1hVzV5WkdSSVVsbHNPVzFsS3pkeVMzazJNWEl2WXpNdlkySXdMM2RqQ21GclRXWlBUREoyZW5SaE56RjNWV2xtYzI1YVUzTnNSVzFYWVU1WVNXaG5iRTB3YkZWdlpscHBkMDB2VGtacGFHdzVhMWxWYmtkblpIQXdhRWRZZDI0S1l6Vm5XRTh5Vkd3NU9WcEdSVTFEY210Wk1FMXphMGRJWmxGUE5TdEZTM0U1TW5WVGIyWm1SbmQzYWtGUFVqZEhUbWhLV0VwbU5EUkhNV05XY1docGJBcFBUWFIwUTJrNWVraDRRMmhXUmxoUFUySnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxSbEV4UjNoeksxTndjM1ZMYldocWF6WTRibVF5YURRclFtTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjV0p3Y25VNUwzSnhURXBRWlRCSVpDOWphbWRQVTFWWlYwMUVTV0ptTVRoM2MzaHFXbk5GYUZFNGJXRnNjMlJhZVFwbll6bEtWbWN5Wmk5dE5tVTVNRzh2WjFGVEsyNWhVMVUwU2prelpHMUJka2MxU1dGUmNra3JOR1pIYW5sbUwzQndORE5qU1UwNGFFSktVVFF3YzBoS0NucEhablowZW1KSU0zWkhhM0ZLU0hwcGFVSjBSVTlrWTB4UlF6WnpNbWx4V1RJek5VeG9PRXB4V0VkVVJsVkpNVk4wVjJGdmNuWnVSU3R6ZG1wTlIxQUtSbmRYWjFkRVowMTZObFpvWjJOcmExQjJXVE5HUTB0cFRGWlNjSGhrWlUxQ1NYYzViM3BwTjBWVlpXUmFkWFZKUzB3M2FIbFdNVVZwU2pScGR6aGtNZ3B2TUdsM1V6TkJiMHhGY1hwVVRGZzRSR2c1VUhSamVGUkRURFExVkRrelJGcFBXR0ozZURoRk1IUnFNVGw1Vm01aVZIWjFZVzgwUm5kcWFWWlRNa28wQ21SeGFqQlFZMmhNZEU5NWFtWldVRkJZWVdWeU1EVkhOMlY2YmpoUVdscHBhMmREVWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2E4MmFkOWE1LWFhMjMtNGRlNy1hYTAzLWE5OGQyNDBkMTMzZC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBtVTN3Mm9MYTROcm5ndUl4bVhyeVhiZVltWjRTYVd5RjdUVXduS0xtZFNVaUt4Z0liaVhnZktMVQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZUU5V2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGl0YUNsaDBXa2N3UlU1V1ZFaHFjMnhpV0ZRclFtdDZNbEYwSzBkS1prcE9PVmhtYWs0eFFucHdaRmR2T1hkbVZERk5UVEprTXpsNWNHaENNM2wzWkZCNk1DOEthRmhZT1VkcVRHWkxWalJoU0hWeFV6TnZTV1prZUhwaFZqRnVNRGx1UjJwWmRHbFVZbkZOWVd0TVpUVkJhMDR5VjJGVlVXeFdjRE5yUVdoTVZraFNZd3BhYVU1SFFuUldaeTh2YkZweFRGbHBWMkpQYWtjeVdYZFBUVll5U2pkRU1rdHRRV2RzV21sTllsQmpTV0ZNYUdsMGF6STNRMU5RVlhjMGMwMVRWV2R2Q2s1cVpVMXJVMnB3UmpodU9ITk1NbTlpZDNRemJuVlBXalE0WkZGMGFUQlZZekpqTm01aWNrbGFSRU13TVdwT2NtWmpZU3RHYTJseFpGY3ZVR3hxTVdzS2FVZEtXbVZKUldReFUzWlBNSHB1Y0RkbGFHbElWSFF4Tm1JemRVdGhWbFpOZERBek9HRjFSRXBsZVZSWVZUTXJhMm80VFM5VVkyeFViMmhOZDFsTmVncE5aVVUzVTFOcVdVbHRXV0pHVlRaWFowUmpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZRMDUxVlZnNFUwWk5ORlY1WVVwVlJGTkRlbEVyUkVKbWRtSk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMGh5ZFVodEsyNXhlVGRWTjNaVWN6WTFLMWgwV1RKc00wNUVlbTU1U3pGNVFYTnlkRVZ5YnpkVk1YZDZPVWxMVHdveGVDOXhWbTFqU0d0RlFsbGlObGxOWWtoSlFtcG9VMUoyYVZoWVZURmlhRFpoVlRFeFMwRmFUMGg1Y2trMFdVTXpVM0JXU25VMmVXbFVWa2RhU3pZNUNtUlhMMnRCYW1wV1ExUXlTR1J5TlVaTWNrWnFaRm81VDFobFRUbFhZa3BtZVVOVlZYRTJWMjgwZFVoc1ZFcDNWRnB6YTB4cWNFVkpZMVkxT1RJMFQwc0tVRk5rWVc4ck9UVjRZWFl2U1dWWE9HVmtSV05SUVRSSWNXRmpibTFPZVhWR2VrWjVOVEppTDJ4UWIyZ3pWVmhoZUd0MVMwcHRVa2x5TWxNcmRESldXZ3A2Y1daV2VsSTRPVTlQUTJoMVVrdHpZMUJtVVVkc1prUnNNRzVMYTJsT1luQkhkMjlMVjBnMFoySTFTbW8wTm1vclQzTlpSaXR0VkdoRFRIZzBNU3R6Q21KTGMzcEhZMVJ3ZG0xbVpXaG1RblJ2WkVoYUswMTFSREYxVlVZeVpFaDVXamhMU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y3MmY5N2JiLTk3Y2EtNDRjYi05MzMwLWQ3N2UwZDA5YzIwMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBSV2t1OXNrS0R0Z1hHR2R3VnZ5U3o4dVhHMk16QmNuQmI5QzJZNFpBYUl6eVM4T2piOXozbU1lYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2670"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:00 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 806cfbd0-8dfe-4d93-a74a-5c24066d2f63
+      - 7da32ba7-e159-4e0c-9f73-47ba7add039c
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:23:57.224459Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.207669Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:00 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c14f98d7-0c3c-45f0-9f2b-5192b1d256c0
+      - 73302b8e-159d-4c40-a65c-1ce1c657adaf
     status: 200 OK
     code: 200
     duration: ""
@@ -315,10 +315,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277483Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654336Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "707"
@@ -327,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:01 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f463266-aff1-453a-a9f5-435b12d6fe6e
+      - 3ecdb2cf-8e43-46fe-8094-c34e2c10f3d8
     status: 200 OK
     code: 200
     duration: ""
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -360,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:01 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcacb2f6-da0f-4aaa-bcd1-7f71300c806b
+      - 49a60064-904a-4a03-98e0-cac935d4c1f8
     status: 200 OK
     code: 200
     duration: ""
@@ -381,10 +381,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -393,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:06 GMT
+      - Mon, 13 Nov 2023 13:51:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8bbffde-a868-451c-afb8-aa851e31cef9
+      - 705c5fab-c84b-4a15-a7a9-d90ba6fa536a
     status: 200 OK
     code: 200
     duration: ""
@@ -414,10 +414,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -426,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:11 GMT
+      - Mon, 13 Nov 2023 13:51:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6eb19a8-6863-4b7c-b540-fcdc7bbf20bc
+      - a668bd35-7216-46ee-ab8d-0d428064f920
     status: 200 OK
     code: 200
     duration: ""
@@ -447,10 +447,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -459,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:16 GMT
+      - Mon, 13 Nov 2023 13:51:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75ea1a33-9296-4954-9b76-80e761d458c5
+      - 6d6af8cb-e762-463d-ad25-98706e15643f
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -492,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:21 GMT
+      - Mon, 13 Nov 2023 13:51:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79ce4521-eb64-41d1-a518-853d7e0d38ce
+      - ced36f49-ceec-4674-9a20-843c322d61e6
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:26 GMT
+      - Mon, 13 Nov 2023 13:51:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0259738d-8c0b-4f28-bca8-45670fb26b80
+      - 0875589e-1a2a-4421-bed6-0db38dcbff40
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:31 GMT
+      - Mon, 13 Nov 2023 13:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4903d676-b3b8-435e-91ac-247eed67a276
+      - 2f6a9ce0-10e6-4371-9105-afe5c733bdc2
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -591,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:36 GMT
+      - Mon, 13 Nov 2023 13:52:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89301d4d-05e8-4a3e-907c-1bb8e2e2b338
+      - ea299a92-04bf-4bf6-955b-558fe2cc0135
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:41 GMT
+      - Mon, 13 Nov 2023 13:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01684a68-c84f-4d83-9a88-867a110c1dac
+      - 766135fa-87a6-4275-8d43-4daa5aa33bf1
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53614c49-6320-4d2e-bde7-9b3fffeef63a
+      - cd9a41f4-04f1-4a8d-9eb4-4939af662775
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:51 GMT
+      - Mon, 13 Nov 2023 13:52:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f47bea67-9e22-4ddf-a6b3-85f25ce33a2d
+      - f0996640-1ce8-4807-bc94-8596951dcf42
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:57 GMT
+      - Mon, 13 Nov 2023 13:52:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abeae860-79e5-42d6-9dd1-33af075bc0f1
+      - 1f79895b-d8bd-4d5c-866e-4a77af2462fb
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:02 GMT
+      - Mon, 13 Nov 2023 13:52:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07ebab75-47ff-48cc-9629-d6f5fe2c0219
+      - 0c771832-1036-43e5-83b9-f5266754a044
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:07 GMT
+      - Mon, 13 Nov 2023 13:52:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60e7fa51-ebb5-4acb-bbf7-a8a21851f6dc
+      - 178e9b5c-9349-4ac3-8d55-1d17e97da3c4
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:12 GMT
+      - Mon, 13 Nov 2023 13:52:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02ae5746-d30b-45af-b847-b8f1b4f7cefc
+      - 651ff7d1-c42c-4cf1-aec1-63f48009297c
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:17 GMT
+      - Mon, 13 Nov 2023 13:52:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca741245-5c55-4287-b361-dabeb10cecda
+      - 6ad2cf91-87a3-4bcc-b79a-0cbd4ea14694
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:22 GMT
+      - Mon, 13 Nov 2023 13:52:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7954829-d287-4945-abb7-7cc9dd6086b7
+      - 5418f478-189e-4398-bc4e-022b040123a2
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:27 GMT
+      - Mon, 13 Nov 2023 13:52:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 047650d8-d327-49b2-91bd-fbf5f455bee8
+      - 85065447-5bda-4945-a36e-437a22d913f7
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:32 GMT
+      - Mon, 13 Nov 2023 13:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d81add1a-8f01-49ea-bc22-b727eb9c594f
+      - 8e9d8f22-3e44-42dc-86fc-7fea2111f6ff
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:37 GMT
+      - Mon, 13 Nov 2023 13:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fe2b9b0-77c2-40b2-8a02-20552d97cba9
+      - 0c64442d-fdbf-4713-a7ad-f486dc238914
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1020,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:42 GMT
+      - Mon, 13 Nov 2023 13:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5002072c-09eb-4748-97ac-95d5de7e92f9
+      - e2ef40f5-f36d-4e26-bd7c-b5127202d7aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1053,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:47 GMT
+      - Mon, 13 Nov 2023 13:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b361579-40bf-4fdd-9ee4-b9fd32879553
+      - 6e29e98e-ab85-4792-a024-c7bcb4605327
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1086,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:52 GMT
+      - Mon, 13 Nov 2023 13:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 258c7bbd-46cc-424a-8e29-bd6bac531d0d
+      - f3d0ccea-00d0-48a2-a2fa-ad4124b3be8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1119,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:57 GMT
+      - Mon, 13 Nov 2023 13:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1074a4a-4e0c-4abc-a77c-60eab3df32d7
+      - 9136e230-4a26-464a-bc2f-09dac5fff16f
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1152,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:02 GMT
+      - Mon, 13 Nov 2023 13:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d8502db-20d0-432b-9533-9a855eb69eef
+      - 0addecec-818d-4e42-81d2-670aa13c2a05
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1185,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:07 GMT
+      - Mon, 13 Nov 2023 13:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f49a1963-2c68-4310-9b4d-2c85d5bdd2df
+      - 72f84fc5-d2c0-47fc-80d4-d64871f4ff3a
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1218,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:12 GMT
+      - Mon, 13 Nov 2023 13:53:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93e8ad10-ea9e-4df5-8d55-335fced3dece
+      - fa2ef82c-4dd8-49b3-a820-3463410cb321
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1251,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:17 GMT
+      - Mon, 13 Nov 2023 13:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 910ff7b6-ec8e-4671-9b3d-6f606b2c07ca
+      - 76062561-0c86-49e4-b76c-453c25ba52eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:22 GMT
+      - Mon, 13 Nov 2023 13:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 014705a7-db2a-4c74-a011-e69f7c6b7e30
+      - a1645cdc-d0fd-4131-a32e-b5d60a74ab08
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1317,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:27 GMT
+      - Mon, 13 Nov 2023 13:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1b0c7e3-2c73-4f08-94b7-71a578ba3fcf
+      - 5e8895b0-bd0b-40b4-9a1c-1f70c524a469
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1350,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:32 GMT
+      - Mon, 13 Nov 2023 13:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b7f65ca-732a-4454-b95b-1ae41c97a60f
+      - 1fc406d0-91e0-4111-89f0-e4ed27bd11f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1383,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:37 GMT
+      - Mon, 13 Nov 2023 13:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e63de832-31d6-436e-ac46-701683bcdd3b
+      - 6e5926ad-3201-4e47-afd5-ea8c4366da0c
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1416,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:43 GMT
+      - Mon, 13 Nov 2023 13:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c234b284-a5f1-43ce-b75f-206b393756eb
+      - 887b8d26-9497-437f-8fee-2ea2229a2374
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1449,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:48 GMT
+      - Mon, 13 Nov 2023 13:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fda69624-3f37-4c87-9c74-6eefc055b9a9
+      - 527dcab2-bbd4-4296-9f3d-77e94a1b5c91
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1482,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:53 GMT
+      - Mon, 13 Nov 2023 13:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dab67778-c950-49b0-a95e-637c96a1dffb
+      - fda9ad7e-55aa-4753-b6ea-094c20be0f3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1515,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:58 GMT
+      - Mon, 13 Nov 2023 13:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fafbc4f9-ad74-4e46-88b9-8b67e3512369
+      - b2fd7632-e807-4ff6-935d-aac2fb4e4b98
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1548,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:03 GMT
+      - Mon, 13 Nov 2023 13:54:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6633cca8-3712-4fa9-91ad-0c1bcfff5012
+      - b409e425-1626-4c5f-9d04-e06453ed17da
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1581,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:08 GMT
+      - Mon, 13 Nov 2023 13:54:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8af1a69b-469d-42e8-802f-4724fba634f6
+      - 888c7315-6a22-4ad3-ab25-87f98e1b1f81
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1614,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:13 GMT
+      - Mon, 13 Nov 2023 13:54:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b314135b-39c5-481b-abdf-43a4c8d3bda3
+      - 65cccc13-30ab-4ec7-9ca6-88e47bdbac95
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1647,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:18 GMT
+      - Mon, 13 Nov 2023 13:54:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37800fdc-c7aa-43af-8327-515bde517f92
+      - cb25af56-b678-4bd9-b664-98f13d7a70df
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1680,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:23 GMT
+      - Mon, 13 Nov 2023 13:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f75b5e3d-a440-4b14-a253-e5ba5c4bc191
+      - c2fe4040-83b5-4e82-88f7-278dfd114510
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1713,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:28 GMT
+      - Mon, 13 Nov 2023 13:54:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5d4c069-922f-45ee-8399-538d20266fff
+      - 12d5eb99-d230-41f1-b06c-70bbb9ba6104
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1746,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:33 GMT
+      - Mon, 13 Nov 2023 13:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cf80818-6163-4ea5-892f-4d36e78df22d
+      - a0375405-81c3-4151-bbf4-61f47868490a
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1779,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:38 GMT
+      - Mon, 13 Nov 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 975b1fbc-304a-47dd-9a26-9b4652bfc8fc
+      - 6d739025-4b8f-4b44-97d7-780f3ebbbd3a
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1812,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:43 GMT
+      - Mon, 13 Nov 2023 13:55:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef16c651-5809-4774-9956-d9add17cb933
+      - 04940d87-4c39-4dea-a056-ace0c759c62c
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1845,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:48 GMT
+      - Mon, 13 Nov 2023 13:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 261c4a79-5dab-4654-83df-aed24ff2041c
+      - 083e846f-cb42-49da-b90c-b429a40bd244
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1878,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
+      - Mon, 13 Nov 2023 13:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77e6a627-afbe-4701-bf9e-3a2c3f1792cc
+      - 0f6de346-7b14-45e8-b0f9-9fd63b2a88e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1911,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:58 GMT
+      - Mon, 13 Nov 2023 13:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98316ca8-7caa-4185-afff-5a5f380af762
+      - 8ed2751a-49df-47f5-9504-ad383a82017b
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1944,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:03 GMT
+      - Mon, 13 Nov 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 162e5057-1b52-41ad-8095-82ff9793b2f3
+      - b49f5cb8-5e76-4799-aadc-caf79d3e2e4c
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -1977,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:08 GMT
+      - Mon, 13 Nov 2023 13:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a2cbb2e-7a60-4784-bb24-d08735d44c3d
+      - 2862b9e6-957d-44fb-a8ef-37fe128dcfca
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -2010,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:13 GMT
+      - Mon, 13 Nov 2023 13:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4769fcc8-5fad-440c-88ce-020148471d3d
+      - 83e18ed1-96f5-45c7-b773-50dd5321e87f
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -2043,7 +2043,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:18 GMT
+      - Mon, 13 Nov 2023 13:55:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6e07667-2957-48da-a360-417cb75d2ff5
+      - 314b0f59-2190-47b7-b4b8-bc5466159caa
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,10 +2064,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -2076,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:23 GMT
+      - Mon, 13 Nov 2023 13:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc4cd018-2a12-48c1-bed3-670c7f5b82a3
+      - f10bc343-16fa-4b6a-8fae-3181f71aa4f3
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,10 +2097,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:24:01.138277Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "704"
@@ -2109,7 +2109,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:28 GMT
+      - Mon, 13 Nov 2023 13:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71ecc817-e880-4057-a141-14682adad570
+      - e6279897-32de-40d6-860e-621c7c9b6c8a
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,10 +2130,241 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 094d427b-69b8-4c5f-af5d-abe8a5098585
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 278f2352-4fce-4c55-bddb-78566aaa54ed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b002abf3-f094-41b2-87e7-21161afdef8d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40fd6f9c-db84-4411-8f13-d000f056ff7f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dc6efa7e-f926-4692-a2ee-30fb8b86f2ed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 296adc38-b80a-48a9-84d0-19015bb70181
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:51:23.845654Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "704"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d69e865-0c86-4024-abe4-ca688cf6b5ce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:36.132559Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "702"
@@ -2142,7 +2373,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 124629d0-346e-4126-8ccc-736a8ff49e8c
+      - fef9e892-2b8e-49ac-9498-0b8fab60109d
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,10 +2394,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:53:07.031299Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -2175,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeaed230-1779-4d5c-9d96-c8e23e7976aa
+      - 373ddebb-5583-4df1-8021-ec7075236c55
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,10 +2427,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:36.132559Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "702"
@@ -2208,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a40bdcee-9d9a-42d8-bbe8-04e5cabcef18
+      - d1379fdc-3caf-4bed-aa76-46f102971a02
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/nodes?order_by=created_at_asc&page=1&pool_id=4b3e3185-7e9a-405b-aa91-d57a3e648a76&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:29.106280Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:33.625301Z","error_message":null,"id":"57a0a7bc-4bfe-4f7e-ba2c-561da517d857","name":"scw-test-pool-kubelet-test-pool-kubelet-57a0a7","pool_id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","provider_id":"scaleway://instance/fr-par-1/72e04501-cdd6-472a-bbae-df560e8b8463","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:36.115428Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f26f246c-7b71-4181-9977-c17e3e76316f
+      - 86535bf9-716f-48eb-8be1-5b42acda8fc8
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,10 +2493,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:53:07.031299Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -2274,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 732ffb94-8b02-4b2d-bfbe-6677af4d793e
+      - 7d091959-3bc7-47cc-994f-05dd3340c117
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2526,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:36.132559Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "702"
@@ -2307,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b22ce951-ad9b-4035-bcd0-d144ee15fb47
+      - 632f91af-f07c-48e1-867d-ee9de5cbea5a
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,10 +2559,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/511ca9f5-fe23-4f59-b44a-7d1f5d2d202e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.727465Z","dhcp_enabled":true,"id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.727465Z","id":"488240ba-5d41-4d09-b1b6-b2d469032b08","subnet":"172.16.20.0/22","updated_at":"2023-11-13T13:51:13.727465Z"},{"created_at":"2023-11-13T13:51:13.727465Z","id":"939c821c-e485-4b6a-a237-421d27ff4bb9","subnet":"fd63:256c:45f7:94cd::/64","updated_at":"2023-11-13T13:51:13.727465Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.727465Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "723"
@@ -2340,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4c5f683-23a9-491e-a625-2a9373d7425f
+      - c7bf47ef-2f94-41e0-ab57-460876491c4c
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,10 +2592,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:53:07.031299Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -2373,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5568f35-b238-43d4-af2f-a892c6236d8f
+      - 8a87aab3-d542-4cb4-a530-e6d09ef8332c
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,10 +2625,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BOTVU1c2IxaEVWRTE2VFZSRmQwOVVSWHBOYWsweFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVwckNtUm9NbGRHVjBzeUwycHhNWE50ZFRZdmEzVnVTamRpTUZScFRtSm9UMnB5UWxwaWFFVlJhR05tUjJ0R1QzbEZWblpEUVVobFV6aEtkV2RzUms5RlowOEtkamhEY0RkM2FtbzNaRWhoZEc5MlJIRkJSRGhYUlRGR1IwRnRaR1ZGVm1Vdkt6QXZhVlpDU2tKU1FqWnVNR2N2YUd0dE5EWnNZbHBVYzBobVVFTkdSZ3BZVkZoQlpXSnRUMnBYVWtKWmVrZG5SQ3RHZG5kb05rUktiMmxtVlU1RFFWcE1hVzV5WkdSSVVsbHNPVzFsS3pkeVMzazJNWEl2WXpNdlkySXdMM2RqQ21GclRXWlBUREoyZW5SaE56RjNWV2xtYzI1YVUzTnNSVzFYWVU1WVNXaG5iRTB3YkZWdlpscHBkMDB2VGtacGFHdzVhMWxWYmtkblpIQXdhRWRZZDI0S1l6Vm5XRTh5Vkd3NU9WcEdSVTFEY210Wk1FMXphMGRJWmxGUE5TdEZTM0U1TW5WVGIyWm1SbmQzYWtGUFVqZEhUbWhLV0VwbU5EUkhNV05XY1docGJBcFBUWFIwUTJrNWVraDRRMmhXUmxoUFUySnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxSbEV4UjNoeksxTndjM1ZMYldocWF6WTRibVF5YURRclFtTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjV0p3Y25VNUwzSnhURXBRWlRCSVpDOWphbWRQVTFWWlYwMUVTV0ptTVRoM2MzaHFXbk5GYUZFNGJXRnNjMlJhZVFwbll6bEtWbWN5Wmk5dE5tVTVNRzh2WjFGVEsyNWhVMVUwU2prelpHMUJka2MxU1dGUmNra3JOR1pIYW5sbUwzQndORE5qU1UwNGFFSktVVFF3YzBoS0NucEhablowZW1KSU0zWkhhM0ZLU0hwcGFVSjBSVTlrWTB4UlF6WnpNbWx4V1RJek5VeG9PRXB4V0VkVVJsVkpNVk4wVjJGdmNuWnVSU3R6ZG1wTlIxQUtSbmRYWjFkRVowMTZObFpvWjJOcmExQjJXVE5HUTB0cFRGWlNjSGhrWlUxQ1NYYzViM3BwTjBWVlpXUmFkWFZKUzB3M2FIbFdNVVZwU2pScGR6aGtNZ3B2TUdsM1V6TkJiMHhGY1hwVVRGZzRSR2c1VUhSamVGUkRURFExVkRrelJGcFBXR0ozZURoRk1IUnFNVGw1Vm01aVZIWjFZVzgwUm5kcWFWWlRNa28wQ21SeGFqQlFZMmhNZEU5NWFtWldVRkJZWVdWeU1EVkhOMlY2YmpoUVdscHBhMmREVWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2E4MmFkOWE1LWFhMjMtNGRlNy1hYTAzLWE5OGQyNDBkMTMzZC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBtVTN3Mm9MYTROcm5ndUl4bVhyeVhiZVltWjRTYVd5RjdUVXduS0xtZFNVaUt4Z0liaVhnZktMVQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZUU5V2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGl0YUNsaDBXa2N3UlU1V1ZFaHFjMnhpV0ZRclFtdDZNbEYwSzBkS1prcE9PVmhtYWs0eFFucHdaRmR2T1hkbVZERk5UVEprTXpsNWNHaENNM2wzWkZCNk1DOEthRmhZT1VkcVRHWkxWalJoU0hWeFV6TnZTV1prZUhwaFZqRnVNRGx1UjJwWmRHbFVZbkZOWVd0TVpUVkJhMDR5VjJGVlVXeFdjRE5yUVdoTVZraFNZd3BhYVU1SFFuUldaeTh2YkZweFRGbHBWMkpQYWtjeVdYZFBUVll5U2pkRU1rdHRRV2RzV21sTllsQmpTV0ZNYUdsMGF6STNRMU5RVlhjMGMwMVRWV2R2Q2s1cVpVMXJVMnB3UmpodU9ITk1NbTlpZDNRemJuVlBXalE0WkZGMGFUQlZZekpqTm01aWNrbGFSRU13TVdwT2NtWmpZU3RHYTJseFpGY3ZVR3hxTVdzS2FVZEtXbVZKUldReFUzWlBNSHB1Y0RkbGFHbElWSFF4Tm1JemRVdGhWbFpOZERBek9HRjFSRXBsZVZSWVZUTXJhMm80VFM5VVkyeFViMmhOZDFsTmVncE5aVVUzVTFOcVdVbHRXV0pHVlRaWFowUmpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZRMDUxVlZnNFUwWk5ORlY1WVVwVlJGTkRlbEVyUkVKbWRtSk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMGh5ZFVodEsyNXhlVGRWTjNaVWN6WTFLMWgwV1RKc00wNUVlbTU1U3pGNVFYTnlkRVZ5YnpkVk1YZDZPVWxMVHdveGVDOXhWbTFqU0d0RlFsbGlObGxOWWtoSlFtcG9VMUoyYVZoWVZURmlhRFpoVlRFeFMwRmFUMGg1Y2trMFdVTXpVM0JXU25VMmVXbFVWa2RhU3pZNUNtUlhMMnRCYW1wV1ExUXlTR1J5TlVaTWNrWnFaRm81VDFobFRUbFhZa3BtZVVOVlZYRTJWMjgwZFVoc1ZFcDNWRnB6YTB4cWNFVkpZMVkxT1RJMFQwc0tVRk5rWVc4ck9UVjRZWFl2U1dWWE9HVmtSV05SUVRSSWNXRmpibTFPZVhWR2VrWjVOVEppTDJ4UWIyZ3pWVmhoZUd0MVMwcHRVa2x5TWxNcmRESldXZ3A2Y1daV2VsSTRPVTlQUTJoMVVrdHpZMUJtVVVkc1prUnNNRzVMYTJsT1luQkhkMjlMVjBnMFoySTFTbW8wTm1vclQzTlpSaXR0VkdoRFRIZzBNU3R6Q21KTGMzcEhZMVJ3ZG0xbVpXaG1RblJ2WkVoYUswMTFSREYxVlVZeVpFaDVXamhMU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y3MmY5N2JiLTk3Y2EtNDRjYi05MzMwLWQ3N2UwZDA5YzIwMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBSV2t1OXNrS0R0Z1hHR2R3VnZ5U3o4dVhHMk16QmNuQmI5QzJZNFpBYUl6eVM4T2piOXozbU1lYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2670"
@@ -2406,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abcb1685-6834-409c-ac72-d3aa9e7ca61d
+      - 7b0decad-0931-47fd-9870-a75fd1210cdd
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,10 +2658,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:36.132559Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "702"
@@ -2439,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d218d9d3-5cdf-4f49-9784-d1a21336166d
+      - 5b562aea-121a-40f2-a9ea-26b08712732e
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2691,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/nodes?order_by=created_at_asc&page=1&pool_id=4b3e3185-7e9a-405b-aa91-d57a3e648a76&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:29.106280Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:33.625301Z","error_message":null,"id":"57a0a7bc-4bfe-4f7e-ba2c-561da517d857","name":"scw-test-pool-kubelet-test-pool-kubelet-57a0a7","pool_id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","provider_id":"scaleway://instance/fr-par-1/72e04501-cdd6-472a-bbae-df560e8b8463","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:36.115428Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d4f9e46-a9c4-42ab-89d3-ea01b1f5f3c6
+      - b8e5a5d7-f115-48cd-8f79-7de3899bd122
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,10 +2724,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/511ca9f5-fe23-4f59-b44a-7d1f5d2d202e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.727465Z","dhcp_enabled":true,"id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.727465Z","id":"488240ba-5d41-4d09-b1b6-b2d469032b08","subnet":"172.16.20.0/22","updated_at":"2023-11-13T13:51:13.727465Z"},{"created_at":"2023-11-13T13:51:13.727465Z","id":"939c821c-e485-4b6a-a237-421d27ff4bb9","subnet":"fd63:256c:45f7:94cd::/64","updated_at":"2023-11-13T13:51:13.727465Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.727465Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "723"
@@ -2505,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e213401b-9c77-4047-ad9a-4ab4db88ae90
+      - 61d4d548-2771-4c24-ac96-e235eec9bd0f
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,10 +2757,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:53:07.031299Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -2538,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fcd36b8-f790-4edf-9aed-a0b89f30d339
+      - 161424d8-e3b7-4741-9c16-4d2feddfc89b
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,10 +2790,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BOTVU1c2IxaEVWRTE2VFZSRmQwOVVSWHBOYWsweFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVwckNtUm9NbGRHVjBzeUwycHhNWE50ZFRZdmEzVnVTamRpTUZScFRtSm9UMnB5UWxwaWFFVlJhR05tUjJ0R1QzbEZWblpEUVVobFV6aEtkV2RzUms5RlowOEtkamhEY0RkM2FtbzNaRWhoZEc5MlJIRkJSRGhYUlRGR1IwRnRaR1ZGVm1Vdkt6QXZhVlpDU2tKU1FqWnVNR2N2YUd0dE5EWnNZbHBVYzBobVVFTkdSZ3BZVkZoQlpXSnRUMnBYVWtKWmVrZG5SQ3RHZG5kb05rUktiMmxtVlU1RFFWcE1hVzV5WkdSSVVsbHNPVzFsS3pkeVMzazJNWEl2WXpNdlkySXdMM2RqQ21GclRXWlBUREoyZW5SaE56RjNWV2xtYzI1YVUzTnNSVzFYWVU1WVNXaG5iRTB3YkZWdlpscHBkMDB2VGtacGFHdzVhMWxWYmtkblpIQXdhRWRZZDI0S1l6Vm5XRTh5Vkd3NU9WcEdSVTFEY210Wk1FMXphMGRJWmxGUE5TdEZTM0U1TW5WVGIyWm1SbmQzYWtGUFVqZEhUbWhLV0VwbU5EUkhNV05XY1docGJBcFBUWFIwUTJrNWVraDRRMmhXUmxoUFUySnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxSbEV4UjNoeksxTndjM1ZMYldocWF6WTRibVF5YURRclFtTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjV0p3Y25VNUwzSnhURXBRWlRCSVpDOWphbWRQVTFWWlYwMUVTV0ptTVRoM2MzaHFXbk5GYUZFNGJXRnNjMlJhZVFwbll6bEtWbWN5Wmk5dE5tVTVNRzh2WjFGVEsyNWhVMVUwU2prelpHMUJka2MxU1dGUmNra3JOR1pIYW5sbUwzQndORE5qU1UwNGFFSktVVFF3YzBoS0NucEhablowZW1KSU0zWkhhM0ZLU0hwcGFVSjBSVTlrWTB4UlF6WnpNbWx4V1RJek5VeG9PRXB4V0VkVVJsVkpNVk4wVjJGdmNuWnVSU3R6ZG1wTlIxQUtSbmRYWjFkRVowMTZObFpvWjJOcmExQjJXVE5HUTB0cFRGWlNjSGhrWlUxQ1NYYzViM3BwTjBWVlpXUmFkWFZKUzB3M2FIbFdNVVZwU2pScGR6aGtNZ3B2TUdsM1V6TkJiMHhGY1hwVVRGZzRSR2c1VUhSamVGUkRURFExVkRrelJGcFBXR0ozZURoRk1IUnFNVGw1Vm01aVZIWjFZVzgwUm5kcWFWWlRNa28wQ21SeGFqQlFZMmhNZEU5NWFtWldVRkJZWVdWeU1EVkhOMlY2YmpoUVdscHBhMmREVWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2E4MmFkOWE1LWFhMjMtNGRlNy1hYTAzLWE5OGQyNDBkMTMzZC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBtVTN3Mm9MYTROcm5ndUl4bVhyeVhiZVltWjRTYVd5RjdUVXduS0xtZFNVaUt4Z0liaVhnZktMVQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZUU5V2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGl0YUNsaDBXa2N3UlU1V1ZFaHFjMnhpV0ZRclFtdDZNbEYwSzBkS1prcE9PVmhtYWs0eFFucHdaRmR2T1hkbVZERk5UVEprTXpsNWNHaENNM2wzWkZCNk1DOEthRmhZT1VkcVRHWkxWalJoU0hWeFV6TnZTV1prZUhwaFZqRnVNRGx1UjJwWmRHbFVZbkZOWVd0TVpUVkJhMDR5VjJGVlVXeFdjRE5yUVdoTVZraFNZd3BhYVU1SFFuUldaeTh2YkZweFRGbHBWMkpQYWtjeVdYZFBUVll5U2pkRU1rdHRRV2RzV21sTllsQmpTV0ZNYUdsMGF6STNRMU5RVlhjMGMwMVRWV2R2Q2s1cVpVMXJVMnB3UmpodU9ITk1NbTlpZDNRemJuVlBXalE0WkZGMGFUQlZZekpqTm01aWNrbGFSRU13TVdwT2NtWmpZU3RHYTJseFpGY3ZVR3hxTVdzS2FVZEtXbVZKUldReFUzWlBNSHB1Y0RkbGFHbElWSFF4Tm1JemRVdGhWbFpOZERBek9HRjFSRXBsZVZSWVZUTXJhMm80VFM5VVkyeFViMmhOZDFsTmVncE5aVVUzVTFOcVdVbHRXV0pHVlRaWFowUmpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZRMDUxVlZnNFUwWk5ORlY1WVVwVlJGTkRlbEVyUkVKbWRtSk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMGh5ZFVodEsyNXhlVGRWTjNaVWN6WTFLMWgwV1RKc00wNUVlbTU1U3pGNVFYTnlkRVZ5YnpkVk1YZDZPVWxMVHdveGVDOXhWbTFqU0d0RlFsbGlObGxOWWtoSlFtcG9VMUoyYVZoWVZURmlhRFpoVlRFeFMwRmFUMGg1Y2trMFdVTXpVM0JXU25VMmVXbFVWa2RhU3pZNUNtUlhMMnRCYW1wV1ExUXlTR1J5TlVaTWNrWnFaRm81VDFobFRUbFhZa3BtZVVOVlZYRTJWMjgwZFVoc1ZFcDNWRnB6YTB4cWNFVkpZMVkxT1RJMFQwc0tVRk5rWVc4ck9UVjRZWFl2U1dWWE9HVmtSV05SUVRSSWNXRmpibTFPZVhWR2VrWjVOVEppTDJ4UWIyZ3pWVmhoZUd0MVMwcHRVa2x5TWxNcmRESldXZ3A2Y1daV2VsSTRPVTlQUTJoMVVrdHpZMUJtVVVkc1prUnNNRzVMYTJsT1luQkhkMjlMVjBnMFoySTFTbW8wTm1vclQzTlpSaXR0VkdoRFRIZzBNU3R6Q21KTGMzcEhZMVJ3ZG0xbVpXaG1RblJ2WkVoYUswMTFSREYxVlVZeVpFaDVXamhMU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y3MmY5N2JiLTk3Y2EtNDRjYi05MzMwLWQ3N2UwZDA5YzIwMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBSV2t1OXNrS0R0Z1hHR2R3VnZ5U3o4dVhHMk16QmNuQmI5QzJZNFpBYUl6eVM4T2piOXozbU1lYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2670"
@@ -2571,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 673f83a6-fc4b-4ad6-8a76-4443004e07d3
+      - b5926afa-4480-47bd-9391-fa203a3c95d5
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,10 +2823,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:29.125754Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:36.132559Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "702"
@@ -2604,7 +2835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 988ba9d3-3886-4d94-a5cf-f859c6a14666
+      - ce747409-4680-46c6-9dfb-72ba054f64db
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,19 +2856,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/nodes?order_by=created_at_asc&page=1&pool_id=4b3e3185-7e9a-405b-aa91-d57a3e648a76&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:29.106280Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:33.625301Z","error_message":null,"id":"57a0a7bc-4bfe-4f7e-ba2c-561da517d857","name":"scw-test-pool-kubelet-test-pool-kubelet-57a0a7","pool_id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","provider_id":"scaleway://instance/fr-par-1/72e04501-cdd6-472a-bbae-df560e8b8463","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:36.115428Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ce0b9ae-2d8e-4414-898e-6b39117e450a
+      - f811896e-f7f5-4fc3-a9cf-d39787d59f58
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,10 +2891,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: PATCH
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327170Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:39.684172015Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "703"
@@ -2672,7 +2903,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:36 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2682,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0d32a9b-67b1-4f5c-9f1f-7fe2c7d0f1d6
+      - dd19d708-c3fc-4e11-8504-c6c499919f2e
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,10 +2924,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:39.684172Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "700"
@@ -2705,7 +2936,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:36 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2715,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4228d0e4-caf1-4a2a-b29b-13a2b3cd04df
+      - 7d1895d7-44ef-4a6f-adc3-98bd0d659f01
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,10 +2957,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:39.684172Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "700"
@@ -2738,7 +2969,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:36 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 582aa171-d0bf-4c40-b972-d2e89f03bb67
+      - 053eb9dc-8abe-44ba-9b1b-608864e7a9db
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,19 +2990,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/nodes?order_by=created_at_asc&page=1&pool_id=4b3e3185-7e9a-405b-aa91-d57a3e648a76&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:29.106280Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:33.625301Z","error_message":null,"id":"57a0a7bc-4bfe-4f7e-ba2c-561da517d857","name":"scw-test-pool-kubelet-test-pool-kubelet-57a0a7","pool_id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","provider_id":"scaleway://instance/fr-par-1/72e04501-cdd6-472a-bbae-df560e8b8463","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:36.115428Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "657"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:36 GMT
+      - Mon, 13 Nov 2023 13:56:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2781,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f96485f-f7cb-45a5-933f-a7bb82f25164
+      - 3b561ea5-76b5-498d-a7f8-8f4966efb36b
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,10 +3023,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:53:07.031299Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -2804,7 +3035,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:36 GMT
+      - Mon, 13 Nov 2023 13:56:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e465c439-d21e-413c-83a9-e194542e1ed5
+      - 950cc9da-71af-41ff-878e-c6fc1f255b63
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,10 +3056,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:39.684172Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "700"
@@ -2837,7 +3068,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:37 GMT
+      - Mon, 13 Nov 2023 13:56:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37b0d989-a9c9-404a-be09-8cdb4c11d095
+      - fbb513ec-f42a-4973-a1f2-4072c2d4c83f
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,10 +3089,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/511ca9f5-fe23-4f59-b44a-7d1f5d2d202e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:53.658333Z","dhcp_enabled":true,"id":"9c19e300-3794-483b-96af-3d4c4bf7023b","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:53.658333Z","id":"b69253a2-725b-4aa8-9fe8-c99345b259f3","subnet":"172.16.36.0/22","updated_at":"2023-11-10T13:23:53.658333Z"},{"created_at":"2023-11-10T13:23:53.658333Z","id":"437d744b-7360-457d-9ac3-e7d84d6b1b37","subnet":"fd63:256c:45f7:fa96::/64","updated_at":"2023-11-10T13:23:53.658333Z"}],"tags":[],"updated_at":"2023-11-10T13:23:53.658333Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.727465Z","dhcp_enabled":true,"id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.727465Z","id":"488240ba-5d41-4d09-b1b6-b2d469032b08","subnet":"172.16.20.0/22","updated_at":"2023-11-13T13:51:13.727465Z"},{"created_at":"2023-11-13T13:51:13.727465Z","id":"939c821c-e485-4b6a-a237-421d27ff4bb9","subnet":"fd63:256c:45f7:94cd::/64","updated_at":"2023-11-13T13:51:13.727465Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.727465Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "723"
@@ -2870,7 +3101,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:37 GMT
+      - Mon, 13 Nov 2023 13:56:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c4512c9-76a4-4b66-b280-cd976b632e0b
+      - da6a90a3-8d0a-44db-89a2-572ff8353713
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,10 +3122,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:25:28.421458Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:53:07.031299Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1507"
@@ -2903,7 +3134,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:37 GMT
+      - Mon, 13 Nov 2023 13:56:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52892fe7-4ac5-43b6-9f46-7b90ae7f5a5a
+      - 9da9dea8-b05e-4eb1-a392-fe008f6ec264
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,10 +3155,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BOTVU1c2IxaEVWRTE2VFZSRmQwOVVSWHBOYWsweFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVwckNtUm9NbGRHVjBzeUwycHhNWE50ZFRZdmEzVnVTamRpTUZScFRtSm9UMnB5UWxwaWFFVlJhR05tUjJ0R1QzbEZWblpEUVVobFV6aEtkV2RzUms5RlowOEtkamhEY0RkM2FtbzNaRWhoZEc5MlJIRkJSRGhYUlRGR1IwRnRaR1ZGVm1Vdkt6QXZhVlpDU2tKU1FqWnVNR2N2YUd0dE5EWnNZbHBVYzBobVVFTkdSZ3BZVkZoQlpXSnRUMnBYVWtKWmVrZG5SQ3RHZG5kb05rUktiMmxtVlU1RFFWcE1hVzV5WkdSSVVsbHNPVzFsS3pkeVMzazJNWEl2WXpNdlkySXdMM2RqQ21GclRXWlBUREoyZW5SaE56RjNWV2xtYzI1YVUzTnNSVzFYWVU1WVNXaG5iRTB3YkZWdlpscHBkMDB2VGtacGFHdzVhMWxWYmtkblpIQXdhRWRZZDI0S1l6Vm5XRTh5Vkd3NU9WcEdSVTFEY210Wk1FMXphMGRJWmxGUE5TdEZTM0U1TW5WVGIyWm1SbmQzYWtGUFVqZEhUbWhLV0VwbU5EUkhNV05XY1docGJBcFBUWFIwUTJrNWVraDRRMmhXUmxoUFUySnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkxSbEV4UjNoeksxTndjM1ZMYldocWF6WTRibVF5YURRclFtTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjV0p3Y25VNUwzSnhURXBRWlRCSVpDOWphbWRQVTFWWlYwMUVTV0ptTVRoM2MzaHFXbk5GYUZFNGJXRnNjMlJhZVFwbll6bEtWbWN5Wmk5dE5tVTVNRzh2WjFGVEsyNWhVMVUwU2prelpHMUJka2MxU1dGUmNra3JOR1pIYW5sbUwzQndORE5qU1UwNGFFSktVVFF3YzBoS0NucEhablowZW1KSU0zWkhhM0ZLU0hwcGFVSjBSVTlrWTB4UlF6WnpNbWx4V1RJek5VeG9PRXB4V0VkVVJsVkpNVk4wVjJGdmNuWnVSU3R6ZG1wTlIxQUtSbmRYWjFkRVowMTZObFpvWjJOcmExQjJXVE5HUTB0cFRGWlNjSGhrWlUxQ1NYYzViM3BwTjBWVlpXUmFkWFZKUzB3M2FIbFdNVVZwU2pScGR6aGtNZ3B2TUdsM1V6TkJiMHhGY1hwVVRGZzRSR2c1VUhSamVGUkRURFExVkRrelJGcFBXR0ozZURoRk1IUnFNVGw1Vm01aVZIWjFZVzgwUm5kcWFWWlRNa28wQ21SeGFqQlFZMmhNZEU5NWFtWldVRkJZWVdWeU1EVkhOMlY2YmpoUVdscHBhMmREVWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2E4MmFkOWE1LWFhMjMtNGRlNy1hYTAzLWE5OGQyNDBkMTMzZC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBtVTN3Mm9MYTROcm5ndUl4bVhyeVhiZVltWjRTYVd5RjdUVXduS0xtZFNVaUt4Z0liaVhnZktMVQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZUU5V2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGl0YUNsaDBXa2N3UlU1V1ZFaHFjMnhpV0ZRclFtdDZNbEYwSzBkS1prcE9PVmhtYWs0eFFucHdaRmR2T1hkbVZERk5UVEprTXpsNWNHaENNM2wzWkZCNk1DOEthRmhZT1VkcVRHWkxWalJoU0hWeFV6TnZTV1prZUhwaFZqRnVNRGx1UjJwWmRHbFVZbkZOWVd0TVpUVkJhMDR5VjJGVlVXeFdjRE5yUVdoTVZraFNZd3BhYVU1SFFuUldaeTh2YkZweFRGbHBWMkpQYWtjeVdYZFBUVll5U2pkRU1rdHRRV2RzV21sTllsQmpTV0ZNYUdsMGF6STNRMU5RVlhjMGMwMVRWV2R2Q2s1cVpVMXJVMnB3UmpodU9ITk1NbTlpZDNRemJuVlBXalE0WkZGMGFUQlZZekpqTm01aWNrbGFSRU13TVdwT2NtWmpZU3RHYTJseFpGY3ZVR3hxTVdzS2FVZEtXbVZKUldReFUzWlBNSHB1Y0RkbGFHbElWSFF4Tm1JemRVdGhWbFpOZERBek9HRjFSRXBsZVZSWVZUTXJhMm80VFM5VVkyeFViMmhOZDFsTmVncE5aVVUzVTFOcVdVbHRXV0pHVlRaWFowUmpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZRMDUxVlZnNFUwWk5ORlY1WVVwVlJGTkRlbEVyUkVKbWRtSk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOMGh5ZFVodEsyNXhlVGRWTjNaVWN6WTFLMWgwV1RKc00wNUVlbTU1U3pGNVFYTnlkRVZ5YnpkVk1YZDZPVWxMVHdveGVDOXhWbTFqU0d0RlFsbGlObGxOWWtoSlFtcG9VMUoyYVZoWVZURmlhRFpoVlRFeFMwRmFUMGg1Y2trMFdVTXpVM0JXU25VMmVXbFVWa2RhU3pZNUNtUlhMMnRCYW1wV1ExUXlTR1J5TlVaTWNrWnFaRm81VDFobFRUbFhZa3BtZVVOVlZYRTJWMjgwZFVoc1ZFcDNWRnB6YTB4cWNFVkpZMVkxT1RJMFQwc0tVRk5rWVc4ck9UVjRZWFl2U1dWWE9HVmtSV05SUVRSSWNXRmpibTFPZVhWR2VrWjVOVEppTDJ4UWIyZ3pWVmhoZUd0MVMwcHRVa2x5TWxNcmRESldXZ3A2Y1daV2VsSTRPVTlQUTJoMVVrdHpZMUJtVVVkc1prUnNNRzVMYTJsT1luQkhkMjlMVjBnMFoySTFTbW8wTm1vclQzTlpSaXR0VkdoRFRIZzBNU3R6Q21KTGMzcEhZMVJ3ZG0xbVpXaG1RblJ2WkVoYUswMTFSREYxVlVZeVpFaDVXamhMU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y3MmY5N2JiLTk3Y2EtNDRjYi05MzMwLWQ3N2UwZDA5YzIwMC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBSV2t1OXNrS0R0Z1hHR2R3VnZ5U3o4dVhHMk16QmNuQmI5QzJZNFpBYUl6eVM4T2piOXozbU1lYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2670"
@@ -2936,7 +3167,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:37 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28642a61-3e26-4f15-9745-b42293ddbfcd
+      - f21c9825-23cd-4f45-9af7-c9bfa145611f
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,10 +3188,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:36.403327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:39.684172Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "700"
@@ -2969,7 +3200,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:37 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d40d8675-76c5-4249-a878-298365b87da9
+      - 13de40cd-bea3-46bd-acc6-dcb14e8f18e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,19 +3221,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d/nodes?order_by=created_at_asc&page=1&pool_id=e02f30cc-f9d8-4e88-8146-9248f1a509a6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200/nodes?order_by=created_at_asc&page=1&pool_id=4b3e3185-7e9a-405b-aa91-d57a3e648a76&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:58.681804Z","error_message":null,"id":"13129cb6-8f2c-44fa-a6d8-ee2f7ea6a199","name":"scw-test-pool-kubelet-test-pool-kubelet-13129c","pool_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","provider_id":"scaleway://instance/fr-par-1/c82a9383-54ce-4829-b11a-dc98669f4c1b","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:37.113612Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:33.625301Z","error_message":null,"id":"57a0a7bc-4bfe-4f7e-ba2c-561da517d857","name":"scw-test-pool-kubelet-test-pool-kubelet-57a0a7","pool_id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","provider_id":"scaleway://instance/fr-par-1/72e04501-cdd6-472a-bbae-df560e8b8463","public_ip_v4":"163.172.144.233","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:40.373842Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "687"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:37 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f86d94c1-daa2-468e-96ef-2fa3d0729799
+      - e6dcb128-cf50-40fb-bb0d-f2bb891c83c8
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,10 +3254,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:45.491236029Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "706"
@@ -3035,7 +3266,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:38 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3663377-8045-47ff-b933-50189e967d52
+      - 4f19dd28-dc08-49df-bcbb-ce8a48f35288
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,10 +3287,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:45.491236Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "703"
@@ -3068,7 +3299,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:38 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - affe5295-20f7-4cbc-b7e0-6c0e44a3e68c
+      - 04c8654d-be68-47d6-a2ab-7dcb85cad5de
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,10 +3320,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:45.491236Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "703"
@@ -3101,7 +3332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:43 GMT
+      - Mon, 13 Nov 2023 13:56:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 606d5349-2192-478a-bfe3-7461bf9cb9c7
+      - e891af92-e8d6-46fc-8113-ef8c6c7de783
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,10 +3353,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:45.491236Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "703"
@@ -3134,7 +3365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:48 GMT
+      - Mon, 13 Nov 2023 13:56:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1da96b34-4527-4d4a-a938-3d5d8326c3cc
+      - 0262f38e-840a-424f-9e7f-f56fc32e0b8a
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,10 +3386,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","container_runtime":"containerd","created_at":"2023-11-10T13:24:01.115969Z","id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-10T13:28:38.443385Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.813889Z","id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-13T13:56:45.491236Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "703"
@@ -3167,7 +3398,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:53 GMT
+      - Mon, 13 Nov 2023 13:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd53eba4-6ccf-4541-ac71-23b50d23e9e1
+      - 2631b029-e3b1-4f40-9652-07c09c2c30e3
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,10 +3419,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3200,7 +3431,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:58 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3210,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a225c3b-9204-453d-ab0c-0611c5419cbe
+      - cd5d9631-ef6e-4b24-b55f-2de8f991f458
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3221,10 +3452,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:28:58.914769034Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:57:05.854212028Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -3233,7 +3464,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:58 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3243,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f86deced-2689-4fb5-a6ae-ac0b47fa4656
+      - 70467746-357d-4254-ae5d-4f20015c41b5
     status: 200 OK
     code: 200
     duration: ""
@@ -3254,10 +3485,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:28:58.914769Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:57:05.854212Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -3266,7 +3497,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:59 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 384e2b0d-d22e-452d-b99f-13725fe4dda9
+      - 870e8769-520d-489c-9f2d-8f71eda3bc54
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,10 +3518,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:28:58.914769Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f72f97bb-97ca-44cb-9330-d77e0d09c200.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.399724Z","created_at":"2023-11-13T13:51:18.399724Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f72f97bb-97ca-44cb-9330-d77e0d09c200.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-13T13:57:05.854212Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1510"
@@ -3299,7 +3530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:04 GMT
+      - Mon, 13 Nov 2023 13:57:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f9212f5-8415-4aab-9a46-882895c2dc04
+      - 265f99b4-f2b5-4d6c-ac74-0dbfd1aa90b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,43 +3551,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a82ad9a5-aa23-4de7-aa03-a98d240d133d.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:54.823947Z","created_at":"2023-11-10T13:23:54.823947Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a82ad9a5-aa23-4de7-aa03-a98d240d133d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-10T13:28:58.914769Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1510"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fac0a070-31c2-4661-af8f-f973c0347435
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3365,7 +3563,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:14 GMT
+      - Mon, 13 Nov 2023 13:57:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc7d5db3-08e7-4a34-a66a-cf50b81bd56b
+      - 73fad4c1-1088-4f1e-bbc7-ea30861bb68c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3386,10 +3584,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/511ca9f5-fe23-4f59-b44a-7d1f5d2d202e
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3398,7 +3596,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:14 GMT
+      - Mon, 13 Nov 2023 13:57:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 624e0eb6-9644-4371-a29c-fce036acb5b0
+      - 5c39e906-6218-43bc-abeb-dd6dd753c65e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3419,76 +3617,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9c19e300-3794-483b-96af-3d4c4bf7023b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4b3e3185-7e9a-405b-aa91-d57a3e648a76
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9c19e300-3794-483b-96af-3d4c4bf7023b","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ba668d8c-61fc-4551-a710-5fde0bf2bf09
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a82ad9a5-aa23-4de7-aa03-a98d240d133d
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a82ad9a5-aa23-4de7-aa03-a98d240d133d","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd0cda55-ba65-4d1e-8388-0c24aad4f906
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e02f30cc-f9d8-4e88-8146-9248f1a509a6
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"e02f30cc-f9d8-4e88-8146-9248f1a509a6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"4b3e3185-7e9a-405b-aa91-d57a3e648a76","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3497,7 +3629,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:14 GMT
+      - Mon, 13 Nov 2023 13:57:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +3639,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc1face7-9c34-4f4b-8863-4f4cbd1da091
+      - a5f15efb-0266-4ef3-8805-5754a80e3ff3
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f72f97bb-97ca-44cb-9330-d77e0d09c200
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f72f97bb-97ca-44cb-9330-d77e0d09c200","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 734ba41c-0385-4b34-b6ec-4cd05bdac12c
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/511ca9f5-fe23-4f59-b44a-7d1f5d2d202e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"511ca9f5-fe23-4f59-b44a-7d1f5d2d202e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dc9bd91e-e999-4aaf-a505-16de00255a7d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-placement-group.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-placement-group.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 707d4a41-924d-4336-bcb5-777fe181af3d
+      - 94e14949-85a9-45f6-9674-b513b25151e7
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"f84af29a-0e2c-4482-a38d-0da33e116f63","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"8980538f-16df-41a2-a00f-3653a5e91e1d","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -59,9 +59,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:10 GMT
+      - Mon, 13 Nov 2023 13:51:14 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8980538f-16df-41a2-a00f-3653a5e91e1d
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acad753f-3867-49a9-b535-d035800100cd
+      - 69491d29-5d8e-48d1-8c3c-379dd6990669
     status: 201 Created
     code: 201
     duration: ""
@@ -82,10 +82,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8980538f-16df-41a2-a00f-3653a5e91e1d
     method: GET
   response:
-    body: '{"placement_group":{"id":"f84af29a-0e2c-4482-a38d-0da33e116f63","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"8980538f-16df-41a2-a00f-3653a5e91e1d","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -94,7 +94,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:10 GMT
+      - Mon, 13 Nov 2023 13:51:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -104,7 +104,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8eb94aa-0919-4fd0-8885-c1e63cff631c
+      - cf7874e4-402f-4965-9096-ea3bac597688
     status: 200 OK
     code: 200
     duration: ""
@@ -120,7 +120,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:24:10.753323Z","dhcp_enabled":true,"id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:24:10.753323Z","id":"fdd2c378-0e1b-4835-992a-e28546ff3067","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:24:10.753323Z"},{"created_at":"2023-11-10T13:24:10.753323Z","id":"dc0f9772-eae0-4816-bfb2-d67ad16b55db","subnet":"fd63:256c:45f7:36bd::/64","updated_at":"2023-11-10T13:24:10.753323Z"}],"tags":[],"updated_at":"2023-11-10T13:24:10.753323Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:14.496479Z","dhcp_enabled":true,"id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:14.496479Z","id":"b3a91bdf-14d6-40c0-85d4-ae9534f1c338","subnet":"172.16.44.0/22","updated_at":"2023-11-13T13:51:14.496479Z"},{"created_at":"2023-11-13T13:51:14.496479Z","id":"5ca7e2c2-7730-4aa5-89ed-1b2ef3ecfb80","subnet":"fd63:256c:45f7:2eef::/64","updated_at":"2023-11-13T13:51:14.496479Z"}],"tags":[],"updated_at":"2023-11-13T13:51:14.496479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "726"
@@ -129,7 +129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:12 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,7 +139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef5a1b1f-648c-41ce-9457-dd77d924cfec
+      - 1cb59476-1f0f-493b-8ad7-00ae740b6809
     status: 200 OK
     code: 200
     duration: ""
@@ -150,10 +150,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f0132fc5-df47-4028-8fa7-33fe283aeb6b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8b5b10dc-070e-40e0-9881-b70984aa0e68
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:24:10.753323Z","dhcp_enabled":true,"id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:24:10.753323Z","id":"fdd2c378-0e1b-4835-992a-e28546ff3067","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:24:10.753323Z"},{"created_at":"2023-11-10T13:24:10.753323Z","id":"dc0f9772-eae0-4816-bfb2-d67ad16b55db","subnet":"fd63:256c:45f7:36bd::/64","updated_at":"2023-11-10T13:24:10.753323Z"}],"tags":[],"updated_at":"2023-11-10T13:24:10.753323Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:14.496479Z","dhcp_enabled":true,"id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:14.496479Z","id":"b3a91bdf-14d6-40c0-85d4-ae9534f1c338","subnet":"172.16.44.0/22","updated_at":"2023-11-13T13:51:14.496479Z"},{"created_at":"2023-11-13T13:51:14.496479Z","id":"5ca7e2c2-7730-4aa5-89ed-1b2ef3ecfb80","subnet":"fd63:256c:45f7:2eef::/64","updated_at":"2023-11-13T13:51:14.496479Z"}],"tags":[],"updated_at":"2023-11-13T13:51:14.496479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "726"
@@ -162,7 +162,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:13 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -172,12 +172,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce56f192-6bec-4796-a8fd-fa07a0425c8f
+      - 1e1e48b6-0d35-4bb9-a46e-8d7f5dacdad0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-placement-group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-placement-group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68"}'
     form: {}
     headers:
       Content-Type:
@@ -188,7 +188,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402070557Z","created_at":"2023-11-10T13:24:13.402070557Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:13.412363565Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851449698Z","created_at":"2023-11-13T13:51:18.851449698Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.862832504Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1525"
@@ -197,7 +197,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:13 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70d93466-5049-4f5f-b2be-5d5689a4fbba
+      - 4ac6373f-4b5d-49a8-89b1-2d496f0ccf5b
     status: 200 OK
     code: 200
     duration: ""
@@ -218,10 +218,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:13.412364Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.862833Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -230,7 +230,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:13 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d9cb01e-8a8a-437b-9847-6f570d1779ce
+      - 62d9dd2b-a108-4e5d-bef0-49706097fecd
     status: 200 OK
     code: 200
     duration: ""
@@ -251,10 +251,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:15.099942Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.633579Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:18 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1f4028c-7bf5-486e-9ca4-048551807c9b
+      - 08c9ca83-617a-42c4-829d-18095c9c52ba
     status: 200 OK
     code: 200
     duration: ""
@@ -284,10 +284,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:15.099942Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.633579Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -296,7 +296,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:18 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 785322a6-b0a0-43a6-b5eb-b8ac4c6062a7
+      - f3437902-f6d4-49dd-bc4d-4bb2b8011f88
     status: 200 OK
     code: 200
     duration: ""
@@ -317,10 +317,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BSZUU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWxGNFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd3MUNrRTRSbkp2YWtZdlRXRnhjMVJUUjFKUFUzQk9aRlJxY1ZaRFRVaDZkWGcxVTBoaFFWZHVla1UzUVRoNU5YVTFiM0ZPWWxKc1JWRjFlVEZIZFhObmMwVUtRa296WldWQlZEUlZWakpRVXpOUVVreFFkVEZ5VjA5R1VrcEpiMkk0UTBSMGVtUXdWVzFJY1M4eFYxRjFSSFZXYTNKS2R5OXFTME5qWjNSUVJFTkNTQXA0TjBOM05EbEpiVVkxZDFsdE1sYzNkRVUxTUhkSFMybE9jRTlMZHk5Q00xSkJaVFpwV0Rob1YyOXRhbk1yY1U1TFUwWlVlbTVKWlV0NmJtTkJaV3R3Q2twMWVtZzBiRmxRT0dkMFZWcFZaMUZqTlRFMFRYWkhNR3h5ZG1kbmVHTjNaM1lyWkhGVmVXRlFUblZWWWtONGFVNDBUMjFLTTNjd1VESTBZVkZqYXk4S1FYVnFjRnA0Ym1NM05HRjJiV2xIT0dOdVNUaElkV04zZWxSdmNuVllXbWgyU1hkc2JGbzRla2cxVWxJMmVtNVpTRTFqUjA4MFF6RmFTMkZ4TDJWMFJncHdSUzlYTkdKcWJuaGFhRTF0TURrd09HWlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBjVk5CYTFoSFpscExZV1JsV1ZRd05IUnhaMUZZVFRGSVZsTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRUMDB3TUdkaFdXSm5aRkpVVmpGMGVqbDRXa2x4WnpSdFdqTXdjSFowT1RONlRqTTVkVkUzTVV4RE5FUjZZVEZKYndvMk5FSktlWFF4VVM5dldWRjZNWFpzVmt0RVIwNDFkMjFDYWtwQk0zWnZiREJLUVZsaGVIUlFUa3RQVW5WWVRHUm1SMGxTWlV3MU5HbzBMMkYyVDBGUUNsaDFjWFZzUkVOT1UxZDJTRXBVVjI1dVRDdFNOMmd4UTNsSU9UUktOVE5ITldKU2VtRjNlWEUzU0ZkelEwVmtiVXBhTTB0YVpsTjFURkE0YjNkSU1Vd0tabkJtTVZrMlZXWTRWM2xpV1hWSVpFSjJMMnRvZVhOUVVuWndjR0ZSYnpKblJVWktMMDQ1TWpNNGFtOXBTMmwzYnpCaFQwTnphMWx6YzNwcmNtVktaUXBzTkhJeVRsTlFaR0pPZFVFeWQzRmpRa3hUYVZRMVUwSnBRVkZDZFhrMFdWbzJkelV4YnpKU1JWaDFTMnRVYkc1aE15OHdSblYxVmtoc05sSjJOemx1Q2xGdlZsVjJTbkEwZUdGclowTXpPWFVyUnpFMVlWSm1SRGxWTVRkSFpYQXlWMDF2VkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUwZDhlNzYzLTIzM2YtNDc0Yi1hMTQ1LTA0NjJlODg1NDUwZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3WnhTdUVvSVpleG1SN0c3aGh3WmVOWXhCdm9KOFVib1FacWZnZXhIaDFBQUNDNFFLaVNlQW1VOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVSVENuRnNTbk5JTlRCSVdXZERjMjk0UzNFNFpURldjMUEzWmxCa1dtbHNRMVIxZUdreFNsZHFURTQxVVV0RldtdENORVZLZUhWeWJrMTJRMFJMYUZSaFJ6RUtRWEpVVW5oSlpFazBhRGQ1Y21sMlVHdFhZbTVNU2t0RFVUbHVSMjgzY0ZScVlsRnBSM2hPVFRkTFpHMDFVekV2UVdZd2RHSnRZblZ2ZEdaSlNUTXhUUXBSU3poSFdsQlZWVm8zWlM5VlIxQndjeTlEUkRSNGVXcHFPVWsxWjJGVFpuRnJUbVJRZERVeWNUZGxhVFJyVUdOWk0zVk1kVU4yUVRSU1JWSnpTbFJ1Q2xSUVpXVXhiVGt6YVdGNGNrUXdNWFkyUnpReFRWWkNiazAyWTFKNU9XdEJiSFZwTHpGclRtWXJjRGRUSzJGeVlTdHhkVFY0UW1kbVdHbGpWa2hhT0ZFS1dUQk5kMnhCYlRGbFoydFRjbkUyZDJZeWMwWjBXR2hvVGpVdk9VaG9XVUZvU2tKWVdFUkNUMU4yU3prNFVXZ3pUWE5SU1dkR2NVMVJPSGRhTW5OUFRRcFJORXg1UjFSaGIyVkxSblYwTHl0QmMyTXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXVFppYXl0VmJEUnJjemxNZUZCUVpESm1SbkZxUlZwSFVHMU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNWSFpuVTBwNVZYTlBiRE5RY2xoMlZWSXlkRXdyWkhCM1kwMXBSR2R6VlN0TlRuZGtVMGxrZVdSSlZFSmFTSGQwT0FveE5WSmpZbk0wVkdOWWFqQTFaRmRDY1ZaTU16VXhXbU5EU0ZaMVZrcHphSE5xVkVsR1RHYzFaRkZKTkdkYVprRjBlbE5hU3pFNFRESTVUV3RaWTFOa0NpdGFkbk5oTm1WV1kyeExaREJGUjNwdlIzSnNSMlpwYWpOeE1uQjNTRTByZWs4clRtbFFNVE5IYWs1elFucGxSRkpxT1hwek5VZE1RMmg0Y1hSVGJHa0tTa1UyZFVoSlUya3JjVTFLUVd4SlNqZHhjSE5yVkdOeVJISXJWRTB2YWs1eFNtWTFaRFIxUjBSUWQwaDNSVTU0TXpONGNUWXpibVU1TWxGNlVGRnJZd3BWTm1wRFNUVllZWEJhUms5bWVITkpVR1JGZFRkQlFWbEhSMUJSY1RGSVlraE9SRUpGUjJveGNEQnNRblJVYmpCVVlUUnBielJ1WW5OaVQwNVBjMjlDQ214TWJsWjNZbFJvU1cweWExQXljRVJEY0djcmJVWm9PV2MyWVc5bU1HTlBPR013YUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2FkMDk4OWYzLWRhMWItNDRlNy1hMzJhLWNhZGYzMjExMmUzMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzbWRWUjNUdEVSdjczWTVkeVBYY0E5dW9iWVpYYXJJbnhDSHhweW8wWnBqclMzS29LTjlOQ1hxbA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2694"
@@ -329,7 +329,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:18 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c482e69-9dce-43f3-bb48-f4884a9fb0fa
+      - a3271e66-3864-4e12-85e8-ed08bddda398
     status: 200 OK
     code: 200
     duration: ""
@@ -350,10 +350,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:24:15.099942Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.633579Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -362,7 +362,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:18 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -372,12 +372,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 866df43b-29ef-4809-b250-eaf9d29d0846
+      - 058f796a-11f6-4098-8081-a24a967fa36a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
+    body: '{"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -385,10 +385,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968699836Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115456Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "674"
@@ -397,7 +397,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:19 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -407,7 +407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3519f0a6-e60b-4c14-990f-28ef5018eeee
+      - 8f6b9870-b384-4342-b2d3-605477ae06f9
     status: 200 OK
     code: 200
     duration: ""
@@ -418,10 +418,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -430,7 +430,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:19 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -440,7 +440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 839e1be3-858c-40d2-9828-8d5c5eb9a869
+      - 546557b7-512f-4a4c-bfc5-b59fc18f1134
     status: 200 OK
     code: 200
     duration: ""
@@ -451,10 +451,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -463,7 +463,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:24 GMT
+      - Mon, 13 Nov 2023 13:51:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fa18620-ef60-4f01-b078-663ff0b69b20
+      - fcabea7b-1340-4c07-a334-f5a140799242
     status: 200 OK
     code: 200
     duration: ""
@@ -484,10 +484,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -496,7 +496,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:29 GMT
+      - Mon, 13 Nov 2023 13:51:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -506,7 +506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbfdd265-eee5-4790-a03a-ab678ee753f7
+      - 2a5f57fe-180e-4726-9054-58bf1027cd78
     status: 200 OK
     code: 200
     duration: ""
@@ -517,10 +517,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -529,7 +529,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:34 GMT
+      - Mon, 13 Nov 2023 13:51:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -539,7 +539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93b77503-6fb8-4993-8d8b-614d155547c1
+      - e04e0c73-db75-44e4-a34a-ab26903d9cfb
     status: 200 OK
     code: 200
     duration: ""
@@ -550,10 +550,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -562,7 +562,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:39 GMT
+      - Mon, 13 Nov 2023 13:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -572,7 +572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0834f2d-9f2f-4b45-8398-60c2f82fc631
+      - 9290928a-7f45-47a6-add0-3e8ed95875d5
     status: 200 OK
     code: 200
     duration: ""
@@ -583,10 +583,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -595,7 +595,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:44 GMT
+      - Mon, 13 Nov 2023 13:51:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5d42bf9-9441-4e9f-b9cb-73d050f8803d
+      - 22dd31b2-2270-478e-8ca3-d5908deb728a
     status: 200 OK
     code: 200
     duration: ""
@@ -616,10 +616,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -628,7 +628,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:49 GMT
+      - Mon, 13 Nov 2023 13:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ae7d084-bcda-4def-8e14-5fca7e8cc547
+      - 8ed76134-30b0-4b80-8526-20979c272b09
     status: 200 OK
     code: 200
     duration: ""
@@ -649,10 +649,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -661,7 +661,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:54 GMT
+      - Mon, 13 Nov 2023 13:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e2885bd-8f1c-4200-a6d1-3d76c15c705c
+      - f4b13378-36f1-4f0f-adda-b4bb706112d9
     status: 200 OK
     code: 200
     duration: ""
@@ -682,10 +682,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -694,7 +694,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:59 GMT
+      - Mon, 13 Nov 2023 13:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -704,7 +704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3b97ab9-0891-4b12-bfdc-22192ad68e66
+      - 00a6f202-49a8-4a51-93f5-3d563451d2fd
     status: 200 OK
     code: 200
     duration: ""
@@ -715,10 +715,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -727,7 +727,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:04 GMT
+      - Mon, 13 Nov 2023 13:52:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -737,7 +737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f1798ed-8678-415f-a9d0-b9b85cdd3cca
+      - c0f220f5-0a45-4657-85df-0df568f875ac
     status: 200 OK
     code: 200
     duration: ""
@@ -748,10 +748,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -760,7 +760,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:09 GMT
+      - Mon, 13 Nov 2023 13:52:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -770,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22709a7a-4edd-4ca9-8c92-107393f1eede
+      - c392ae6f-74be-4cef-9588-f49391e46c95
     status: 200 OK
     code: 200
     duration: ""
@@ -781,10 +781,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -793,7 +793,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:14 GMT
+      - Mon, 13 Nov 2023 13:52:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -803,7 +803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af10567a-8762-4fe1-b951-c399d6b3f9ab
+      - ea598d58-ff36-4601-8b8d-e912435cf27b
     status: 200 OK
     code: 200
     duration: ""
@@ -814,10 +814,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -826,7 +826,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:19 GMT
+      - Mon, 13 Nov 2023 13:52:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c27c904-68e6-4109-b2c1-06402f5e3203
+      - 26f44993-d548-427f-aea9-1327d6690876
     status: 200 OK
     code: 200
     duration: ""
@@ -847,10 +847,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -859,7 +859,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:24 GMT
+      - Mon, 13 Nov 2023 13:52:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -869,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1115b16-8678-4da2-b00e-ae0a4ef4d1ca
+      - 84d1bb50-a05b-4c04-ad89-3f3c169aa361
     status: 200 OK
     code: 200
     duration: ""
@@ -880,10 +880,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -892,7 +892,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:30 GMT
+      - Mon, 13 Nov 2023 13:52:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -902,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d81367f9-b97f-45ab-b5cb-4adff46c64ba
+      - 4387023f-fc02-4e91-b25f-09057b995a7e
     status: 200 OK
     code: 200
     duration: ""
@@ -913,10 +913,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -925,7 +925,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:35 GMT
+      - Mon, 13 Nov 2023 13:52:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -935,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c267261-ee20-4be4-a15b-5633b2e24474
+      - 60ad9ca1-5827-4902-a014-614b1f91444f
     status: 200 OK
     code: 200
     duration: ""
@@ -946,10 +946,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -958,7 +958,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:40 GMT
+      - Mon, 13 Nov 2023 13:52:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -968,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 856d76ac-3058-4416-a44f-1240d4591cc2
+      - 55be3f25-f63b-4086-a0c2-66a26bce7a93
     status: 200 OK
     code: 200
     duration: ""
@@ -979,10 +979,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -991,7 +991,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:45 GMT
+      - Mon, 13 Nov 2023 13:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1001,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef135f05-4c21-4852-999d-b25d86bd6396
+      - 14762fd4-7672-44f2-a8de-b0782eec6e3a
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,10 +1012,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1024,7 +1024,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:50 GMT
+      - Mon, 13 Nov 2023 13:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1034,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12b38643-1872-492f-81ba-5f8607682715
+      - 6e4e757e-2271-4331-a4eb-f80e195107bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,10 +1045,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1057,7 +1057,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:55 GMT
+      - Mon, 13 Nov 2023 13:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1067,7 +1067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec18b224-0b97-437c-aa49-ac153f602305
+      - 048a5678-9f34-4548-8283-dfffc49a9335
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,10 +1078,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1090,7 +1090,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:00 GMT
+      - Mon, 13 Nov 2023 13:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1100,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f373b518-f221-4a11-a754-02c6fab217e8
+      - 6fa1fb0b-3321-4488-aaed-270d2237f96e
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,10 +1111,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1123,7 +1123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:05 GMT
+      - Mon, 13 Nov 2023 13:53:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1133,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fd774fd-aa1a-484b-acc5-fe5ad916d7da
+      - 598a218b-a1a1-4943-bbc2-8cf9524b9ca5
     status: 200 OK
     code: 200
     duration: ""
@@ -1144,10 +1144,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1156,7 +1156,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:10 GMT
+      - Mon, 13 Nov 2023 13:53:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92bf773d-c7c6-4a59-958e-a6d4a3dd32e5
+      - db57c466-edee-48f7-b6e5-a9bb13a69cec
     status: 200 OK
     code: 200
     duration: ""
@@ -1177,10 +1177,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1189,7 +1189,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:15 GMT
+      - Mon, 13 Nov 2023 13:53:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a118094f-c7eb-4bc9-933e-6431713304f4
+      - 5e17c299-5d2e-4d36-94a5-4912c0ae62a7
     status: 200 OK
     code: 200
     duration: ""
@@ -1210,10 +1210,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1222,7 +1222,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:20 GMT
+      - Mon, 13 Nov 2023 13:53:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5ade3b8-482e-43b6-828c-bf7eca02210f
+      - 11ed3d24-37e0-470b-b804-c5e78d88a22c
     status: 200 OK
     code: 200
     duration: ""
@@ -1243,10 +1243,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1255,7 +1255,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:25 GMT
+      - Mon, 13 Nov 2023 13:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1265,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 903c9e13-2d46-41c1-922b-b46c86a06094
+      - d99f691e-e6fb-4a92-a22c-9e8dfa16c6cb
     status: 200 OK
     code: 200
     duration: ""
@@ -1276,10 +1276,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1288,7 +1288,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:30 GMT
+      - Mon, 13 Nov 2023 13:53:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1298,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb1d17b1-24bb-40c6-9277-7ba4aabf0b0a
+      - 792143b7-f3b6-452b-826f-78b24c429bec
     status: 200 OK
     code: 200
     duration: ""
@@ -1309,10 +1309,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1321,7 +1321,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:35 GMT
+      - Mon, 13 Nov 2023 13:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1331,7 +1331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a888a66e-1659-454b-ab34-3edfa04ec358
+      - 9a9704f8-a980-4bbc-a054-748af4ec3ba7
     status: 200 OK
     code: 200
     duration: ""
@@ -1342,10 +1342,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1354,7 +1354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:40 GMT
+      - Mon, 13 Nov 2023 13:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1364,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab7b3f38-1ec2-4fb6-9d13-8e0bc5b975a4
+      - 67f19f43-03da-4ea6-9493-c6105e553418
     status: 200 OK
     code: 200
     duration: ""
@@ -1375,10 +1375,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1387,7 +1387,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:45 GMT
+      - Mon, 13 Nov 2023 13:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1397,7 +1397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b27efe76-f043-4474-b620-220c635f2e81
+      - d74b1161-42df-447b-998a-645ae9708269
     status: 200 OK
     code: 200
     duration: ""
@@ -1408,10 +1408,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1420,7 +1420,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:50 GMT
+      - Mon, 13 Nov 2023 13:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1430,7 +1430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6621b971-47eb-4b71-a4f3-b3e6a5501a2a
+      - 507320a0-c58d-4d6b-bfe8-c83cfc2ac013
     status: 200 OK
     code: 200
     duration: ""
@@ -1441,10 +1441,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1453,7 +1453,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:55 GMT
+      - Mon, 13 Nov 2023 13:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1463,7 +1463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2df36f35-54c7-4308-8bdf-5bf19a56b83a
+      - 005e806a-6575-4119-bf77-cc27b0e2e3f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1474,10 +1474,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1486,7 +1486,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:00 GMT
+      - Mon, 13 Nov 2023 13:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1496,7 +1496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be2bb69e-6ca4-4a1b-98c5-289b2c3b4e19
+      - a8aa05c2-1552-42bf-b93c-80178308a90e
     status: 200 OK
     code: 200
     duration: ""
@@ -1507,10 +1507,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1519,7 +1519,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:05 GMT
+      - Mon, 13 Nov 2023 13:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1529,7 +1529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 831f7951-eb45-4fa3-8c7f-fb0fdbaef2d0
+      - 72c995df-0d0c-404b-ad54-51fb0334106b
     status: 200 OK
     code: 200
     duration: ""
@@ -1540,10 +1540,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1552,7 +1552,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:11 GMT
+      - Mon, 13 Nov 2023 13:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,7 +1562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 358ee1fc-90da-45b0-ac2c-ca288688831e
+      - 1f51903e-0805-4d21-a5c2-47e9d6d1d310
     status: 200 OK
     code: 200
     duration: ""
@@ -1573,10 +1573,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1585,7 +1585,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:16 GMT
+      - Mon, 13 Nov 2023 13:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1595,7 +1595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02703413-91f1-46d8-842a-6c251ed56aa8
+      - da6007ee-5720-49db-8f07-e86d19819825
     status: 200 OK
     code: 200
     duration: ""
@@ -1606,10 +1606,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1618,7 +1618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:21 GMT
+      - Mon, 13 Nov 2023 13:54:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1628,7 +1628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d10e0dd6-8841-41a2-afdf-7a22d81ab819
+      - 4e98ddbc-5c07-4b20-84f7-3d1bab274cb8
     status: 200 OK
     code: 200
     duration: ""
@@ -1639,10 +1639,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1651,7 +1651,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:26 GMT
+      - Mon, 13 Nov 2023 13:54:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1661,7 +1661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b49201f-726b-41fd-8438-09818f86d880
+      - 9382c67c-b299-4588-a20a-820607cd73bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1672,10 +1672,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1684,7 +1684,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:31 GMT
+      - Mon, 13 Nov 2023 13:54:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1694,7 +1694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f25effed-0233-43e6-b0ff-b4f08df10513
+      - bf519856-67b6-4336-89f3-f203a0ef2dc8
     status: 200 OK
     code: 200
     duration: ""
@@ -1705,10 +1705,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1717,7 +1717,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:36 GMT
+      - Mon, 13 Nov 2023 13:54:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1727,7 +1727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8453a396-00ca-4736-801a-5552b4353b86
+      - e875139f-7b3f-4f3b-bb9d-dd3c3dae0a3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1738,10 +1738,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1750,7 +1750,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:41 GMT
+      - Mon, 13 Nov 2023 13:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1760,7 +1760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21f10121-55f2-4152-afeb-f1294d846ee9
+      - 2904899e-14e3-49f3-b9cb-c30aa3354f6a
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,10 +1771,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1783,7 +1783,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:46 GMT
+      - Mon, 13 Nov 2023 13:54:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1793,7 +1793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 355071b8-7445-4620-972f-884140786a70
+      - 157c7e64-62aa-4476-b707-e2c8aa03e37c
     status: 200 OK
     code: 200
     duration: ""
@@ -1804,10 +1804,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1816,7 +1816,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:51 GMT
+      - Mon, 13 Nov 2023 13:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1826,7 +1826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38439422-5bab-44ec-9fde-bbf432a7691a
+      - 3ef9b7c0-2835-4812-8fd8-f73ca93cb55f
     status: 200 OK
     code: 200
     duration: ""
@@ -1837,10 +1837,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1849,7 +1849,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:56 GMT
+      - Mon, 13 Nov 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1859,7 +1859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24cb6a5c-a859-455c-9511-17e832e81182
+      - d67d78a9-f1ea-4b05-8720-fbebeaf2b2ff
     status: 200 OK
     code: 200
     duration: ""
@@ -1870,10 +1870,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1882,7 +1882,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:01 GMT
+      - Mon, 13 Nov 2023 13:55:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1892,7 +1892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8687a844-5c35-427a-bf7d-f9829d03d107
+      - 59f424de-7a8d-4a2b-bc9b-a6999d500d05
     status: 200 OK
     code: 200
     duration: ""
@@ -1903,10 +1903,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1915,7 +1915,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:06 GMT
+      - Mon, 13 Nov 2023 13:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1925,7 +1925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76c82573-1e9b-44be-adf6-5bd8782368fa
+      - 37d73a7c-c9dd-4fa4-9909-ac924860d9ee
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,10 +1936,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1948,7 +1948,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1958,7 +1958,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa5a29d8-3e06-4057-a6c8-cfa2ea8e2814
+      - 841585b5-d838-484a-8f8d-db5f3d37204e
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,10 +1969,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -1981,7 +1981,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:16 GMT
+      - Mon, 13 Nov 2023 13:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1991,7 +1991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a54676f2-2cfd-4219-9800-1cb1bd63f9d6
+      - 998c5dab-50e4-4889-a328-6e7309c8bc7e
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,10 +2002,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2014,7 +2014,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:21 GMT
+      - Mon, 13 Nov 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2024,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30d8a3e6-cdcc-4f60-a561-ee1fe687ce12
+      - 5b31f590-e312-44e0-8051-f1cfcda6abd0
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,10 +2035,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2047,7 +2047,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:26 GMT
+      - Mon, 13 Nov 2023 13:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2057,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd6a8ba4-e591-49f7-a787-9d1bee195e95
+      - 8ac879a8-29f3-424c-8ebb-809694aae9ac
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,10 +2068,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2080,7 +2080,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:31 GMT
+      - Mon, 13 Nov 2023 13:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2090,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfe330dc-4a42-43ba-a407-63f1ff66aeff
+      - bcdb12b8-515a-4aa9-af65-69b968b76c5c
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,10 +2101,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2113,7 +2113,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:36 GMT
+      - Mon, 13 Nov 2023 13:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2123,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3acb6033-9201-4951-a550-7b30e91fe201
+      - 4fab8860-5f88-4588-9d26-e3dde87f085a
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,10 +2134,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2146,7 +2146,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:41 GMT
+      - Mon, 13 Nov 2023 13:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2156,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 327e9135-083b-4588-ad60-2814ecae9d17
+      - d467e3a0-252c-4a0c-a43e-9e777f4ff239
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,10 +2167,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2179,7 +2179,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 13:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2189,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8cd6ee6-28c1-402b-bf88-281b0e2e847b
+      - 70bc4c4e-2dfb-456e-8ffe-0fdba8602699
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,10 +2200,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2212,7 +2212,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:52 GMT
+      - Mon, 13 Nov 2023 13:56:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2222,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15b01fa4-46f7-4fe4-8af0-8379476a452f
+      - d88dbf2d-aa32-4c92-84b5-2147ec4b9ab9
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,10 +2233,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2245,7 +2245,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:57 GMT
+      - Mon, 13 Nov 2023 13:56:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 157e6397-f879-44f3-982b-2ac5349abac3
+      - 04cae0bd-e234-423a-a400-e83496e49c56
     status: 200 OK
     code: 200
     duration: ""
@@ -2266,10 +2266,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2278,7 +2278,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:02 GMT
+      - Mon, 13 Nov 2023 13:56:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2288,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cffc88ba-273e-45c3-b80d-f70878322200
+      - 5d75a1b8-8b69-4d7e-8cf1-29a5923e083f
     status: 200 OK
     code: 200
     duration: ""
@@ -2299,10 +2299,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:24.384115Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "671"
@@ -2311,7 +2311,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:07 GMT
+      - Mon, 13 Nov 2023 13:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2321,7 +2321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87018a01-96e5-4058-9fef-1555d50db7e8
+      - f87868aa-767b-4f1f-8dcf-5a20ccd5e038
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,43 +2332,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:24:18.968700Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dad54234-4785-4b9c-af5c-c3f4581b8c29
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:17.272333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -2377,7 +2344,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:17 GMT
+      - Mon, 13 Nov 2023 13:56:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2387,7 +2354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca0f2947-96b9-4310-9250-9cc26eeae198
+      - b6502029-c56f-4318-8aa3-76ec35bc8a0b
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,10 +2365,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:25:29.301440Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:53:11.205901Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2410,7 +2377,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:17 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2420,7 +2387,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2022309-ec72-41ca-a80d-29befa49c6eb
+      - cfe960df-0d72-4b7f-a3cb-9d182b5fa0ad
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,10 +2398,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:17.272333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -2443,7 +2410,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:17 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2453,7 +2420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 419a9f92-43a5-4ada-9dc1-a478f711780f
+      - d1261e5d-fdb1-49b2-b623-78a39c26caa9
     status: 200 OK
     code: 200
     duration: ""
@@ -2464,19 +2431,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/nodes?order_by=created_at_asc&page=1&pool_id=5b83fc02-791d-409e-9a6a-617f693efb13&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33/nodes?order_by=created_at_asc&page=1&pool_id=6c929fde-f625-43ea-9db3-5413c5cac0b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:58.352043Z","error_message":null,"id":"28043bc2-995c-4c87-b9ab-8b8f8887086d","name":"scw-test-pool-placeme-test-pool-placeme-28043b","pool_id":"5b83fc02-791d-409e-9a6a-617f693efb13","provider_id":"scaleway://instance/fr-par-1/5f404cf7-73dc-4d65-b603-1d7b5c1e9b77","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:14.119351Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:35.223529Z","error_message":null,"id":"7249918f-5508-4947-8cb2-49d6ff093024","name":"scw-test-pool-placeme-test-pool-placeme-724991","pool_id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","provider_id":"scaleway://instance/fr-par-1/4c41e6c0-83a4-4b55-a3a9-a47921126a6c","public_ip_v4":"51.158.101.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:17.255963Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:17 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89edc1bf-8525-4b1e-8680-2555a63e0fb7
+      - 00c0b868-c028-4faf-9edc-ea715e0b7e79
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,10 +2464,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:25:29.301440Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:53:11.205901Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2509,7 +2476,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:17 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2519,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28ce8f16-5ddf-4d39-860f-7efba4bf09b1
+      - 424c242e-76da-487a-97f2-30daa7f8b69c
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,10 +2497,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:17.272333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -2542,7 +2509,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:17 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2552,7 +2519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1e0b04a-c761-474f-83e0-cc4386b01e5b
+      - 991cf0d1-5151-48a1-8a75-7e418d6a87f0
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,10 +2530,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f0132fc5-df47-4028-8fa7-33fe283aeb6b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8b5b10dc-070e-40e0-9881-b70984aa0e68
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:24:10.753323Z","dhcp_enabled":true,"id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:24:10.753323Z","id":"fdd2c378-0e1b-4835-992a-e28546ff3067","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:24:10.753323Z"},{"created_at":"2023-11-10T13:24:10.753323Z","id":"dc0f9772-eae0-4816-bfb2-d67ad16b55db","subnet":"fd63:256c:45f7:36bd::/64","updated_at":"2023-11-10T13:24:10.753323Z"}],"tags":[],"updated_at":"2023-11-10T13:24:10.753323Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:14.496479Z","dhcp_enabled":true,"id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:14.496479Z","id":"b3a91bdf-14d6-40c0-85d4-ae9534f1c338","subnet":"172.16.44.0/22","updated_at":"2023-11-13T13:51:14.496479Z"},{"created_at":"2023-11-13T13:51:14.496479Z","id":"5ca7e2c2-7730-4aa5-89ed-1b2ef3ecfb80","subnet":"fd63:256c:45f7:2eef::/64","updated_at":"2023-11-13T13:51:14.496479Z"}],"tags":[],"updated_at":"2023-11-13T13:51:14.496479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "726"
@@ -2575,7 +2542,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2585,7 +2552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a3781d8-343b-47f0-9f2e-777e4971a325
+      - e9b193de-1388-470b-9ca4-a31d123484bd
     status: 200 OK
     code: 200
     duration: ""
@@ -2596,10 +2563,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8980538f-16df-41a2-a00f-3653a5e91e1d
     method: GET
   response:
-    body: '{"placement_group":{"id":"f84af29a-0e2c-4482-a38d-0da33e116f63","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"8980538f-16df-41a2-a00f-3653a5e91e1d","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -2608,7 +2575,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2618,7 +2585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6f634f9-cda8-4fab-8527-39042e3c41d7
+      - b7539756-399f-4440-9ce1-5b849ec441f3
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,10 +2596,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:25:29.301440Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:53:11.205901Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2641,7 +2608,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2651,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e07ac8a9-2a70-40ce-b500-3a6a5a52d0e4
+      - a8df6eda-c769-47d7-af45-7a157b5be792
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,10 +2629,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BSZUU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWxGNFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd3MUNrRTRSbkp2YWtZdlRXRnhjMVJUUjFKUFUzQk9aRlJxY1ZaRFRVaDZkWGcxVTBoaFFWZHVla1UzUVRoNU5YVTFiM0ZPWWxKc1JWRjFlVEZIZFhObmMwVUtRa296WldWQlZEUlZWakpRVXpOUVVreFFkVEZ5VjA5R1VrcEpiMkk0UTBSMGVtUXdWVzFJY1M4eFYxRjFSSFZXYTNKS2R5OXFTME5qWjNSUVJFTkNTQXA0TjBOM05EbEpiVVkxZDFsdE1sYzNkRVUxTUhkSFMybE9jRTlMZHk5Q00xSkJaVFpwV0Rob1YyOXRhbk1yY1U1TFUwWlVlbTVKWlV0NmJtTkJaV3R3Q2twMWVtZzBiRmxRT0dkMFZWcFZaMUZqTlRFMFRYWkhNR3h5ZG1kbmVHTjNaM1lyWkhGVmVXRlFUblZWWWtONGFVNDBUMjFLTTNjd1VESTBZVkZqYXk4S1FYVnFjRnA0Ym1NM05HRjJiV2xIT0dOdVNUaElkV04zZWxSdmNuVllXbWgyU1hkc2JGbzRla2cxVWxJMmVtNVpTRTFqUjA4MFF6RmFTMkZ4TDJWMFJncHdSUzlYTkdKcWJuaGFhRTF0TURrd09HWlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBjVk5CYTFoSFpscExZV1JsV1ZRd05IUnhaMUZZVFRGSVZsTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRUMDB3TUdkaFdXSm5aRkpVVmpGMGVqbDRXa2x4WnpSdFdqTXdjSFowT1RONlRqTTVkVkUzTVV4RE5FUjZZVEZKYndvMk5FSktlWFF4VVM5dldWRjZNWFpzVmt0RVIwNDFkMjFDYWtwQk0zWnZiREJLUVZsaGVIUlFUa3RQVW5WWVRHUm1SMGxTWlV3MU5HbzBMMkYyVDBGUUNsaDFjWFZzUkVOT1UxZDJTRXBVVjI1dVRDdFNOMmd4UTNsSU9UUktOVE5ITldKU2VtRjNlWEUzU0ZkelEwVmtiVXBhTTB0YVpsTjFURkE0YjNkSU1Vd0tabkJtTVZrMlZXWTRWM2xpV1hWSVpFSjJMMnRvZVhOUVVuWndjR0ZSYnpKblJVWktMMDQ1TWpNNGFtOXBTMmwzYnpCaFQwTnphMWx6YzNwcmNtVktaUXBzTkhJeVRsTlFaR0pPZFVFeWQzRmpRa3hUYVZRMVUwSnBRVkZDZFhrMFdWbzJkelV4YnpKU1JWaDFTMnRVYkc1aE15OHdSblYxVmtoc05sSjJOemx1Q2xGdlZsVjJTbkEwZUdGclowTXpPWFVyUnpFMVlWSm1SRGxWTVRkSFpYQXlWMDF2VkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUwZDhlNzYzLTIzM2YtNDc0Yi1hMTQ1LTA0NjJlODg1NDUwZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3WnhTdUVvSVpleG1SN0c3aGh3WmVOWXhCdm9KOFVib1FacWZnZXhIaDFBQUNDNFFLaVNlQW1VOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVSVENuRnNTbk5JTlRCSVdXZERjMjk0UzNFNFpURldjMUEzWmxCa1dtbHNRMVIxZUdreFNsZHFURTQxVVV0RldtdENORVZLZUhWeWJrMTJRMFJMYUZSaFJ6RUtRWEpVVW5oSlpFazBhRGQ1Y21sMlVHdFhZbTVNU2t0RFVUbHVSMjgzY0ZScVlsRnBSM2hPVFRkTFpHMDFVekV2UVdZd2RHSnRZblZ2ZEdaSlNUTXhUUXBSU3poSFdsQlZWVm8zWlM5VlIxQndjeTlEUkRSNGVXcHFPVWsxWjJGVFpuRnJUbVJRZERVeWNUZGxhVFJyVUdOWk0zVk1kVU4yUVRSU1JWSnpTbFJ1Q2xSUVpXVXhiVGt6YVdGNGNrUXdNWFkyUnpReFRWWkNiazAyWTFKNU9XdEJiSFZwTHpGclRtWXJjRGRUSzJGeVlTdHhkVFY0UW1kbVdHbGpWa2hhT0ZFS1dUQk5kMnhCYlRGbFoydFRjbkUyZDJZeWMwWjBXR2hvVGpVdk9VaG9XVUZvU2tKWVdFUkNUMU4yU3prNFVXZ3pUWE5SU1dkR2NVMVJPSGRhTW5OUFRRcFJORXg1UjFSaGIyVkxSblYwTHl0QmMyTXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXVFppYXl0VmJEUnJjemxNZUZCUVpESm1SbkZxUlZwSFVHMU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNWSFpuVTBwNVZYTlBiRE5RY2xoMlZWSXlkRXdyWkhCM1kwMXBSR2R6VlN0TlRuZGtVMGxrZVdSSlZFSmFTSGQwT0FveE5WSmpZbk0wVkdOWWFqQTFaRmRDY1ZaTU16VXhXbU5EU0ZaMVZrcHphSE5xVkVsR1RHYzFaRkZKTkdkYVprRjBlbE5hU3pFNFRESTVUV3RaWTFOa0NpdGFkbk5oTm1WV1kyeExaREJGUjNwdlIzSnNSMlpwYWpOeE1uQjNTRTByZWs4clRtbFFNVE5IYWs1elFucGxSRkpxT1hwek5VZE1RMmg0Y1hSVGJHa0tTa1UyZFVoSlUya3JjVTFLUVd4SlNqZHhjSE5yVkdOeVJISXJWRTB2YWs1eFNtWTFaRFIxUjBSUWQwaDNSVTU0TXpONGNUWXpibVU1TWxGNlVGRnJZd3BWTm1wRFNUVllZWEJhUms5bWVITkpVR1JGZFRkQlFWbEhSMUJSY1RGSVlraE9SRUpGUjJveGNEQnNRblJVYmpCVVlUUnBielJ1WW5OaVQwNVBjMjlDQ214TWJsWjNZbFJvU1cweWExQXljRVJEY0djcmJVWm9PV2MyWVc5bU1HTlBPR013YUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2FkMDk4OWYzLWRhMWItNDRlNy1hMzJhLWNhZGYzMjExMmUzMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzbWRWUjNUdEVSdjczWTVkeVBYY0E5dW9iWVpYYXJJbnhDSHhweW8wWnBqclMzS29LTjlOQ1hxbA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2694"
@@ -2674,7 +2641,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2684,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 155e566e-fd30-4d4a-aa33-1b76f45b792c
+      - 1679710a-390a-474e-aca3-d2dffc166d28
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,10 +2662,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:17.272333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -2707,7 +2674,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 13:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2717,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7fb8c3e-b485-4f7d-b0ad-2c178c993e3e
+      - 306d1f4c-e8af-489f-887e-58bbd2f58f83
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,19 +2695,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/nodes?order_by=created_at_asc&page=1&pool_id=5b83fc02-791d-409e-9a6a-617f693efb13&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33/nodes?order_by=created_at_asc&page=1&pool_id=6c929fde-f625-43ea-9db3-5413c5cac0b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:58.352043Z","error_message":null,"id":"28043bc2-995c-4c87-b9ab-8b8f8887086d","name":"scw-test-pool-placeme-test-pool-placeme-28043b","pool_id":"5b83fc02-791d-409e-9a6a-617f693efb13","provider_id":"scaleway://instance/fr-par-1/5f404cf7-73dc-4d65-b603-1d7b5c1e9b77","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:14.119351Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:35.223529Z","error_message":null,"id":"7249918f-5508-4947-8cb2-49d6ff093024","name":"scw-test-pool-placeme-test-pool-placeme-724991","pool_id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","provider_id":"scaleway://instance/fr-par-1/4c41e6c0-83a4-4b55-a3a9-a47921126a6c","public_ip_v4":"51.158.101.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:17.255963Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 13:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2750,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 135f9a39-c70a-44f7-9295-c9b36bfde90d
+      - f0b2cb72-7ced-47df-9fed-b92134df4f5f
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,10 +2728,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f0132fc5-df47-4028-8fa7-33fe283aeb6b
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:24:10.753323Z","dhcp_enabled":true,"id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:24:10.753323Z","id":"fdd2c378-0e1b-4835-992a-e28546ff3067","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:24:10.753323Z"},{"created_at":"2023-11-10T13:24:10.753323Z","id":"dc0f9772-eae0-4816-bfb2-d67ad16b55db","subnet":"fd63:256c:45f7:36bd::/64","updated_at":"2023-11-10T13:24:10.753323Z"}],"tags":[],"updated_at":"2023-11-10T13:24:10.753323Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:53:11.205901Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1513"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 33285f95-b5be-41e0-aa3d-3d11be4419b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8b5b10dc-070e-40e0-9881-b70984aa0e68
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-13T13:51:14.496479Z","dhcp_enabled":true,"id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:14.496479Z","id":"b3a91bdf-14d6-40c0-85d4-ae9534f1c338","subnet":"172.16.44.0/22","updated_at":"2023-11-13T13:51:14.496479Z"},{"created_at":"2023-11-13T13:51:14.496479Z","id":"5ca7e2c2-7730-4aa5-89ed-1b2ef3ecfb80","subnet":"fd63:256c:45f7:2eef::/64","updated_at":"2023-11-13T13:51:14.496479Z"}],"tags":[],"updated_at":"2023-11-13T13:51:14.496479Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "726"
@@ -2773,7 +2773,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 13:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2783,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f816486e-3387-4996-ba6f-4d8133d3a478
+      - e878f179-4ea0-4c7c-9532-1c1a7fc7357d
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,10 +2794,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:14.132275Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:17.272333Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "669"
@@ -2806,7 +2806,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 13:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2816,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0f20f30-2796-4ecb-b66e-b60b90cf8107
+      - ec481213-8528-45d4-b03f-0411cf65b22d
     status: 200 OK
     code: 200
     duration: ""
@@ -2827,76 +2827,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8980538f-16df-41a2-a00f-3653a5e91e1d
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:25:29.301440Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85b5ba51-313b-47aa-96dc-33319d04c7bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/nodes?order_by=created_at_asc&page=1&pool_id=5b83fc02-791d-409e-9a6a-617f693efb13&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:58.352043Z","error_message":null,"id":"28043bc2-995c-4c87-b9ab-8b8f8887086d","name":"scw-test-pool-placeme-test-pool-placeme-28043b","pool_id":"5b83fc02-791d-409e-9a6a-617f693efb13","provider_id":"scaleway://instance/fr-par-1/5f404cf7-73dc-4d65-b603-1d7b5c1e9b77","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:14.119351Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "660"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e36331e3-8f88-4a35-9774-82e0af50e22b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
-    method: GET
-  response:
-    body: '{"placement_group":{"id":"f84af29a-0e2c-4482-a38d-0da33e116f63","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"8980538f-16df-41a2-a00f-3653a5e91e1d","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -2905,7 +2839,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 13:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2915,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03fc1581-01e1-45af-9944-88160ed2d20e
+      - fc4c9403-a473-4e58-8a56-d1950695757f
     status: 200 OK
     code: 200
     duration: ""
@@ -2926,10 +2860,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33/nodes?order_by=created_at_asc&page=1&pool_id=6c929fde-f625-43ea-9db3-5413c5cac0b9&status=unknown
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BSZUU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWxGNFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFd3MUNrRTRSbkp2YWtZdlRXRnhjMVJUUjFKUFUzQk9aRlJxY1ZaRFRVaDZkWGcxVTBoaFFWZHVla1UzUVRoNU5YVTFiM0ZPWWxKc1JWRjFlVEZIZFhObmMwVUtRa296WldWQlZEUlZWakpRVXpOUVVreFFkVEZ5VjA5R1VrcEpiMkk0UTBSMGVtUXdWVzFJY1M4eFYxRjFSSFZXYTNKS2R5OXFTME5qWjNSUVJFTkNTQXA0TjBOM05EbEpiVVkxZDFsdE1sYzNkRVUxTUhkSFMybE9jRTlMZHk5Q00xSkJaVFpwV0Rob1YyOXRhbk1yY1U1TFUwWlVlbTVKWlV0NmJtTkJaV3R3Q2twMWVtZzBiRmxRT0dkMFZWcFZaMUZqTlRFMFRYWkhNR3h5ZG1kbmVHTjNaM1lyWkhGVmVXRlFUblZWWWtONGFVNDBUMjFLTTNjd1VESTBZVkZqYXk4S1FYVnFjRnA0Ym1NM05HRjJiV2xIT0dOdVNUaElkV04zZWxSdmNuVllXbWgyU1hkc2JGbzRla2cxVWxJMmVtNVpTRTFqUjA4MFF6RmFTMkZ4TDJWMFJncHdSUzlYTkdKcWJuaGFhRTF0TURrd09HWlZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBjVk5CYTFoSFpscExZV1JsV1ZRd05IUnhaMUZZVFRGSVZsTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRUMDB3TUdkaFdXSm5aRkpVVmpGMGVqbDRXa2x4WnpSdFdqTXdjSFowT1RONlRqTTVkVkUzTVV4RE5FUjZZVEZKYndvMk5FSktlWFF4VVM5dldWRjZNWFpzVmt0RVIwNDFkMjFDYWtwQk0zWnZiREJLUVZsaGVIUlFUa3RQVW5WWVRHUm1SMGxTWlV3MU5HbzBMMkYyVDBGUUNsaDFjWFZzUkVOT1UxZDJTRXBVVjI1dVRDdFNOMmd4UTNsSU9UUktOVE5ITldKU2VtRjNlWEUzU0ZkelEwVmtiVXBhTTB0YVpsTjFURkE0YjNkSU1Vd0tabkJtTVZrMlZXWTRWM2xpV1hWSVpFSjJMMnRvZVhOUVVuWndjR0ZSYnpKblJVWktMMDQ1TWpNNGFtOXBTMmwzYnpCaFQwTnphMWx6YzNwcmNtVktaUXBzTkhJeVRsTlFaR0pPZFVFeWQzRmpRa3hUYVZRMVUwSnBRVkZDZFhrMFdWbzJkelV4YnpKU1JWaDFTMnRVYkc1aE15OHdSblYxVmtoc05sSjJOemx1Q2xGdlZsVjJTbkEwZUdGclowTXpPWFVyUnpFMVlWSm1SRGxWTVRkSFpYQXlWMDF2VkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzUwZDhlNzYzLTIzM2YtNDc0Yi1hMTQ1LTA0NjJlODg1NDUwZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3WnhTdUVvSVpleG1SN0c3aGh3WmVOWXhCdm9KOFVib1FacWZnZXhIaDFBQUNDNFFLaVNlQW1VOA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"nodes":[{"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:35.223529Z","error_message":null,"id":"7249918f-5508-4947-8cb2-49d6ff093024","name":"scw-test-pool-placeme-test-pool-placeme-724991","pool_id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","provider_id":"scaleway://instance/fr-par-1/4c41e6c0-83a4-4b55-a3a9-a47921126a6c","public_ip_v4":"51.158.101.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:17.255963Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "658"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b8ef9dad-2493-41dd-ad31-c7aa3811ef1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJGZVUxR2IxaEVWRTE2VFZSRmVFMXFSWHBPVkVWNVRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEVSVENuRnNTbk5JTlRCSVdXZERjMjk0UzNFNFpURldjMUEzWmxCa1dtbHNRMVIxZUdreFNsZHFURTQxVVV0RldtdENORVZLZUhWeWJrMTJRMFJMYUZSaFJ6RUtRWEpVVW5oSlpFazBhRGQ1Y21sMlVHdFhZbTVNU2t0RFVUbHVSMjgzY0ZScVlsRnBSM2hPVFRkTFpHMDFVekV2UVdZd2RHSnRZblZ2ZEdaSlNUTXhUUXBSU3poSFdsQlZWVm8zWlM5VlIxQndjeTlEUkRSNGVXcHFPVWsxWjJGVFpuRnJUbVJRZERVeWNUZGxhVFJyVUdOWk0zVk1kVU4yUVRSU1JWSnpTbFJ1Q2xSUVpXVXhiVGt6YVdGNGNrUXdNWFkyUnpReFRWWkNiazAyWTFKNU9XdEJiSFZwTHpGclRtWXJjRGRUSzJGeVlTdHhkVFY0UW1kbVdHbGpWa2hhT0ZFS1dUQk5kMnhCYlRGbFoydFRjbkUyZDJZeWMwWjBXR2hvVGpVdk9VaG9XVUZvU2tKWVdFUkNUMU4yU3prNFVXZ3pUWE5SU1dkR2NVMVJPSGRhTW5OUFRRcFJORXg1UjFSaGIyVkxSblYwTHl0QmMyTXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXVFppYXl0VmJEUnJjemxNZUZCUVpESm1SbkZxUlZwSFVHMU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNWSFpuVTBwNVZYTlBiRE5RY2xoMlZWSXlkRXdyWkhCM1kwMXBSR2R6VlN0TlRuZGtVMGxrZVdSSlZFSmFTSGQwT0FveE5WSmpZbk0wVkdOWWFqQTFaRmRDY1ZaTU16VXhXbU5EU0ZaMVZrcHphSE5xVkVsR1RHYzFaRkZKTkdkYVprRjBlbE5hU3pFNFRESTVUV3RaWTFOa0NpdGFkbk5oTm1WV1kyeExaREJGUjNwdlIzSnNSMlpwYWpOeE1uQjNTRTByZWs4clRtbFFNVE5IYWs1elFucGxSRkpxT1hwek5VZE1RMmg0Y1hSVGJHa0tTa1UyZFVoSlUya3JjVTFLUVd4SlNqZHhjSE5yVkdOeVJISXJWRTB2YWs1eFNtWTFaRFIxUjBSUWQwaDNSVTU0TXpONGNUWXpibVU1TWxGNlVGRnJZd3BWTm1wRFNUVllZWEJhUms5bWVITkpVR1JGZFRkQlFWbEhSMUJSY1RGSVlraE9SRUpGUjJveGNEQnNRblJVYmpCVVlUUnBielJ1WW5OaVQwNVBjMjlDQ214TWJsWjNZbFJvU1cweWExQXljRVJEY0djcmJVWm9PV2MyWVc5bU1HTlBPR013YUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2FkMDk4OWYzLWRhMWItNDRlNy1hMzJhLWNhZGYzMjExMmUzMy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAzbWRWUjNUdEVSdjczWTVkeVBYY0E5dW9iWVpYYXJJbnhDSHhweW8wWnBqclMzS29LTjlOQ1hxbA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2694"
@@ -2938,7 +2905,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 13:56:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2948,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2449aae7-571f-40ec-88e3-85e3f14e4f43
+      - 5d1c4e83-7c1e-4dca-95b2-146f32a73a20
     status: 200 OK
     code: 200
     duration: ""
@@ -2959,10 +2926,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405553554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:24.661316166Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "675"
@@ -2971,7 +2938,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:20 GMT
+      - Mon, 13 Nov 2023 13:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2981,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10fbe3db-6375-4b7f-958f-6eda2673cae2
+      - 09186106-a94f-40eb-a706-1452b10af855
     status: 200 OK
     code: 200
     duration: ""
@@ -2992,10 +2959,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:24.661316Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "672"
@@ -3004,7 +2971,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:20 GMT
+      - Mon, 13 Nov 2023 13:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3014,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e996dfce-5785-49f1-bb34-5dc271d7c94c
+      - d11f8b25-aa75-43a9-aca1-1bfece8fac14
     status: 200 OK
     code: 200
     duration: ""
@@ -3025,10 +2992,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:24.661316Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "672"
@@ -3037,7 +3004,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:25 GMT
+      - Mon, 13 Nov 2023 13:56:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3047,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abdcef00-c8b9-4d74-9c06-59aea269e05c
+      - 5949271a-48aa-46be-98a4-44dea44b7b59
     status: 200 OK
     code: 200
     duration: ""
@@ -3058,10 +3025,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:24.661316Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "672"
@@ -3070,7 +3037,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:30 GMT
+      - Mon, 13 Nov 2023 13:56:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3080,7 +3047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56df17c1-05b9-4711-b914-1052ba2090f0
+      - 3a6530a6-0802-4c1d-b4aa-3be1150c5f08
     status: 200 OK
     code: 200
     duration: ""
@@ -3091,10 +3058,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"50d8e763-233f-474b-a145-0462e885450e","container_runtime":"containerd","created_at":"2023-11-10T13:24:18.960077Z","id":"5b83fc02-791d-409e-9a6a-617f693efb13","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"f84af29a-0e2c-4482-a38d-0da33e116f63","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.405554Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","container_runtime":"containerd","created_at":"2023-11-13T13:51:24.372865Z","id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"8980538f-16df-41a2-a00f-3653a5e91e1d","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:24.661316Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "672"
@@ -3103,7 +3070,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:35 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3113,7 +3080,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcfb6f48-7856-47f5-a9e1-68bcf581a348
+      - 845f42b6-9bfc-4991-bcc2-6aeba9cd3a77
     status: 200 OK
     code: 200
     duration: ""
@@ -3124,10 +3091,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/5b83fc02-791d-409e-9a6a-617f693efb13
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6c929fde-f625-43ea-9db3-5413c5cac0b9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"5b83fc02-791d-409e-9a6a-617f693efb13","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"6c929fde-f625-43ea-9db3-5413c5cac0b9","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3136,7 +3103,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:40 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3146,7 +3113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b534fda4-7d19-4722-8eab-71b22da72984
+      - 12d10ab0-a40c-4e65-8898-38e1f3e50490
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3157,10 +3124,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:40.716342601Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:56:44.954622019Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1519"
@@ -3169,7 +3136,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:40 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3179,7 +3146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fd159d5-6971-4731-af7b-fd88903b5d95
+      - a161f572-7eb8-405a-9204-71e51bfb045d
     status: 200 OK
     code: 200
     duration: ""
@@ -3190,7 +3157,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/f84af29a-0e2c-4482-a38d-0da33e116f63
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/8980538f-16df-41a2-a00f-3653a5e91e1d
     method: DELETE
   response:
     body: ""
@@ -3198,7 +3165,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 10 Nov 2023 13:29:40 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3208,7 +3175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f781a7e-016a-4596-982a-03294a86a4a7
+      - 440fa652-3c2d-41cf-b241-95aa948bbf44
     status: 204 No Content
     code: 204
     duration: ""
@@ -3219,10 +3186,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:40.716343Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:56:44.954622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -3231,7 +3198,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:40 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3241,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd54f8e7-d5ea-464a-9b4c-a4e0f7ca27dd
+      - 66b06892-7c6b-45c0-94a0-97d3a5f799ff
     status: 200 OK
     code: 200
     duration: ""
@@ -3257,7 +3224,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"c172067b-41d4-4890-a33c-b6436e908f8c","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -3266,9 +3233,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:43 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/b7adfbe1-fed5-4293-aa43-25e4e6d75b25
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +3245,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 561ee323-31e0-421f-9e54-60d6ae5e1347
+      - 87dfc0de-2e39-4fd0-bfbc-3057857928b2
     status: 201 Created
     code: 201
     duration: ""
@@ -3289,10 +3256,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/b7adfbe1-fed5-4293-aa43-25e4e6d75b25
     method: GET
   response:
-    body: '{"placement_group":{"id":"c172067b-41d4-4890-a33c-b6436e908f8c","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -3301,7 +3268,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:43 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3311,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 271073b9-3ac3-4235-82dc-6cf2088d7db9
+      - 8a4a269e-6c6d-4909-b91e-f0364c8e433e
     status: 200 OK
     code: 200
     duration: ""
@@ -3322,10 +3289,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:40.716343Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ad0989f3-da1b-44e7-a32a-cadf32112e33.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.851450Z","created_at":"2023-11-13T13:51:18.851450Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ad0989f3-da1b-44e7-a32a-cadf32112e33.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:56:44.954622Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -3334,7 +3301,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:45 GMT
+      - Mon, 13 Nov 2023 13:56:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3344,7 +3311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca71a988-871d-41bb-963e-9f588f7da3d9
+      - 92556ae1-c230-434c-94aa-6e772a19c0ef
     status: 200 OK
     code: 200
     duration: ""
@@ -3355,43 +3322,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ad0989f3-da1b-44e7-a32a-cadf32112e33
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://50d8e763-233f-474b-a145-0462e885450e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:24:13.402071Z","created_at":"2023-11-10T13:24:13.402071Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.50d8e763-233f-474b-a145-0462e885450e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"50d8e763-233f-474b-a145-0462e885450e","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:40.716343Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1516"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6578fc66-9560-453e-9209-43b1e08cb9a2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/50d8e763-233f-474b-a145-0462e885450e
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"50d8e763-233f-474b-a145-0462e885450e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ad0989f3-da1b-44e7-a32a-cadf32112e33","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3400,7 +3334,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:55 GMT
+      - Mon, 13 Nov 2023 13:56:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3410,7 +3344,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e9410c3-cb3b-46ea-a081-a730646fd73c
+      - 9413438b-78b6-47c4-a9ed-dfa1ce581adf
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3421,10 +3355,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f0132fc5-df47-4028-8fa7-33fe283aeb6b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8b5b10dc-070e-40e0-9881-b70984aa0e68
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"f0132fc5-df47-4028-8fa7-33fe283aeb6b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"8b5b10dc-070e-40e0-9881-b70984aa0e68","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3433,7 +3367,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:55 GMT
+      - Mon, 13 Nov 2023 13:56:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3443,7 +3377,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92d3a056-cc26-4c90-9cde-d48e59307ade
+      - a4b912df-8bba-40c8-a6ab-61d99d337db6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3459,7 +3393,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:29:55.989724Z","dhcp_enabled":true,"id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:29:55.989724Z","id":"e024b64d-0ac7-4cbf-a501-9e2ee8d306d1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:29:55.989724Z"},{"created_at":"2023-11-10T13:29:55.989724Z","id":"e58a3a79-a0cf-48ac-8984-0f8dc525a06d","subnet":"fd68:d440:21c4:cc76::/64","updated_at":"2023-11-10T13:29:55.989724Z"}],"tags":[],"updated_at":"2023-11-10T13:29:55.989724Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:56:55.206123Z","dhcp_enabled":true,"id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:56:55.206123Z","id":"623363e3-ff96-455b-833e-e1d478df144f","subnet":"172.16.4.0/22","updated_at":"2023-11-13T13:56:55.206123Z"},{"created_at":"2023-11-13T13:56:55.206123Z","id":"16a86205-8fb7-4b9c-b740-800e85a3c809","subnet":"fd68:d440:21c4:ad4b::/64","updated_at":"2023-11-13T13:56:55.206123Z"}],"tags":[],"updated_at":"2023-11-13T13:56:55.206123Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "725"
@@ -3468,7 +3402,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:56 GMT
+      - Mon, 13 Nov 2023 13:56:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3478,7 +3412,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cab7193-17a4-4d47-9e18-deba1d5bb672
+      - 86744042-94f5-4587-acef-4a98dfe712eb
     status: 200 OK
     code: 200
     duration: ""
@@ -3489,10 +3423,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea7e0919-223d-4892-8f01-fcc02bad1ed4
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/9377678e-6fed-464c-a2ae-b3e40e4f9c82
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:29:55.989724Z","dhcp_enabled":true,"id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:29:55.989724Z","id":"e024b64d-0ac7-4cbf-a501-9e2ee8d306d1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:29:55.989724Z"},{"created_at":"2023-11-10T13:29:55.989724Z","id":"e58a3a79-a0cf-48ac-8984-0f8dc525a06d","subnet":"fd68:d440:21c4:cc76::/64","updated_at":"2023-11-10T13:29:55.989724Z"}],"tags":[],"updated_at":"2023-11-10T13:29:55.989724Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:56:55.206123Z","dhcp_enabled":true,"id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:56:55.206123Z","id":"623363e3-ff96-455b-833e-e1d478df144f","subnet":"172.16.4.0/22","updated_at":"2023-11-13T13:56:55.206123Z"},{"created_at":"2023-11-13T13:56:55.206123Z","id":"16a86205-8fb7-4b9c-b740-800e85a3c809","subnet":"fd68:d440:21c4:ad4b::/64","updated_at":"2023-11-13T13:56:55.206123Z"}],"tags":[],"updated_at":"2023-11-13T13:56:55.206123Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "725"
@@ -3501,7 +3435,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:56 GMT
+      - Mon, 13 Nov 2023 13:56:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3511,12 +3445,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 712121c0-2307-471a-a13b-1bf84281872c
+      - 5893e1d5-1fbf-49b7-9b0e-2348c80266fd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82"}'
     form: {}
     headers:
       Content-Type:
@@ -3527,7 +3461,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644092Z","created_at":"2023-11-10T13:29:57.173644092Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:57.190218001Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173270738Z","created_at":"2023-11-13T13:56:56.173270738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:56:56.187581045Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1527"
@@ -3536,7 +3470,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:57 GMT
+      - Mon, 13 Nov 2023 13:56:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3546,7 +3480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d97e7ab2-daf0-462a-a23e-89939697b175
+      - e9105184-4272-406c-b263-3d6ac69ae1f9
     status: 200 OK
     code: 200
     duration: ""
@@ -3557,10 +3491,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:57.190218Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:56:56.187581Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1518"
@@ -3569,7 +3503,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:57 GMT
+      - Mon, 13 Nov 2023 13:56:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3579,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1b6b7b7-726b-4c16-a309-e5027d8138aa
+      - 8ce91cc2-3734-4d52-bc9e-2a7ca45d429f
     status: 200 OK
     code: 200
     duration: ""
@@ -3590,10 +3524,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:58.806331Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:56:57.812614Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -3602,7 +3536,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:02 GMT
+      - Mon, 13 Nov 2023 13:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3612,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d909900f-d87c-46fd-a276-98a6b46c6b3a
+      - 15992811-5a54-4c38-9def-b5d6ad1536a9
     status: 200 OK
     code: 200
     duration: ""
@@ -3623,10 +3557,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:58.806331Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:56:57.812614Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -3635,7 +3569,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:02 GMT
+      - Mon, 13 Nov 2023 13:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3645,7 +3579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 461d7187-1a6f-4c38-9859-55401c8649f1
+      - 3fd115f5-44dc-4d14-9ce6-cfb2d33bfd3a
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,10 +3590,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcHJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5hbXN4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTakZFQ25aVFNGRnFWa1pKYldkbFltYzRhRFZsWjB3NWQwVTRTVzlXV1VZcmJFRTVlRXB4VjA5aGJ6UXJZV1pQVm1SbFdUbHRkR3RwUlhwaFRubGFSM0ZSZGpjS1pWbDVPV1p6WWpCR2IzbFpTalo2UlVaWWJXOU9NVFY0VEdZckswVTNRazlSU0dKak0ybzJPR3Q1T0VadGVXMHJObmcxUzJVelR6TkVhMFZUV0ZKMVJ3cE5UVXR1WkRWcFdWZzBXV3hMVjBWbEt6UTVValEwY0ZoM2NEQjBSRmx5VVZwS1FVZDJWRXhJV2t0TFdqSXhhMUUyVGxCSFVsQmtZVXBMUjJ0c1NUQmpDa2c0TWpsTlVFdHJVbFpaY0cxbVpqTXdUVWxyUTA5TFYxbENiMVE1WWxoRlprWmtPRVZDYzFabmRUUlZhM3BLVm5CT1dVcEJjR3Q1VTFFMVprUmhUQzhLWkVWQmIxQnNVVUpxVWtOVWN6WlhObUpZT0dFMmVHcDJaM0l5UTBreWVVNXJja3RFTTNNclpFVkJhblJxVm1wSVZEVlJaSGN2VVZOclJEZFJVa1o0Y0FvMWJ6Z3dRV1pGTUc5aFVpc3Zka0V3VUhkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRk5VSXZUVXRzUm1FcmJYVldRMmRIUVdrd1NWSk1LMkZhTVVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlFWSklOV3BOTkUxSlNuRjVVMUJGY25aR1ZrTktTbXhOVUdwUVFVcFFaRzlKVG0wemIwVlFlbEowUlU5SlYyMUljQW81VkZkdGIwZFBkek41YVhGelowUnFZaloyT0V0UlZFZ3dUWFJsWlVSU04yVXdMMjFVY0N0TGRuVXJXVzh3Wkcxb01VMUhiSGMyUm1aM1ZVaENTazFIQ2l0dmJuZHpMMDVYWjJsdVJuTkxOelEyYW5oVmFDOU1iVmh3U2pORk9UUkxhMGMxZUVkelFUUk5TMlF2V1dKVFl6WllNRlZQYjJOemVuUldja05DYzNjS1dsZGhiVXQyVDJWTE5WVnVWWEl4Umtwck1XeEdPVUpSVVZGak9WSk1NV3MxV0RGNVdrbHVhbk5EZDFac1NXMXJUVzlaWW1KR2RrUTVTRVJCWkZCaVNncHFLMjE1YmtkcVJDOVlZeTlvTDJORmRsaG1aa2hoWkhRdlFtMXVkbU5GZUdRNFJUbHlTRlZpTmxwME1VeFRRVXRzYW5oS2FGSldXVFp4Yld0NmFWa3lDbkYxYkV0cVRVMTRaMlJzVUdOVFkzVkhha2RCVlRjeWVrOUxTVEJwTm14UE5FeDVUUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZjFjYTgwMzgtNmY0My00NGJhLWI5MTctOTcwMmMzZDZiNTUxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxNTRYZmhVSlUyeXlIMzZid2RpaXRTaGl2bzRIcmVTZEUwSVA2YWltT21UZkc4dGtEUWI3Q1lmTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUlpNVTR4YjFoRVZFMTZUVlJGZUUxcVJYcE9WRmt4VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUa2MwQ2pnMmRGQlFXbVZ0YVcwMlVuWlZjVmd2ZDNKWlUxZzJLM1psWjJOc1dsZENSalUwUXpnMFVUQjNhbTFwZWtGTmNFMXRhVFo2TlRKcWFVeDZjSEpGVDNNS01IUlNjamRuZGtGS01sRmFkMFpTYjNaa1pWVmFOVk5pTUZBd2FrVllkVXQwWldwbk9YVTNaa3B0V1N0SFNISmxjWHBwT0dwMlduaG9NVEJqUWpodVFRb3JUR3h1WmxOUGVXSTJZVWxWUzJvck1FTjVVSFJXWTBJeVptUlNRV2hqYWxaemRVSmFiMkYzVGxWWFRFNXVOamxGYm5oNFUyVkJUMDFTTm5aeVJFSm1DbUkxVjA1YVZuVTVWR0p0TlZNeWMzUkhiM2xFVGt0YVVuZExZVEpHVDNObFpHNWxlWGRhTlhveVpFWkdTU3RYU0VKTVJpOTRNbFk0V21KUmRUTm1MMlVLYms5VmVEZzBaRkpCYkVkaWRUY3dZV2RhVERobVNubzRVSGRTY0d4RU5GaGllVFI2TjJ0U1pUTlZOMlJ2S3k5c1JHeE1kbEZPVnpKVFNrd3pWR1pxTmdwWllrRXlWMFpqWVV4bU9XSnpkMGxzZG1ORlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlJVWnhkMEZ4VVZad1VEaDZVMDF5WVdobU4xbHRiMVUxUWpCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQllrSnNPVFkwT1RCbmIybHVaV1pLV1VwU1lsVkplR1o1Y2s4d1UyWXhVa3hpVW1ad1JuWk5TbUpzUzNCYVQyTkxkd3BqTVdsa2JUZzFjRFZYY1dSeGQzZDNjV05WYmpNd1NuRkpPRzl4U0VwTFJFMUdURUZxYjA4NVRtSXpaMmRYYlZOUlQwSjFNMjlOVlZwWGRGbDVRVEJ1Q25aTlpXbzBTMDFOT1ZSdFUwWlNNMVp3YlVKelJFcDFXRWhsWjNJMWEwZFdPRFYwVlVOdlRIcFVjbEpvYlhSeE1ETnplVU5zVFhVMlQxVjZRMUpTUlVrS2NqbDBWMjlxUTNjMFZtSm5aa05rYTBGUVdDdGtNRUZ5ZURjMWNtbG5hbGRpVHpscllWWkVkakZrY1hwWlpVSnBSa1poVkZWa2VWRjJLekpPWlRJcmVRcDZXSGg2V0RsSk9ESm1WVlJ4VFVoeGJWcFdlWGRGV2tGcGQyWnllV2ROWkc1Rk5uQTRiR1JaYjNkNE5XWXZia2xoYmpsSldYQmhVVloyT1hWb05sVnpDbmcxYWxOdE9FdG9kMWh6VGtOak5sTkRjM2g1Y1ZwNFlUaGlRVlIwYUV0Q0wwdHplQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTJhMGUxMjctYjI0Ni00ZTdjLWIxZjYtZWI4Nzc2MmZmNzYzLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOd3FranlUZFVkdmFxM0RVTDRJUDJ0ejZPdEdtUVdkSzRwaTNvWkhSQkZNck1jV0xXWW95STFnQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -3668,7 +3602,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:02 GMT
+      - Mon, 13 Nov 2023 13:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3678,7 +3612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75115334-ba6e-4c0a-932d-0e550af463a1
+      - 8164f33f-eab6-404b-9e2f-07fd473eb090
     status: 200 OK
     code: 200
     duration: ""
@@ -3689,10 +3623,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:29:58.806331Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:56:57.812614Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -3701,7 +3635,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:02 GMT
+      - Mon, 13 Nov 2023 13:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3711,12 +3645,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80bdde33-7d06-4127-95fb-595fac9b1d33
+      - bb6ad152-3ac9-4ce8-920f-eac4ba3bc20b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-2","root_volume_type":"default_volume_type","public_ip_disabled":false}'
+    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-2","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -3724,10 +3658,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/pools
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407074Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882201Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "676"
@@ -3736,7 +3670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:03 GMT
+      - Mon, 13 Nov 2023 13:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3746,7 +3680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7b6d252-c301-4609-a616-7c599ee284ba
+      - 353940b1-721d-4615-b2b6-09209dc47bce
     status: 200 OK
     code: 200
     duration: ""
@@ -3757,10 +3691,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -3769,7 +3703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:03 GMT
+      - Mon, 13 Nov 2023 13:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3779,7 +3713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccbb99a5-2f0e-44d8-92e9-960280af3181
+      - 9fc6df24-d1fa-4705-8957-944b9cee1990
     status: 200 OK
     code: 200
     duration: ""
@@ -3790,10 +3724,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -3802,7 +3736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:08 GMT
+      - Mon, 13 Nov 2023 13:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3812,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 846e54e3-8a01-4d1b-b4ea-202a2da6322b
+      - f9b05bd7-5bf1-48ea-b14d-7def5b0c71a4
     status: 200 OK
     code: 200
     duration: ""
@@ -3823,10 +3757,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -3835,7 +3769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:13 GMT
+      - Mon, 13 Nov 2023 13:57:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3845,7 +3779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a0976c5-5134-47b6-9cf8-8979a2d580e7
+      - da405232-216a-4e8d-93bc-02baa654b0b6
     status: 200 OK
     code: 200
     duration: ""
@@ -3856,10 +3790,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -3868,7 +3802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:18 GMT
+      - Mon, 13 Nov 2023 13:57:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3878,7 +3812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ac69533-3573-4176-80d7-07197b3b156a
+      - 7fb5a241-d311-4b82-a140-3d1c658df4cc
     status: 200 OK
     code: 200
     duration: ""
@@ -3889,10 +3823,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -3901,7 +3835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:23 GMT
+      - Mon, 13 Nov 2023 13:57:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3911,7 +3845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2de6d299-6cbe-485c-b577-df9af27b7094
+      - ad2a9589-2b6e-415a-9eb1-81bc08b437d5
     status: 200 OK
     code: 200
     duration: ""
@@ -3922,10 +3856,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -3934,7 +3868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:28 GMT
+      - Mon, 13 Nov 2023 13:57:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3944,7 +3878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dc3ac25-2f99-4e7c-b0b1-42f8a1fc4017
+      - e4f09f68-71ac-42b4-bdb5-e07f61cd8160
     status: 200 OK
     code: 200
     duration: ""
@@ -3955,10 +3889,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -3967,7 +3901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:33 GMT
+      - Mon, 13 Nov 2023 13:57:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3977,7 +3911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c33728c2-6c66-43db-857a-1a257f6f16dc
+      - eb978b7e-48cd-4e31-bd0d-faf798c530fc
     status: 200 OK
     code: 200
     duration: ""
@@ -3988,10 +3922,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4000,7 +3934,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:38 GMT
+      - Mon, 13 Nov 2023 13:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4010,7 +3944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edd6423c-38c7-4961-a344-e3c1bad1d96c
+      - 3b451f1b-44c7-4d3a-9fe8-e35c74cfcbf4
     status: 200 OK
     code: 200
     duration: ""
@@ -4021,10 +3955,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4033,7 +3967,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:43 GMT
+      - Mon, 13 Nov 2023 13:57:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4043,7 +3977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a4e9bd1-6de7-4c28-8a0f-be2ee947d006
+      - 64ae4408-dd38-4bd7-b376-6d309f97c696
     status: 200 OK
     code: 200
     duration: ""
@@ -4054,10 +3988,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4066,7 +4000,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:48 GMT
+      - Mon, 13 Nov 2023 13:57:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4076,7 +4010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36fa36c7-df3c-48c7-a30f-f20c38833531
+      - 01438f6a-6f42-49d6-a26e-5cca45c0836b
     status: 200 OK
     code: 200
     duration: ""
@@ -4087,10 +4021,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4099,7 +4033,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:53 GMT
+      - Mon, 13 Nov 2023 13:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4109,7 +4043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d05748f-59b2-4bfa-be08-f37ef7fb1466
+      - 3bc447d9-979a-4f8d-979d-c406bf3fe0a0
     status: 200 OK
     code: 200
     duration: ""
@@ -4120,10 +4054,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4132,7 +4066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:59 GMT
+      - Mon, 13 Nov 2023 13:57:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4142,7 +4076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 321e6c19-1900-4921-a61e-cdeec85ac1a0
+      - 5bfdb043-ad83-4005-8ed0-56b3d9cce06c
     status: 200 OK
     code: 200
     duration: ""
@@ -4153,10 +4087,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4165,7 +4099,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:04 GMT
+      - Mon, 13 Nov 2023 13:58:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4175,7 +4109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2684321-e68e-4d74-8525-cda67f382247
+      - 97db4d4c-5669-4c0f-bb86-e67b4e3b7818
     status: 200 OK
     code: 200
     duration: ""
@@ -4186,10 +4120,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4198,7 +4132,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:09 GMT
+      - Mon, 13 Nov 2023 13:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4208,7 +4142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75e85bcc-db69-4c5d-9cef-33ec235b264a
+      - cca14e82-8198-4b35-a8c4-b2641d515391
     status: 200 OK
     code: 200
     duration: ""
@@ -4219,10 +4153,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4231,7 +4165,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:14 GMT
+      - Mon, 13 Nov 2023 13:58:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4241,7 +4175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c2f2bc1-5f49-43ae-b6da-6e9757196e0c
+      - ce743cb8-8cdc-405a-aa38-899177fd4c2d
     status: 200 OK
     code: 200
     duration: ""
@@ -4252,10 +4186,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4264,7 +4198,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:19 GMT
+      - Mon, 13 Nov 2023 13:58:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4274,7 +4208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06e7a906-f687-4da4-85af-8fc86d22fe4a
+      - ddaf3a44-12e3-4f60-8771-33a95fbf387f
     status: 200 OK
     code: 200
     duration: ""
@@ -4285,10 +4219,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4297,7 +4231,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:24 GMT
+      - Mon, 13 Nov 2023 13:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4307,7 +4241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 436422ed-65d9-4ab6-a86a-893508613d65
+      - 92d3b8f0-97ac-44b5-bde4-17a9ecc3a3e3
     status: 200 OK
     code: 200
     duration: ""
@@ -4318,10 +4252,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4330,7 +4264,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:29 GMT
+      - Mon, 13 Nov 2023 13:58:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4340,7 +4274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 173e81bd-62fa-4e23-b66b-06bb92a3e357
+      - 2f5b43c0-09d6-4e8a-a525-b01eeabbb892
     status: 200 OK
     code: 200
     duration: ""
@@ -4351,10 +4285,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4363,7 +4297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:34 GMT
+      - Mon, 13 Nov 2023 13:58:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4373,7 +4307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d1a2456-8c36-4dfe-9f81-a2abf654e3cf
+      - fd7c169f-e84e-4e98-84b7-d98f374dc490
     status: 200 OK
     code: 200
     duration: ""
@@ -4384,10 +4318,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4396,7 +4330,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:39 GMT
+      - Mon, 13 Nov 2023 13:58:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4406,7 +4340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89391b66-c643-4c42-b6c2-a0ddc5384f15
+      - 292d6907-32fb-494e-bede-e25cf0e1cead
     status: 200 OK
     code: 200
     duration: ""
@@ -4417,10 +4351,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4429,7 +4363,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:44 GMT
+      - Mon, 13 Nov 2023 13:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4439,7 +4373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 133fc4d5-e8a2-4d82-9359-14d01396588b
+      - 67107c76-f5a7-4ade-a3fb-7c95f812a21c
     status: 200 OK
     code: 200
     duration: ""
@@ -4450,10 +4384,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4462,7 +4396,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:31:49 GMT
+      - Mon, 13 Nov 2023 13:58:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4472,7 +4406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6eb31ff8-52f6-4228-8ddb-bc4b13267ef9
+      - 04d98387-70ea-4d3e-816c-6ad3f15c44ad
     status: 200 OK
     code: 200
     duration: ""
@@ -4483,10 +4417,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4495,7 +4429,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:32:25 GMT
+      - Mon, 13 Nov 2023 13:58:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4505,7 +4439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 486b22ca-256e-4d44-9243-43d0d4ba0e10
+      - 9896546f-70dc-4446-9b2b-68fcf830d5e6
     status: 200 OK
     code: 200
     duration: ""
@@ -4516,10 +4450,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4528,7 +4462,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:32:31 GMT
+      - Mon, 13 Nov 2023 13:58:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4538,7 +4472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9201c82-a5a4-49f6-971d-303d00154143
+      - 96695914-6bd8-450d-871e-cdcaabb19a92
     status: 200 OK
     code: 200
     duration: ""
@@ -4549,10 +4483,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4561,7 +4495,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:32:36 GMT
+      - Mon, 13 Nov 2023 13:59:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4571,7 +4505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c040b68-6901-437d-8a61-77a6f91dba49
+      - 4b705f85-b5b9-44d3-86e4-4375004689c5
     status: 200 OK
     code: 200
     duration: ""
@@ -4582,10 +4516,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4594,7 +4528,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:32:41 GMT
+      - Mon, 13 Nov 2023 13:59:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4604,7 +4538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f31be28-f26a-4b98-97a4-f3aef013a176
+      - c1354d34-2c2f-44db-843d-03f222c17555
     status: 200 OK
     code: 200
     duration: ""
@@ -4615,10 +4549,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4627,7 +4561,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:32:46 GMT
+      - Mon, 13 Nov 2023 13:59:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4637,7 +4571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a7cd21a-8d7a-4e32-8c4f-5cb51543ac21
+      - 2a3fc6f7-0efc-47e5-87a9-c3e43286bbaf
     status: 200 OK
     code: 200
     duration: ""
@@ -4648,10 +4582,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4660,7 +4594,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:32:51 GMT
+      - Mon, 13 Nov 2023 13:59:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4670,7 +4604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea3a0f76-7e5d-4389-bac4-a58f8bd9887f
+      - f1ec5c94-a540-4dfa-bb25-eb1da868c22a
     status: 200 OK
     code: 200
     duration: ""
@@ -4681,10 +4615,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4693,7 +4627,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:32:56 GMT
+      - Mon, 13 Nov 2023 13:59:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4703,7 +4637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b21f6a54-0c5a-4953-ab04-ad8238fcb0dd
+      - 1a462b5b-a414-40cc-9cac-14aea3557867
     status: 200 OK
     code: 200
     duration: ""
@@ -4714,10 +4648,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4726,7 +4660,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:01 GMT
+      - Mon, 13 Nov 2023 13:59:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4736,7 +4670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2ee2987-ba3e-4ad1-9f13-b868a6cabc93
+      - 93da6fdd-8a61-49de-8d7e-e0603f5c5b85
     status: 200 OK
     code: 200
     duration: ""
@@ -4747,10 +4681,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4759,7 +4693,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:06 GMT
+      - Mon, 13 Nov 2023 13:59:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4769,7 +4703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72e7a2cc-d48f-42d7-aa24-d535c632f444
+      - 094d5055-6901-4ea6-863b-5190fe6068c6
     status: 200 OK
     code: 200
     duration: ""
@@ -4780,10 +4714,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4792,7 +4726,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:11 GMT
+      - Mon, 13 Nov 2023 13:59:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4802,7 +4736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c91ed368-9fbd-4896-9764-eb0f6c113298
+      - e8504128-744e-46f7-8cc7-b3934d0e2b89
     status: 200 OK
     code: 200
     duration: ""
@@ -4813,10 +4747,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4825,7 +4759,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:16 GMT
+      - Mon, 13 Nov 2023 13:59:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4835,7 +4769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95b7b760-d13b-4759-9fa8-ef02faa982c7
+      - 5ae8b2b0-5207-49be-bd77-1403fd212a94
     status: 200 OK
     code: 200
     duration: ""
@@ -4846,10 +4780,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4858,7 +4792,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:21 GMT
+      - Mon, 13 Nov 2023 13:59:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4868,7 +4802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec6af4c7-a68a-4d9b-ad7d-42fd5640b7c6
+      - f302e88b-5d97-4fb2-909d-59f2f5be283d
     status: 200 OK
     code: 200
     duration: ""
@@ -4879,10 +4813,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4891,7 +4825,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:26 GMT
+      - Mon, 13 Nov 2023 13:59:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4901,7 +4835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e8a2674-013e-43a4-9e80-5bcc50377017
+      - 3d250a59-3e40-40a2-9015-21020429325f
     status: 200 OK
     code: 200
     duration: ""
@@ -4912,10 +4846,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4924,7 +4858,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:31 GMT
+      - Mon, 13 Nov 2023 14:00:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4934,7 +4868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b052fe47-f52b-408b-9dde-806d1473e6c0
+      - 466311d9-201f-4949-84c7-2d9d07f4350c
     status: 200 OK
     code: 200
     duration: ""
@@ -4945,10 +4879,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4957,7 +4891,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:37 GMT
+      - Mon, 13 Nov 2023 14:00:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4967,7 +4901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b6d6f4e-8484-491e-b260-d009d13c4a30
+      - f1484245-4775-4b27-a543-e73ccb413de0
     status: 200 OK
     code: 200
     duration: ""
@@ -4978,10 +4912,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -4990,7 +4924,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:42 GMT
+      - Mon, 13 Nov 2023 14:00:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5000,7 +4934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bea2adeb-6b38-4107-bd5e-ba35fadb0523
+      - b1a8dcee-4558-4e6a-bbee-67069fedcd12
     status: 200 OK
     code: 200
     duration: ""
@@ -5011,10 +4945,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -5023,7 +4957,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:47 GMT
+      - Mon, 13 Nov 2023 14:00:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5033,7 +4967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39a871ae-0baf-441b-bec1-667f42c5dcb9
+      - f8930b7a-8d99-4700-9a0a-89969407d4f8
     status: 200 OK
     code: 200
     duration: ""
@@ -5044,10 +4978,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -5056,7 +4990,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:52 GMT
+      - Mon, 13 Nov 2023 14:00:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5066,7 +5000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25319739-943c-463b-9d95-965bf86c6643
+      - 48de48e3-ac8e-44b2-b52b-e21049b6d552
     status: 200 OK
     code: 200
     duration: ""
@@ -5077,10 +5011,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -5089,7 +5023,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:33:57 GMT
+      - Mon, 13 Nov 2023 14:00:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5099,7 +5033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08f6712c-e74b-4736-8181-04484c54aae9
+      - 9ad02ccd-8f14-487f-846c-15b577f33018
     status: 200 OK
     code: 200
     duration: ""
@@ -5110,10 +5044,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -5122,7 +5056,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:02 GMT
+      - Mon, 13 Nov 2023 14:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5132,7 +5066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a26d62f-70fa-4939-8019-702179b994d7
+      - 57e25823-a438-4044-a7ab-a6f729d827b0
     status: 200 OK
     code: 200
     duration: ""
@@ -5143,10 +5077,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -5155,7 +5089,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:07 GMT
+      - Mon, 13 Nov 2023 14:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5165,7 +5099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16c0e795-46ab-4b64-ba25-783f49e9edcd
+      - b8821d7e-9d47-44c8-a712-5eb5449ddc3f
     status: 200 OK
     code: 200
     duration: ""
@@ -5176,10 +5110,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:57:01.979882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "673"
@@ -5188,7 +5122,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:12 GMT
+      - Mon, 13 Nov 2023 14:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5198,7 +5132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa4f4c6a-0eca-4036-8490-2aa1805d074a
+      - c71892ab-596c-41f6-b68d-c793dd069412
     status: 200 OK
     code: 200
     duration: ""
@@ -5209,43 +5143,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:30:02.945407Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:34:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d8e8d64f-f416-49a0-8307-132158cf02b8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:44.836829Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "671"
@@ -5254,7 +5155,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:22 GMT
+      - Mon, 13 Nov 2023 14:00:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5264,7 +5165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fa31fd2-c4b3-4be9-94f7-cdd14c15dde4
+      - d63b01d2-526e-4e3f-9860-29834ea1c810
     status: 200 OK
     code: 200
     duration: ""
@@ -5275,10 +5176,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:31:27.025089Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:58:10.912448Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -5287,7 +5188,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:23 GMT
+      - Mon, 13 Nov 2023 14:00:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5297,7 +5198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 363828d9-5925-4cc7-9c47-241813b3b96c
+      - bec59341-679d-41cc-80b5-589aa2676934
     status: 200 OK
     code: 200
     duration: ""
@@ -5308,10 +5209,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:44.836829Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "671"
@@ -5320,7 +5221,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:23 GMT
+      - Mon, 13 Nov 2023 14:00:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5330,7 +5231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cd69f68-39b4-4db0-bff4-47c781aea1fa
+      - b5275545-d9a1-4ecb-abf8-a02e3a2b1112
     status: 200 OK
     code: 200
     duration: ""
@@ -5341,19 +5242,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/nodes?order_by=created_at_asc&page=1&pool_id=3a32248e-d389-4d5b-979f-328f68abd855&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/nodes?order_by=created_at_asc&page=1&pool_id=549dd02e-61ea-40de-9aec-1c68dedcda39&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:31:41.662987Z","error_message":null,"id":"d806b746-cf85-4235-9871-d7301bd70f1e","name":"scw-test-pool-placeme-test-pool-placeme-d806b7","pool_id":"3a32248e-d389-4d5b-979f-328f68abd855","provider_id":"scaleway://instance/nl-ams-2/832e2bc3-52fe-4237-870b-324943cd6b57","public_ip_v4":"51.158.236.212","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-10T13:34:18.847255Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:38.751025Z","error_message":null,"id":"85120e23-c614-472a-b9f1-fb4b0f8a777b","name":"scw-test-pool-placeme-test-pool-placeme-85120e","pool_id":"549dd02e-61ea-40de-9aec-1c68dedcda39","provider_id":"scaleway://instance/nl-ams-2/9568932f-33d9-44f0-8240-077f4300de38","public_ip_v4":"51.158.238.63","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-13T14:00:44.815322Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:23 GMT
+      - Mon, 13 Nov 2023 14:00:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5363,7 +5264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1876a09-3d1d-431d-8d08-ae635ad1f843
+      - 98ce9f78-cddd-46a8-8ec6-c568ece2fae1
     status: 200 OK
     code: 200
     duration: ""
@@ -5374,10 +5275,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:31:27.025089Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:58:10.912448Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -5386,7 +5287,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:23 GMT
+      - Mon, 13 Nov 2023 14:00:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5396,7 +5297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c43a3b9-70ab-4986-bfc8-619ae81a96b3
+      - 1f510249-9e03-4e0d-8a7e-0e6bedcfbacf
     status: 200 OK
     code: 200
     duration: ""
@@ -5407,10 +5308,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:44.836829Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "671"
@@ -5419,7 +5320,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:23 GMT
+      - Mon, 13 Nov 2023 14:00:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5429,7 +5330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 642471ab-22c9-4e85-89e9-3e15a59c36f4
+      - 8ee962cd-fd2c-4649-bff4-ab4e68c9627d
     status: 200 OK
     code: 200
     duration: ""
@@ -5440,10 +5341,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea7e0919-223d-4892-8f01-fcc02bad1ed4
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/9377678e-6fed-464c-a2ae-b3e40e4f9c82
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:29:55.989724Z","dhcp_enabled":true,"id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:29:55.989724Z","id":"e024b64d-0ac7-4cbf-a501-9e2ee8d306d1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:29:55.989724Z"},{"created_at":"2023-11-10T13:29:55.989724Z","id":"e58a3a79-a0cf-48ac-8984-0f8dc525a06d","subnet":"fd68:d440:21c4:cc76::/64","updated_at":"2023-11-10T13:29:55.989724Z"}],"tags":[],"updated_at":"2023-11-10T13:29:55.989724Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:56:55.206123Z","dhcp_enabled":true,"id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:56:55.206123Z","id":"623363e3-ff96-455b-833e-e1d478df144f","subnet":"172.16.4.0/22","updated_at":"2023-11-13T13:56:55.206123Z"},{"created_at":"2023-11-13T13:56:55.206123Z","id":"16a86205-8fb7-4b9c-b740-800e85a3c809","subnet":"fd68:d440:21c4:ad4b::/64","updated_at":"2023-11-13T13:56:55.206123Z"}],"tags":[],"updated_at":"2023-11-13T13:56:55.206123Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "725"
@@ -5452,7 +5353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:24 GMT
+      - Mon, 13 Nov 2023 14:00:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5462,7 +5363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5281744d-cee3-4c94-baca-83926686ffc9
+      - dc16f246-bb88-4b0f-9739-8efa2b72bfae
     status: 200 OK
     code: 200
     duration: ""
@@ -5473,10 +5374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/b7adfbe1-fed5-4293-aa43-25e4e6d75b25
     method: GET
   response:
-    body: '{"placement_group":{"id":"c172067b-41d4-4890-a33c-b6436e908f8c","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -5485,7 +5386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:24 GMT
+      - Mon, 13 Nov 2023 14:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5495,7 +5396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f0f1b20-45eb-4e59-b500-0f1398297bba
+      - 2ef54e82-f02b-4749-b13a-883aad9f4392
     status: 200 OK
     code: 200
     duration: ""
@@ -5506,10 +5407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:31:27.025089Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:58:10.912448Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -5518,7 +5419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:24 GMT
+      - Mon, 13 Nov 2023 14:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5528,7 +5429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34527f1c-7746-4bd4-9eda-3eecd34d4227
+      - e1924e5b-b518-4649-b942-f72c353faf8e
     status: 200 OK
     code: 200
     duration: ""
@@ -5539,10 +5440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcHJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5hbXN4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTakZFQ25aVFNGRnFWa1pKYldkbFltYzRhRFZsWjB3NWQwVTRTVzlXV1VZcmJFRTVlRXB4VjA5aGJ6UXJZV1pQVm1SbFdUbHRkR3RwUlhwaFRubGFSM0ZSZGpjS1pWbDVPV1p6WWpCR2IzbFpTalo2UlVaWWJXOU9NVFY0VEdZckswVTNRazlSU0dKak0ybzJPR3Q1T0VadGVXMHJObmcxUzJVelR6TkVhMFZUV0ZKMVJ3cE5UVXR1WkRWcFdWZzBXV3hMVjBWbEt6UTVValEwY0ZoM2NEQjBSRmx5VVZwS1FVZDJWRXhJV2t0TFdqSXhhMUUyVGxCSFVsQmtZVXBMUjJ0c1NUQmpDa2c0TWpsTlVFdHJVbFpaY0cxbVpqTXdUVWxyUTA5TFYxbENiMVE1WWxoRlprWmtPRVZDYzFabmRUUlZhM3BLVm5CT1dVcEJjR3Q1VTFFMVprUmhUQzhLWkVWQmIxQnNVVUpxVWtOVWN6WlhObUpZT0dFMmVHcDJaM0l5UTBreWVVNXJja3RFTTNNclpFVkJhblJxVm1wSVZEVlJaSGN2VVZOclJEZFJVa1o0Y0FvMWJ6Z3dRV1pGTUc5aFVpc3Zka0V3VUhkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRk5VSXZUVXRzUm1FcmJYVldRMmRIUVdrd1NWSk1LMkZhTVVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlFWSklOV3BOTkUxSlNuRjVVMUJGY25aR1ZrTktTbXhOVUdwUVFVcFFaRzlKVG0wemIwVlFlbEowUlU5SlYyMUljQW81VkZkdGIwZFBkek41YVhGelowUnFZaloyT0V0UlZFZ3dUWFJsWlVSU04yVXdMMjFVY0N0TGRuVXJXVzh3Wkcxb01VMUhiSGMyUm1aM1ZVaENTazFIQ2l0dmJuZHpMMDVYWjJsdVJuTkxOelEyYW5oVmFDOU1iVmh3U2pORk9UUkxhMGMxZUVkelFUUk5TMlF2V1dKVFl6WllNRlZQYjJOemVuUldja05DYzNjS1dsZGhiVXQyVDJWTE5WVnVWWEl4Umtwck1XeEdPVUpSVVZGak9WSk1NV3MxV0RGNVdrbHVhbk5EZDFac1NXMXJUVzlaWW1KR2RrUTVTRVJCWkZCaVNncHFLMjE1YmtkcVJDOVlZeTlvTDJORmRsaG1aa2hoWkhRdlFtMXVkbU5GZUdRNFJUbHlTRlZpTmxwME1VeFRRVXRzYW5oS2FGSldXVFp4Yld0NmFWa3lDbkYxYkV0cVRVMTRaMlJzVUdOVFkzVkhha2RCVlRjeWVrOUxTVEJwTm14UE5FeDVUUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZjFjYTgwMzgtNmY0My00NGJhLWI5MTctOTcwMmMzZDZiNTUxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxNTRYZmhVSlUyeXlIMzZid2RpaXRTaGl2bzRIcmVTZEUwSVA2YWltT21UZkc4dGtEUWI3Q1lmTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUlpNVTR4YjFoRVZFMTZUVlJGZUUxcVJYcE9WRmt4VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUa2MwQ2pnMmRGQlFXbVZ0YVcwMlVuWlZjVmd2ZDNKWlUxZzJLM1psWjJOc1dsZENSalUwUXpnMFVUQjNhbTFwZWtGTmNFMXRhVFo2TlRKcWFVeDZjSEpGVDNNS01IUlNjamRuZGtGS01sRmFkMFpTYjNaa1pWVmFOVk5pTUZBd2FrVllkVXQwWldwbk9YVTNaa3B0V1N0SFNISmxjWHBwT0dwMlduaG9NVEJqUWpodVFRb3JUR3h1WmxOUGVXSTJZVWxWUzJvck1FTjVVSFJXWTBJeVptUlNRV2hqYWxaemRVSmFiMkYzVGxWWFRFNXVOamxGYm5oNFUyVkJUMDFTTm5aeVJFSm1DbUkxVjA1YVZuVTVWR0p0TlZNeWMzUkhiM2xFVGt0YVVuZExZVEpHVDNObFpHNWxlWGRhTlhveVpFWkdTU3RYU0VKTVJpOTRNbFk0V21KUmRUTm1MMlVLYms5VmVEZzBaRkpCYkVkaWRUY3dZV2RhVERobVNubzRVSGRTY0d4RU5GaGllVFI2TjJ0U1pUTlZOMlJ2S3k5c1JHeE1kbEZPVnpKVFNrd3pWR1pxTmdwWllrRXlWMFpqWVV4bU9XSnpkMGxzZG1ORlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlJVWnhkMEZ4VVZad1VEaDZVMDF5WVdobU4xbHRiMVUxUWpCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQllrSnNPVFkwT1RCbmIybHVaV1pLV1VwU1lsVkplR1o1Y2s4d1UyWXhVa3hpVW1ad1JuWk5TbUpzUzNCYVQyTkxkd3BqTVdsa2JUZzFjRFZYY1dSeGQzZDNjV05WYmpNd1NuRkpPRzl4U0VwTFJFMUdURUZxYjA4NVRtSXpaMmRYYlZOUlQwSjFNMjlOVlZwWGRGbDVRVEJ1Q25aTlpXbzBTMDFOT1ZSdFUwWlNNMVp3YlVKelJFcDFXRWhsWjNJMWEwZFdPRFYwVlVOdlRIcFVjbEpvYlhSeE1ETnplVU5zVFhVMlQxVjZRMUpTUlVrS2NqbDBWMjlxUTNjMFZtSm5aa05rYTBGUVdDdGtNRUZ5ZURjMWNtbG5hbGRpVHpscllWWkVkakZrY1hwWlpVSnBSa1poVkZWa2VWRjJLekpPWlRJcmVRcDZXSGg2V0RsSk9ESm1WVlJ4VFVoeGJWcFdlWGRGV2tGcGQyWnllV2ROWkc1Rk5uQTRiR1JaYjNkNE5XWXZia2xoYmpsSldYQmhVVloyT1hWb05sVnpDbmcxYWxOdE9FdG9kMWh6VGtOak5sTkRjM2g1Y1ZwNFlUaGlRVlIwYUV0Q0wwdHplQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTJhMGUxMjctYjI0Ni00ZTdjLWIxZjYtZWI4Nzc2MmZmNzYzLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOd3FranlUZFVkdmFxM0RVTDRJUDJ0ejZPdEdtUVdkSzRwaTNvWkhSQkZNck1jV0xXWW95STFnQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -5551,7 +5452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:24 GMT
+      - Mon, 13 Nov 2023 14:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5561,7 +5462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da754193-b52c-4d18-b447-02ef4bf0ec9c
+      - 613ce93a-9094-4355-adb9-47e301fb4689
     status: 200 OK
     code: 200
     duration: ""
@@ -5572,10 +5473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:44.836829Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "671"
@@ -5584,7 +5485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:24 GMT
+      - Mon, 13 Nov 2023 14:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5594,7 +5495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69033928-15ed-4bf7-9c6f-00d910d3bc25
+      - 4a99e293-4426-4ca8-abab-ecc0456152b0
     status: 200 OK
     code: 200
     duration: ""
@@ -5605,19 +5506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/nodes?order_by=created_at_asc&page=1&pool_id=3a32248e-d389-4d5b-979f-328f68abd855&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/nodes?order_by=created_at_asc&page=1&pool_id=549dd02e-61ea-40de-9aec-1c68dedcda39&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:31:41.662987Z","error_message":null,"id":"d806b746-cf85-4235-9871-d7301bd70f1e","name":"scw-test-pool-placeme-test-pool-placeme-d806b7","pool_id":"3a32248e-d389-4d5b-979f-328f68abd855","provider_id":"scaleway://instance/nl-ams-2/832e2bc3-52fe-4237-870b-324943cd6b57","public_ip_v4":"51.158.236.212","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-10T13:34:18.847255Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:38.751025Z","error_message":null,"id":"85120e23-c614-472a-b9f1-fb4b0f8a777b","name":"scw-test-pool-placeme-test-pool-placeme-85120e","pool_id":"549dd02e-61ea-40de-9aec-1c68dedcda39","provider_id":"scaleway://instance/nl-ams-2/9568932f-33d9-44f0-8240-077f4300de38","public_ip_v4":"51.158.238.63","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-13T14:00:44.815322Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:24 GMT
+      - Mon, 13 Nov 2023 14:00:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5627,7 +5528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 841e3755-589d-481d-8205-394569fe0c43
+      - 65e1881d-465b-4e3f-b7d7-e73580366b7c
     status: 200 OK
     code: 200
     duration: ""
@@ -5638,10 +5539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:31:27.025089Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T13:58:10.912448Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -5650,7 +5551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5660,7 +5561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3826101-1768-4864-b5b6-d887271918da
+      - 0827e39a-f051-4bfe-bad6-149f0a804984
     status: 200 OK
     code: 200
     duration: ""
@@ -5671,10 +5572,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea7e0919-223d-4892-8f01-fcc02bad1ed4
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/9377678e-6fed-464c-a2ae-b3e40e4f9c82
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:29:55.989724Z","dhcp_enabled":true,"id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-10T13:29:55.989724Z","id":"e024b64d-0ac7-4cbf-a501-9e2ee8d306d1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:29:55.989724Z"},{"created_at":"2023-11-10T13:29:55.989724Z","id":"e58a3a79-a0cf-48ac-8984-0f8dc525a06d","subnet":"fd68:d440:21c4:cc76::/64","updated_at":"2023-11-10T13:29:55.989724Z"}],"tags":[],"updated_at":"2023-11-10T13:29:55.989724Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-13T13:56:55.206123Z","dhcp_enabled":true,"id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-13T13:56:55.206123Z","id":"623363e3-ff96-455b-833e-e1d478df144f","subnet":"172.16.4.0/22","updated_at":"2023-11-13T13:56:55.206123Z"},{"created_at":"2023-11-13T13:56:55.206123Z","id":"16a86205-8fb7-4b9c-b740-800e85a3c809","subnet":"fd68:d440:21c4:ad4b::/64","updated_at":"2023-11-13T13:56:55.206123Z"}],"tags":[],"updated_at":"2023-11-13T13:56:55.206123Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
       - "725"
@@ -5683,7 +5584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5693,7 +5594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1d931a3-8a84-487d-82ee-1d6bbf6ea551
+      - 69701e54-8d18-4512-8300-80231d73d2f8
     status: 200 OK
     code: 200
     duration: ""
@@ -5704,10 +5605,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/b7adfbe1-fed5-4293-aa43-25e4e6d75b25
     method: GET
   response:
-    body: '{"placement_group":{"id":"c172067b-41d4-4890-a33c-b6436e908f8c","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -5716,7 +5617,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5726,7 +5627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8469541d-010e-440a-a4b0-97270e79b9bd
+      - 0fb10711-2100-42a6-a52b-4484a971ebf4
     status: 200 OK
     code: 200
     duration: ""
@@ -5737,10 +5638,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcHJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5hbXN4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTakZFQ25aVFNGRnFWa1pKYldkbFltYzRhRFZsWjB3NWQwVTRTVzlXV1VZcmJFRTVlRXB4VjA5aGJ6UXJZV1pQVm1SbFdUbHRkR3RwUlhwaFRubGFSM0ZSZGpjS1pWbDVPV1p6WWpCR2IzbFpTalo2UlVaWWJXOU9NVFY0VEdZckswVTNRazlSU0dKak0ybzJPR3Q1T0VadGVXMHJObmcxUzJVelR6TkVhMFZUV0ZKMVJ3cE5UVXR1WkRWcFdWZzBXV3hMVjBWbEt6UTVValEwY0ZoM2NEQjBSRmx5VVZwS1FVZDJWRXhJV2t0TFdqSXhhMUUyVGxCSFVsQmtZVXBMUjJ0c1NUQmpDa2c0TWpsTlVFdHJVbFpaY0cxbVpqTXdUVWxyUTA5TFYxbENiMVE1WWxoRlprWmtPRVZDYzFabmRUUlZhM3BLVm5CT1dVcEJjR3Q1VTFFMVprUmhUQzhLWkVWQmIxQnNVVUpxVWtOVWN6WlhObUpZT0dFMmVHcDJaM0l5UTBreWVVNXJja3RFTTNNclpFVkJhblJxVm1wSVZEVlJaSGN2VVZOclJEZFJVa1o0Y0FvMWJ6Z3dRV1pGTUc5aFVpc3Zka0V3VUhkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRk5VSXZUVXRzUm1FcmJYVldRMmRIUVdrd1NWSk1LMkZhTVVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlFWSklOV3BOTkUxSlNuRjVVMUJGY25aR1ZrTktTbXhOVUdwUVFVcFFaRzlKVG0wemIwVlFlbEowUlU5SlYyMUljQW81VkZkdGIwZFBkek41YVhGelowUnFZaloyT0V0UlZFZ3dUWFJsWlVSU04yVXdMMjFVY0N0TGRuVXJXVzh3Wkcxb01VMUhiSGMyUm1aM1ZVaENTazFIQ2l0dmJuZHpMMDVYWjJsdVJuTkxOelEyYW5oVmFDOU1iVmh3U2pORk9UUkxhMGMxZUVkelFUUk5TMlF2V1dKVFl6WllNRlZQYjJOemVuUldja05DYzNjS1dsZGhiVXQyVDJWTE5WVnVWWEl4Umtwck1XeEdPVUpSVVZGak9WSk1NV3MxV0RGNVdrbHVhbk5EZDFac1NXMXJUVzlaWW1KR2RrUTVTRVJCWkZCaVNncHFLMjE1YmtkcVJDOVlZeTlvTDJORmRsaG1aa2hoWkhRdlFtMXVkbU5GZUdRNFJUbHlTRlZpTmxwME1VeFRRVXRzYW5oS2FGSldXVFp4Yld0NmFWa3lDbkYxYkV0cVRVMTRaMlJzVUdOVFkzVkhha2RCVlRjeWVrOUxTVEJwTm14UE5FeDVUUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZjFjYTgwMzgtNmY0My00NGJhLWI5MTctOTcwMmMzZDZiNTUxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxNTRYZmhVSlUyeXlIMzZid2RpaXRTaGl2bzRIcmVTZEUwSVA2YWltT21UZkc4dGtEUWI3Q1lmTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUlpNVTR4YjFoRVZFMTZUVlJGZUUxcVJYcE9WRmt4VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUa2MwQ2pnMmRGQlFXbVZ0YVcwMlVuWlZjVmd2ZDNKWlUxZzJLM1psWjJOc1dsZENSalUwUXpnMFVUQjNhbTFwZWtGTmNFMXRhVFo2TlRKcWFVeDZjSEpGVDNNS01IUlNjamRuZGtGS01sRmFkMFpTYjNaa1pWVmFOVk5pTUZBd2FrVllkVXQwWldwbk9YVTNaa3B0V1N0SFNISmxjWHBwT0dwMlduaG9NVEJqUWpodVFRb3JUR3h1WmxOUGVXSTJZVWxWUzJvck1FTjVVSFJXWTBJeVptUlNRV2hqYWxaemRVSmFiMkYzVGxWWFRFNXVOamxGYm5oNFUyVkJUMDFTTm5aeVJFSm1DbUkxVjA1YVZuVTVWR0p0TlZNeWMzUkhiM2xFVGt0YVVuZExZVEpHVDNObFpHNWxlWGRhTlhveVpFWkdTU3RYU0VKTVJpOTRNbFk0V21KUmRUTm1MMlVLYms5VmVEZzBaRkpCYkVkaWRUY3dZV2RhVERobVNubzRVSGRTY0d4RU5GaGllVFI2TjJ0U1pUTlZOMlJ2S3k5c1JHeE1kbEZPVnpKVFNrd3pWR1pxTmdwWllrRXlWMFpqWVV4bU9XSnpkMGxzZG1ORlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlJVWnhkMEZ4VVZad1VEaDZVMDF5WVdobU4xbHRiMVUxUWpCTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQllrSnNPVFkwT1RCbmIybHVaV1pLV1VwU1lsVkplR1o1Y2s4d1UyWXhVa3hpVW1ad1JuWk5TbUpzUzNCYVQyTkxkd3BqTVdsa2JUZzFjRFZYY1dSeGQzZDNjV05WYmpNd1NuRkpPRzl4U0VwTFJFMUdURUZxYjA4NVRtSXpaMmRYYlZOUlQwSjFNMjlOVlZwWGRGbDVRVEJ1Q25aTlpXbzBTMDFOT1ZSdFUwWlNNMVp3YlVKelJFcDFXRWhsWjNJMWEwZFdPRFYwVlVOdlRIcFVjbEpvYlhSeE1ETnplVU5zVFhVMlQxVjZRMUpTUlVrS2NqbDBWMjlxUTNjMFZtSm5aa05rYTBGUVdDdGtNRUZ5ZURjMWNtbG5hbGRpVHpscllWWkVkakZrY1hwWlpVSnBSa1poVkZWa2VWRjJLekpPWlRJcmVRcDZXSGg2V0RsSk9ESm1WVlJ4VFVoeGJWcFdlWGRGV2tGcGQyWnllV2ROWkc1Rk5uQTRiR1JaYjNkNE5XWXZia2xoYmpsSldYQmhVVloyT1hWb05sVnpDbmcxYWxOdE9FdG9kMWh6VGtOak5sTkRjM2g1Y1ZwNFlUaGlRVlIwYUV0Q0wwdHplQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTJhMGUxMjctYjI0Ni00ZTdjLWIxZjYtZWI4Nzc2MmZmNzYzLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOd3FranlUZFVkdmFxM0RVTDRJUDJ0ejZPdEdtUVdkSzRwaTNvWkhSQkZNck1jV0xXWW95STFnQQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -5749,7 +5650,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5759,7 +5660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1c893b5-10f0-40dc-ac71-911321ceb4e0
+      - c881ebc3-abc7-4bfd-843d-105121381c0b
     status: 200 OK
     code: 200
     duration: ""
@@ -5770,7 +5671,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
@@ -5782,7 +5683,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5792,7 +5693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e192d892-bff5-4404-9e49-0d142f9a5175
+      - 54d5e3d4-99ae-4ba1-8619-a17fde078b9a
     status: 200 OK
     code: 200
     duration: ""
@@ -5803,10 +5704,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:34:18.869117Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:44.836829Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "671"
@@ -5815,7 +5716,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5825,7 +5726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89e11fdb-0a5b-4580-b76f-d3f350aabebc
+      - 07518b3b-8edb-497e-8e13-310e03af04ac
     status: 200 OK
     code: 200
     duration: ""
@@ -5836,19 +5737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/nodes?order_by=created_at_asc&page=1&pool_id=3a32248e-d389-4d5b-979f-328f68abd855&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/nodes?order_by=created_at_asc&page=1&pool_id=549dd02e-61ea-40de-9aec-1c68dedcda39&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:31:41.662987Z","error_message":null,"id":"d806b746-cf85-4235-9871-d7301bd70f1e","name":"scw-test-pool-placeme-test-pool-placeme-d806b7","pool_id":"3a32248e-d389-4d5b-979f-328f68abd855","provider_id":"scaleway://instance/nl-ams-2/832e2bc3-52fe-4237-870b-324943cd6b57","public_ip_v4":"51.158.236.212","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-10T13:34:18.847255Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:38.751025Z","error_message":null,"id":"85120e23-c614-472a-b9f1-fb4b0f8a777b","name":"scw-test-pool-placeme-test-pool-placeme-85120e","pool_id":"549dd02e-61ea-40de-9aec-1c68dedcda39","provider_id":"scaleway://instance/nl-ams-2/9568932f-33d9-44f0-8240-077f4300de38","public_ip_v4":"51.158.238.63","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-13T14:00:44.815322Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5858,7 +5759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 363a0b96-9a38-41a4-a8a1-a65ee0159689
+      - 74572eae-6926-4208-ae83-1d8820d2efbe
     status: 200 OK
     code: 200
     duration: ""
@@ -5869,7 +5770,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
@@ -5881,7 +5782,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5891,7 +5792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0cc9aae-b771-4ec2-9d8e-b92dadc56ebd
+      - 18000d1d-9773-4ed4-8151-6b910c1d1cda
     status: 200 OK
     code: 200
     duration: ""
@@ -5902,10 +5803,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:00:50.442643421Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "677"
@@ -5914,7 +5815,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:26 GMT
+      - Mon, 13 Nov 2023 14:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5924,7 +5825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6770729-ef29-4f7a-a223-3c3c70166cf6
+      - 9976f121-05bf-4013-9b15-4f721364be02
     status: 200 OK
     code: 200
     duration: ""
@@ -5935,10 +5836,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:00:50.442643Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "674"
@@ -5947,7 +5848,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:26 GMT
+      - Mon, 13 Nov 2023 14:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5957,7 +5858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7df4b59-7549-448d-9944-257eddf1dd34
+      - 53fc04c0-364c-4663-bd32-bbb73275c2ca
     status: 200 OK
     code: 200
     duration: ""
@@ -5968,10 +5869,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","container_runtime":"containerd","created_at":"2023-11-13T13:57:01.967275Z","id":"549dd02e-61ea-40de-9aec-1c68dedcda39","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"b7adfbe1-fed5-4293-aa43-25e4e6d75b25","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:00:50.442643Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
       - "674"
@@ -5980,7 +5881,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:31 GMT
+      - Mon, 13 Nov 2023 14:00:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5990,7 +5891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ad6bda2-01dd-41fb-8819-ff698416308b
+      - 1f8a5c98-230c-464d-a515-7a8fcf6965ca
     status: 200 OK
     code: 200
     duration: ""
@@ -6001,76 +5902,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/549dd02e-61ea-40de-9aec-1c68dedcda39
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:34:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b2f83cb0-060d-4052-b12d-4abfb17c7104
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","container_runtime":"containerd","created_at":"2023-11-10T13:30:02.929894Z","id":"3a32248e-d389-4d5b-979f-328f68abd855","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"c172067b-41d4-4890-a33c-b6436e908f8c","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:34:26.415537Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "674"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:34:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6ed83c8f-c42d-4681-9e9d-62893c9c4fe2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/3a32248e-d389-4d5b-979f-328f68abd855
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"3a32248e-d389-4d5b-979f-328f68abd855","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"549dd02e-61ea-40de-9aec-1c68dedcda39","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -6079,7 +5914,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:46 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6089,7 +5924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11d76918-c466-462d-8d28-1213d54e856e
+      - f702b1a7-c171-499d-9fd0-caec963f9fd0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6100,39 +5935,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/c172067b-41d4-4890-a33c-b6436e908f8c
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763?with_additional_resources=true
     method: DELETE
   response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Fri, 10 Nov 2023 13:34:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e9cbf41b-f86a-4412-b4a5-c4f0d228137e
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:34:46.854089967Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T14:01:00.780939509Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -6141,7 +5947,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:46 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6151,7 +5957,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 211bb420-66f9-4277-a42f-7d10188f768c
+      - 7d600000-1c7e-4207-8475-1f7269f22d83
     status: 200 OK
     code: 200
     duration: ""
@@ -6162,19 +5968,15 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
-    method: GET
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/b7adfbe1-fed5-4293-aa43-25e4e6d75b25
+    method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:34:46.854090Z","upgrade_available":false,"version":"1.28.2"}'
+    body: ""
     headers:
-      Content-Length:
-      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:46 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6184,7 +5986,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72227d6d-b87f-4a3a-953d-e37d2c9700a4
+      - 8ce4d6ea-ba4a-4866-9857-fe498f0e9321
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T14:01:00.780940Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1518"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52070013-2418-4d3e-8166-656784bad3c5
     status: 200 OK
     code: 200
     duration: ""
@@ -6200,7 +6035,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"6d767778-3717-4398-83d6-1afdf4935a54","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"placement_group":{"id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -6209,9 +6044,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:47 GMT
+      - Mon, 13 Nov 2023 14:01:01 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/6d767778-3717-4398-83d6-1afdf4935a54
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/5950daa2-7826-4eab-b245-35eb5dd2aba8
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6221,7 +6056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e474be8-9b8e-41cb-875b-98ca2978430f
+      - 90b31d91-52d6-44b0-b0d8-fe36b50e259f
     status: 201 Created
     code: 201
     duration: ""
@@ -6232,10 +6067,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/6d767778-3717-4398-83d6-1afdf4935a54
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/5950daa2-7826-4eab-b245-35eb5dd2aba8
     method: GET
   response:
-    body: '{"placement_group":{"id":"6d767778-3717-4398-83d6-1afdf4935a54","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"placement_group":{"id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -6244,7 +6079,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:47 GMT
+      - Mon, 13 Nov 2023 14:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6254,7 +6089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c309106-f9a9-49cb-addb-9121634748ea
+      - 2955703e-1ad9-45dd-8a31-0d3e1b782b7f
     status: 200 OK
     code: 200
     duration: ""
@@ -6265,10 +6100,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f1ca8038-6f43-44ba-b917-9702c3d6b551.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:29:57.173644Z","created_at":"2023-11-10T13:29:57.173644Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f1ca8038-6f43-44ba-b917-9702c3d6b551.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-10T13:34:46.854090Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a2a0e127-b246-4e7c-b1f6-eb87762ff763.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:56:56.173271Z","created_at":"2023-11-13T13:56:56.173271Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a2a0e127-b246-4e7c-b1f6-eb87762ff763.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-13T14:01:00.780940Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1518"
@@ -6277,7 +6112,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:52 GMT
+      - Mon, 13 Nov 2023 14:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6287,7 +6122,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c2089c7-4270-4784-a6ef-da2be7dfacbf
+      - f84d8995-373f-4dd9-8fac-35d015a5ffff
     status: 200 OK
     code: 200
     duration: ""
@@ -6298,10 +6133,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/f1ca8038-6f43-44ba-b917-9702c3d6b551
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/a2a0e127-b246-4e7c-b1f6-eb87762ff763
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f1ca8038-6f43-44ba-b917-9702c3d6b551","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a2a0e127-b246-4e7c-b1f6-eb87762ff763","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6310,7 +6145,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:57 GMT
+      - Mon, 13 Nov 2023 14:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6320,7 +6155,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6948fcea-a019-44cc-b7da-3261deaaadec
+      - efa2aea6-f13b-46b5-8ad4-fae56403eced
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6331,10 +6166,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ea7e0919-223d-4892-8f01-fcc02bad1ed4
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/9377678e-6fed-464c-a2ae-b3e40e4f9c82
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"ea7e0919-223d-4892-8f01-fcc02bad1ed4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9377678e-6fed-464c-a2ae-b3e40e4f9c82","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -6343,7 +6178,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:57 GMT
+      - Mon, 13 Nov 2023 14:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6353,7 +6188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dd2c2be-7ca4-4501-ae3b-f34c0d018eee
+      - 7d394708-fa06-45a0-880d-b66dba0ecac9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6369,7 +6204,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299916696Z","created_at":"2023-11-10T13:34:57.299916696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846206Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522465Z","created_at":"2023-11-13T14:01:11.288522465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303527518Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -6378,7 +6213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:57 GMT
+      - Mon, 13 Nov 2023 14:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6388,7 +6223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 505e4f01-c22e-4f20-903f-e72178bd2ba6
+      - 4802b9f0-2ec2-42e1-9cc5-784cb9f3545a
     status: 200 OK
     code: 200
     duration: ""
@@ -6399,10 +6234,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6411,7 +6246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:34:57 GMT
+      - Mon, 13 Nov 2023 14:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6421,7 +6256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60d5780e-f267-45a6-8a96-26a08cae2369
+      - 6f4b06ae-e9cc-4dc8-b474-eecee4976f5b
     status: 200 OK
     code: 200
     duration: ""
@@ -6432,10 +6267,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6444,7 +6279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:02 GMT
+      - Mon, 13 Nov 2023 14:01:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6454,7 +6289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e17f9e4-14a0-4181-9191-e288c8447758
+      - 0850238f-905b-425a-9a54-abf049257089
     status: 200 OK
     code: 200
     duration: ""
@@ -6465,10 +6300,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6477,7 +6312,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:07 GMT
+      - Mon, 13 Nov 2023 14:01:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6487,7 +6322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f99a729-cda9-4dbd-9109-ee0482eb9c30
+      - 1deb0df7-4388-4435-ac76-1993a46e081a
     status: 200 OK
     code: 200
     duration: ""
@@ -6498,10 +6333,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6510,7 +6345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:12 GMT
+      - Mon, 13 Nov 2023 14:01:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6520,7 +6355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5199352-fe06-42e5-8e8e-54163006d6c2
+      - 20e86db1-c939-4c53-86db-be610f2d74b2
     status: 200 OK
     code: 200
     duration: ""
@@ -6531,10 +6366,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6543,7 +6378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:17 GMT
+      - Mon, 13 Nov 2023 14:01:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6553,7 +6388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0973b44e-1be9-436d-a4e1-69f2ef37c43d
+      - 02feaaa2-7230-4e4e-bc9b-2885c1bfd601
     status: 200 OK
     code: 200
     duration: ""
@@ -6564,10 +6399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6576,7 +6411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:22 GMT
+      - Mon, 13 Nov 2023 14:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6586,7 +6421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d7672a5-cea5-44d6-8b16-057a9caba16f
+      - b4303b8b-ed8f-469b-ad17-333cec504259
     status: 200 OK
     code: 200
     duration: ""
@@ -6597,10 +6432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6609,7 +6444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:27 GMT
+      - Mon, 13 Nov 2023 14:01:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6619,7 +6454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e0a00f7-73c0-46d3-b46b-80b8bcddc4e6
+      - 6568fc02-1d33-43da-9179-ce785828cddd
     status: 200 OK
     code: 200
     duration: ""
@@ -6630,10 +6465,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6642,7 +6477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:32 GMT
+      - Mon, 13 Nov 2023 14:01:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6652,7 +6487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e12df065-9496-4343-81d1-428550941153
+      - ff634778-5462-4ac7-af25-11509f40667f
     status: 200 OK
     code: 200
     duration: ""
@@ -6663,10 +6498,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6675,7 +6510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:37 GMT
+      - Mon, 13 Nov 2023 14:01:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6685,7 +6520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56f8216c-8409-4f16-8f1d-1b06a3aa3096
+      - cb829989-e205-41c0-bcec-f7e969aaf6b2
     status: 200 OK
     code: 200
     duration: ""
@@ -6696,10 +6531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6708,7 +6543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:42 GMT
+      - Mon, 13 Nov 2023 14:01:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6718,7 +6553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db12a4c4-c399-4c6c-b918-fbbb1eadcbfc
+      - b4a421eb-1349-4e7a-9175-dc898a7fa9b1
     status: 200 OK
     code: 200
     duration: ""
@@ -6729,10 +6564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6741,7 +6576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:48 GMT
+      - Mon, 13 Nov 2023 14:02:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6751,7 +6586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18cafafe-6197-4e9c-a281-53ef08bfa7e7
+      - fb1efa7c-ade2-4ab6-b922-5d440656207f
     status: 200 OK
     code: 200
     duration: ""
@@ -6762,10 +6597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6774,7 +6609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:53 GMT
+      - Mon, 13 Nov 2023 14:02:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6784,7 +6619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6323096-afc9-460f-a909-227c72ed9f62
+      - 468a50ed-7114-4be5-8c1a-a9bb464643c6
     status: 200 OK
     code: 200
     duration: ""
@@ -6795,10 +6630,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6807,7 +6642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:35:58 GMT
+      - Mon, 13 Nov 2023 14:02:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6817,7 +6652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3eb6f0d-dc6b-4fda-b1ee-4948119ddcce
+      - a307f4b1-d2b1-4f15-8351-10bc653c3e26
     status: 200 OK
     code: 200
     duration: ""
@@ -6828,10 +6663,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:34:57.328846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6840,7 +6675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:03 GMT
+      - Mon, 13 Nov 2023 14:02:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6850,7 +6685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52224a5e-5214-467e-b7f1-fb9f0445231f
+      - e9cff673-9bf3-4f64-a9f5-befb4cbdf0a1
     status: 200 OK
     code: 200
     duration: ""
@@ -6861,10 +6696,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:01:11.303528Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1485"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60e94763-037d-4ee6-b276-baab1d570794
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:02:22.986688Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6873,7 +6741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:08 GMT
+      - Mon, 13 Nov 2023 14:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6883,7 +6751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61c68e62-e1b6-42d9-9b7f-20ff64f04b3d
+      - ab0d7d85-5877-4dd1-a085-3b4667a6902b
     status: 200 OK
     code: 200
     duration: ""
@@ -6894,10 +6762,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:02:22.986688Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6906,7 +6774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:08 GMT
+      - Mon, 13 Nov 2023 14:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6916,7 +6784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61353c33-df3e-44ad-b2cc-7153769f0452
+      - 88d72116-ae5f-4910-b56d-0be039d85ba1
     status: 200 OK
     code: 200
     duration: ""
@@ -6927,10 +6795,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRYcFJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5lbEV4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbTVQQ20xelZ6WkpTelZCZFdKVk1UWmlTbFJsUm5aeWNETlpjekZQSzI5UVNuQlJWR0pNYWtnNUsxcHpZMFJqYVVwaGVqY3JTV1pGTXpoUlNuRkRVR0kzVW1RS0wxazVaazFOT0RsdFFVeFlORTR3VVhsNFN6SnpaVVZtY1doSlVETkpOWFJEVUU5bllVNTFaMjExUmpadVkzcFVSSE5OY1dkc1R5OHJWRk4yZEdsNGR3cHBhaTlEZVhVd01IZzFObmxRV0dweGRtSjBaVmxvU2t4VldYSllSVWxtZEZCU01qWXpTemd3TVU1RlZuWnFhV0Y2ZFZOclN6QjNjM2hQWld0b2RYVnhDbFowT1ROUFkwaExha1pzTUdsWllYWnZOREE0YzFJek1XNUtTa1YyU1RSUWRWWndRMFI0UW5CclVIQjJSbnAwTlRkUk5YcHlUR050V1U1MVV6VlFTWElLZGtGNmVHODVVaXRYWmpoTGFHeDRWRWc1YUdGbkswNXdXWEl3VURaVk0wOVBaRXMxVkV4MFZWTlpSRmRtV2psSlRIbHhiRzVtVTJOS1ZHVkhNalZ6YkFwS2Qxb3djVUZDYUdkT2NGQkphSEpzUkVJNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2VWbzVPVFZaUmxKYVRHcEplbXBrUWk4MVJqTTNlWGRsYUhSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1JsQjVUMFpZZWtKaFdHTjNkWG9yYWxKUWVtY3lORTFYY1UxVU5VaDZiRVYxUjJSaFkwcHdjV1ZTVG5ScWRqUmpUQXA0YWtkckswUndNSGRRVm04Mk9UTktNelE1Wmxab2MwczVXRnBJVVZadmFHeG1ia2s1V1ROVGR6QktWMGRLVjJGeWJrTjVWbFpOTW14Uk5uaFRPWEpvQ2t0UlZHcG5VVTB4VmpoT2QyMXlUR2xrT1dWck5uazRSV3REZUVVNFpraHVia2RGZVRGcmRqZDNVbTFSVkRnNE5ETlJNbWxMYVZnd1prVnJSV3NyY1UwS2VUaE1XbkJSVEVGVWFGVlBaRkU0VjJKTWEwdG9ORGhNV25kcVpISmhMMHgwUlV0UVJ6TnJVME4xTWxRclZFbDNNblk1WVZaS05qRm9VVWxJZFhkbWNncGxUbGN4VW01blZsVTBPVXRXUm5SM1J6QktabUZhUW5sWmFUY3JTMjFtTTJSNFlteGpVelJtU1U5dlVUbFZUakpSVFRCT1YxcG1XRXhRUm5SRFpHZGFDbkYxYjI5RlNYTndNVkZ3Ym1kRlMyeDNiWHBoYzBzNFRtc3hkV1J4ZUZOeWVFWkJTUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTNhYWM4ZmItZDY1Ni00ODY0LWI1MGItNmU5YzIxMDhlMTBkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBhcFBnS1lnblRoZTgyeGEyQjRqR0pTSzNBYVdza2JkUE1aV212bUd4WVcxNGM5VWd1RVRkQjh4Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtVd1RVUkZlRTFzYjFoRVZFMTZUVlJGZUUxcVJUQk5SRVY0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVEJqQ25GVFlYZFlVMWszU25ObWNIWkxURTFGYURCSlptdFhRM1ppUWs1U1RHaEVVM05QWW5rMk1taE5OblJtTmtsSlZrdDNOMGhpUzBwWU5rMWtPWFJ3TmpFS1pVbEZLMHN6ZFZscFFrWmxibkZOVUVoR1MwOU5aaXRyVjNOMU1HSk1WRVF6VEN0TVF6UldRVTlXTkVjcloyRmhZVGxtVERndlJEWm5XbEZTZW5sa01RcHNVbmRxSzJ4dGJHZHJVVVJXYTJzNFFWUTVWVkpzWkRFcmNHZzVWMHBFZFZCTlJsQmtSVEpyWjJnMVdFd3ZRMU5wU2xSc1VqZHdSRzl2ZFZsVE1tSXpDbE5zZVRSSE0wZzBha2xhV0VKVVRteHNia3hKVG10WVZIQTFNM1p2UnpKWWJqQTFRelF3U1dkcWEwWjNiRGRRTW5JNVlYTkZNRWhtV205a01qQjJieXNLU25WUFVHbHhla0l5WVhCdVVUUTFVeXRzTUZCU1dXY3ZRMWgyTmpSTFVHWTNaVVp5V1ZjNU1VcDRhREJ0ZUhGbloyRktTVTlTUVVOT01YSkxRWE4zYkFwQmFITlFSbEEwV1ROS1VrbzRTbU5rYzFvd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT2VrcDVVMWt6U3k5UU1IUXZRVFExYWtoMldHUjVNVFo1ZGsxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05VRnlkMEZYT0ZscE5GVjBOak5rYTJScE1rcEZLMG8zZFN0cGIwRlNhSEZRTTNoblpXZDJTbHBUVVVoQlRGcFhiZ280VWpCTmF5dHhhVEoyVWpGdlVtNTFXbnBxT1hoRVlXOUthbUYwZFRKUU1sSmhkRkpoTjBKcFIyTjNOQ3RqYjJKNFZFdzJUWFZhU2xjM1dtaFZSa0V2Q2tWUWJreHJVR2hUWjA4dmFTOXlTVzFuYTFacWNXNWlhRFY0VERVd1IzRjJOVFEyUVVsM1VHRTVSekJGY1dGUVNHSkJhME5LU2tOT1lsQkZPVUo0UmtVS1pFRjFXVGhPWXpSdWNVMVVOek5sV21ab05VTmFOR3QwTWtrMVUya3daSE5pUzJkb1NIVm9ibGR6Y2sxS00zcGthalUzU3pRd1prdHdWM1ZqYUcxcE13cDRlWGt3VjJSdWJXcFNNRFozYmtzeFNISjZhRmhUZG1kRFFYaFhWMjUxY1hSdmFraHRLMWxwVHprNGQzTnhWMGcxT0U1RldHUXZUalZIVFROck4wRmtDbTFRUVVadU1VSXJOVWRpWjNReE9IaFFUR3h3ZERKNlpYRlNSR1VyZFdONEswbDFkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMTk3NWVlZDEtM2YwMC00ODI0LThlZWItMDc5ZTg1MWEyMGE1LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBDSnpqUTZwd3BDZ0NOUHZtYjlQTHVNejBGRmthWmJyRnQ4S2FzN2lONEM5TWNDdXZHNmtuNUNTcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -6939,7 +6807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:08 GMT
+      - Mon, 13 Nov 2023 14:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6949,7 +6817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3d41d14-e089-4a62-b43e-cc50104b8b51
+      - 05ddfd01-539b-43c9-8ff3-87af0a9d6332
     status: 200 OK
     code: 200
     duration: ""
@@ -6960,10 +6828,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:02:22.986688Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6972,7 +6840,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:08 GMT
+      - Mon, 13 Nov 2023 14:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6982,12 +6850,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac01ffcb-4a39-4a1f-a323-49de430183cc
+      - 1f5931b0-e570-498a-9bbf-dee5e32959c6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
+    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -6995,10 +6863,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243304Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782071Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "676"
@@ -7007,7 +6875,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:09 GMT
+      - Mon, 13 Nov 2023 14:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7017,7 +6885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04329fb1-a4b6-48a2-b85a-e5e801e8a49a
+      - d20aebdc-5160-4d81-874f-e38b7b246a53
     status: 200 OK
     code: 200
     duration: ""
@@ -7028,10 +6896,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7040,7 +6908,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:09 GMT
+      - Mon, 13 Nov 2023 14:02:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7050,7 +6918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3dfb088-8934-4fd9-b859-a6e2143d7859
+      - f3053bee-6a8e-4c45-b587-53c190691313
     status: 200 OK
     code: 200
     duration: ""
@@ -7061,10 +6929,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7073,7 +6941,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:14 GMT
+      - Mon, 13 Nov 2023 14:02:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7083,7 +6951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef9a7322-2579-4fcd-9716-54d1829624ec
+      - fe89fded-6acd-4c6e-84b2-4bd413ca1201
     status: 200 OK
     code: 200
     duration: ""
@@ -7094,10 +6962,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7106,7 +6974,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:19 GMT
+      - Mon, 13 Nov 2023 14:02:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7116,7 +6984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e10945e8-743b-4196-bb08-13090febe3ea
+      - 3484bbb8-5f25-4360-a334-f05dac766b82
     status: 200 OK
     code: 200
     duration: ""
@@ -7127,10 +6995,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7139,7 +7007,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:24 GMT
+      - Mon, 13 Nov 2023 14:02:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7149,7 +7017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97694042-20b8-4887-bf91-9022edb94f98
+      - f20461d1-0890-4d81-9b99-cdc5cf8d37f3
     status: 200 OK
     code: 200
     duration: ""
@@ -7160,10 +7028,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7172,7 +7040,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:29 GMT
+      - Mon, 13 Nov 2023 14:02:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7182,7 +7050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06df751d-2c18-4efd-ac03-b1a40b20efa4
+      - b887b9fc-5910-46f6-b512-6a8757ad08d7
     status: 200 OK
     code: 200
     duration: ""
@@ -7193,10 +7061,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7205,7 +7073,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:34 GMT
+      - Mon, 13 Nov 2023 14:02:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7215,7 +7083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d74715b6-6acf-4027-bc20-c0a7859c0def
+      - f5d27efd-2c31-4784-9717-56a3c38d72d6
     status: 200 OK
     code: 200
     duration: ""
@@ -7226,10 +7094,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7238,7 +7106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:39 GMT
+      - Mon, 13 Nov 2023 14:02:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7248,7 +7116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2834f35-91d0-47d9-996e-b25c07f41d23
+      - 0d1e9b52-439c-4cea-b51c-d859eba89195
     status: 200 OK
     code: 200
     duration: ""
@@ -7259,10 +7127,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7271,7 +7139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:44 GMT
+      - Mon, 13 Nov 2023 14:03:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7281,7 +7149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 405a4d0a-3b47-405c-bde9-1923e34b6c26
+      - 7fa5e90d-c93f-41d7-9167-da40c4ed6f26
     status: 200 OK
     code: 200
     duration: ""
@@ -7292,10 +7160,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7304,7 +7172,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:49 GMT
+      - Mon, 13 Nov 2023 14:03:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7314,7 +7182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd713a79-9841-49b8-add6-5caf329c7313
+      - 8e95d2e4-15cc-4363-812e-d5b67a79e873
     status: 200 OK
     code: 200
     duration: ""
@@ -7325,10 +7193,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7337,7 +7205,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:54 GMT
+      - Mon, 13 Nov 2023 14:03:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7347,7 +7215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a1d9b36-363a-4ca7-84c4-5b1f0d775359
+      - 3db19542-ec12-4e5c-8ea1-82c58a9c29fd
     status: 200 OK
     code: 200
     duration: ""
@@ -7358,10 +7226,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7370,7 +7238,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:36:59 GMT
+      - Mon, 13 Nov 2023 14:03:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7380,7 +7248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64f63154-618f-4135-b9c3-1b991d381765
+      - dfd3cd0c-c706-41fc-8ae4-f4f8777a797f
     status: 200 OK
     code: 200
     duration: ""
@@ -7391,10 +7259,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7403,7 +7271,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:04 GMT
+      - Mon, 13 Nov 2023 14:03:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7413,7 +7281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c757096-082d-4ce0-bbd3-646b10e64451
+      - 79816bd7-c8ba-4ae7-8a18-617449d96011
     status: 200 OK
     code: 200
     duration: ""
@@ -7424,10 +7292,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7436,7 +7304,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:09 GMT
+      - Mon, 13 Nov 2023 14:03:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7446,7 +7314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cc46e8d-d177-4434-92bb-db4aed577cf0
+      - 71cf4f7b-6fb0-4aae-a2b0-b86fc150b8a2
     status: 200 OK
     code: 200
     duration: ""
@@ -7457,10 +7325,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7469,7 +7337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:14 GMT
+      - Mon, 13 Nov 2023 14:03:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7479,7 +7347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8124704-1c90-42da-9981-804aebce75e4
+      - 2ffbaef2-02ba-4f94-99bf-07a2f15bf562
     status: 200 OK
     code: 200
     duration: ""
@@ -7490,10 +7358,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7502,7 +7370,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:19 GMT
+      - Mon, 13 Nov 2023 14:03:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7512,7 +7380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5052f5e6-7eca-4170-80fd-63e8830dba29
+      - 58afc496-1aa9-44c4-b292-8d6c4905bde6
     status: 200 OK
     code: 200
     duration: ""
@@ -7523,10 +7391,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7535,7 +7403,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:24 GMT
+      - Mon, 13 Nov 2023 14:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7545,7 +7413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9044abd4-b035-4b3d-967c-c3678dc6053b
+      - 7f3ac924-f533-4620-b4b5-052f853da1f0
     status: 200 OK
     code: 200
     duration: ""
@@ -7556,10 +7424,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7568,7 +7436,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:30 GMT
+      - Mon, 13 Nov 2023 14:03:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7578,7 +7446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63e0e3ab-d215-4064-8686-8bfa8a68e4ac
+      - 3f2b84ea-0feb-4d4d-afc2-40c9cf65fd65
     status: 200 OK
     code: 200
     duration: ""
@@ -7589,10 +7457,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7601,7 +7469,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:35 GMT
+      - Mon, 13 Nov 2023 14:03:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7611,7 +7479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da621b7b-cd15-4bdc-b5c6-271841b4d18b
+      - d0191e70-32c1-4a18-b5bc-0327c8e0b32d
     status: 200 OK
     code: 200
     duration: ""
@@ -7622,10 +7490,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7634,7 +7502,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:40 GMT
+      - Mon, 13 Nov 2023 14:03:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7644,7 +7512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 599ab9d6-2bc7-4e61-b2e3-b410cbc15df0
+      - d62a20e1-4dc3-4719-a7d9-71510d719aac
     status: 200 OK
     code: 200
     duration: ""
@@ -7655,10 +7523,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7667,7 +7535,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:45 GMT
+      - Mon, 13 Nov 2023 14:04:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7677,7 +7545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 741ac7a5-8bec-4cf0-9473-d416150a6806
+      - 2e79c4e3-9e54-47d6-878f-cf6c2473c8d9
     status: 200 OK
     code: 200
     duration: ""
@@ -7688,10 +7556,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7700,7 +7568,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:50 GMT
+      - Mon, 13 Nov 2023 14:04:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7710,7 +7578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dac89df-923b-46c7-8e5f-fe5661ad6fd7
+      - 14690763-a685-4fe9-9d76-ab1172e8958c
     status: 200 OK
     code: 200
     duration: ""
@@ -7721,10 +7589,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7733,7 +7601,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:37:55 GMT
+      - Mon, 13 Nov 2023 14:04:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7743,7 +7611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bd9f4bd-a513-45d1-a5b1-aa28847de754
+      - e80ca11b-67ee-442f-922e-8d2027c8b540
     status: 200 OK
     code: 200
     duration: ""
@@ -7754,10 +7622,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7766,7 +7634,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:00 GMT
+      - Mon, 13 Nov 2023 14:04:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7776,7 +7644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a5f4647-5de8-49e4-a09c-d2346ebca853
+      - c82d8f8b-7c71-4b9f-8ac4-8fc45e8f218e
     status: 200 OK
     code: 200
     duration: ""
@@ -7787,10 +7655,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7799,7 +7667,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:05 GMT
+      - Mon, 13 Nov 2023 14:04:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7809,7 +7677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fdef80a-6052-420f-9343-0b010df71dd2
+      - de3e5445-4030-415a-a376-722845db7291
     status: 200 OK
     code: 200
     duration: ""
@@ -7820,10 +7688,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7832,7 +7700,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:10 GMT
+      - Mon, 13 Nov 2023 14:04:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7842,7 +7710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 541d6d3b-6841-4467-aa43-43a490bbc027
+      - 01e69820-5ddb-4b47-9d34-ff387d3c3be3
     status: 200 OK
     code: 200
     duration: ""
@@ -7853,10 +7721,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7865,7 +7733,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:15 GMT
+      - Mon, 13 Nov 2023 14:04:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7875,7 +7743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49d7dcf6-8640-4224-9e45-d1c3d9a0bb21
+      - 3eadefee-b0ec-4249-aed1-69acf9ed4e06
     status: 200 OK
     code: 200
     duration: ""
@@ -7886,10 +7754,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7898,7 +7766,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:20 GMT
+      - Mon, 13 Nov 2023 14:04:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7908,7 +7776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eeef5e5b-8466-43fb-92e0-1e84904fc0e9
+      - f31caf94-554a-4ac4-9f28-06c6f89942f8
     status: 200 OK
     code: 200
     duration: ""
@@ -7919,10 +7787,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7931,7 +7799,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:25 GMT
+      - Mon, 13 Nov 2023 14:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7941,7 +7809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 682815b9-925c-4953-9ca4-67218563c193
+      - 749a3195-db5c-4034-9a30-96d33359f3c7
     status: 200 OK
     code: 200
     duration: ""
@@ -7952,10 +7820,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7964,7 +7832,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:30 GMT
+      - Mon, 13 Nov 2023 14:04:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7974,7 +7842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02e1ba32-a8ca-46f3-bebd-96cbb10b668d
+      - 879c2a18-221e-44de-80ea-4024a5a39748
     status: 200 OK
     code: 200
     duration: ""
@@ -7985,10 +7853,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -7997,7 +7865,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:35 GMT
+      - Mon, 13 Nov 2023 14:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8007,7 +7875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24e65575-b614-42c2-a415-fe992fd3bc55
+      - 5c28de70-40e3-4387-bd9c-e34699651e75
     status: 200 OK
     code: 200
     duration: ""
@@ -8018,10 +7886,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -8030,7 +7898,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:40 GMT
+      - Mon, 13 Nov 2023 14:05:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8040,7 +7908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11777550-d8ad-46b9-8056-375297e327cc
+      - 24a5bfdb-1821-4aab-a90a-50c93079072f
     status: 200 OK
     code: 200
     duration: ""
@@ -8051,10 +7919,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -8063,7 +7931,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:45 GMT
+      - Mon, 13 Nov 2023 14:05:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8073,7 +7941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b14f834c-4008-4bd2-b607-5b00950763a1
+      - bbef2b9d-6ae9-4637-82fb-716e8d1e178d
     status: 200 OK
     code: 200
     duration: ""
@@ -8084,10 +7952,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -8096,7 +7964,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:50 GMT
+      - Mon, 13 Nov 2023 14:05:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8106,7 +7974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea231b09-ce11-4e20-9e91-ccca41758a97
+      - ce977f05-5d1a-4411-825d-564574b6183b
     status: 200 OK
     code: 200
     duration: ""
@@ -8117,10 +7985,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:36:08.723243Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "673"
@@ -8129,7 +7997,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:38:55 GMT
+      - Mon, 13 Nov 2023 14:05:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8139,7 +8007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 793b25fb-174d-471f-85f1-40152d2d65b0
+      - a1565040-efe7-4e9a-968b-5d09e4dad64e
     status: 200 OK
     code: 200
     duration: ""
@@ -8150,10 +8018,868 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:39:00.469752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74fd75cf-0ef0-4b2d-a67a-30f2b56e2aa6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ad88c3b0-1cd1-4f41-ab2c-49221a6ba0d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e4c49b44-cf42-4ff4-a6d0-ea5ce4a1c770
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7257d987-86d2-47b9-99d4-ad1735afc564
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 97a4eed3-917e-4da9-95fb-b39dc84704a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 070b7001-a689-4ba6-8cde-8cdca932febb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - edc664ca-d83f-4438-b2e2-2ee698474852
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:05:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4f85d47-5c8c-433c-af2c-9799505d7c59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 812b70ae-45a8-4ce5-9269-58dcc46b672e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b60d4130-4326-4dc8-9fd8-331e0b5ccc8d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a8788fb9-f6b4-4eae-ad74-fceb64898c52
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06c5117f-b16f-47c8-a368-4c3add5b8dc2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 064f730e-d076-44fe-b1f4-8d0f6f03fa50
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 07f8770a-b5ef-4272-bc99-0aa3aa418b7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d652f113-be0b-4021-a6ff-b01dae20cb97
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 68cdd8a4-c7bf-429e-8ee5-df9a0a5b7013
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 50cd7cd1-d944-466e-a513-2c545f76ae34
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74315021-a4c2-4b03-a3a7-99ca19f3d5f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfa2e9a5-b5af-4b05-9fa1-42b869f57c68
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b83ff0a0-567d-4ef3-8531-2d6b032a40d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a47e452-e7d2-40cf-815e-4eb74df3a342
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6fcf57ed-1842-4dd9-8d23-941a3120544a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2f72866f-431a-4282-828a-a7a41cec3917
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ff7dc32-e323-41f8-b316-a7784808ef13
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 138f7701-7b4b-4348-81a2-6f784b10edc8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:02:27.699782Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "673"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1744b8d0-8978-4f2b-9b4c-1ea4e7b876a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:07:29.088260Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "671"
@@ -8162,7 +8888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8172,7 +8898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4380cc59-0497-4aad-b1a4-9916af66dc0d
+      - 20fa8ef3-c515-493c-b9ed-5d7c7413833f
     status: 200 OK
     code: 200
     duration: ""
@@ -8183,10 +8909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:39:00.469752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:07:29.088260Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "671"
@@ -8195,7 +8921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8205,7 +8931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc094642-0fc7-408c-af25-4b61a5bb1c13
+      - 4ce5cad1-fcd0-4681-9589-8349786fcea7
     status: 200 OK
     code: 200
     duration: ""
@@ -8216,10 +8942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/nodes?order_by=created_at_asc&page=1&pool_id=0dcdff54-d609-4715-9d67-ec96bc263841&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5/nodes?order_by=created_at_asc&page=1&pool_id=548fbd02-d615-4a4a-b949-afcd80e2095a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-10T13:36:09.259332Z","error_message":null,"id":"805f244b-2f21-429d-bd92-de1a17a75f48","name":"scw-test-pool-placeme-test-pool-placeme-805f24","pool_id":"0dcdff54-d609-4715-9d67-ec96bc263841","provider_id":"scaleway://instance/nl-ams-1/062e03c2-60a7-4b65-9eca-c189b2964d8f","public_ip_v4":"51.15.60.254","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:39:00.456279Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-13T14:04:58.407357Z","error_message":null,"id":"7d8e7d14-48e8-422a-9650-f915682a8c8a","name":"scw-test-pool-placeme-test-pool-placeme-7d8e7d","pool_id":"548fbd02-d615-4a4a-b949-afcd80e2095a","provider_id":"scaleway://instance/nl-ams-1/08842a06-1018-4284-9746-0af02ed7edfd","public_ip_v4":"51.15.60.254","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:07:29.072452Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "620"
@@ -8228,7 +8954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8238,7 +8964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7cfe261-848f-43ec-9d9c-d1e07b42bf01
+      - f42f3a1d-1018-462f-b36b-0e77b730190a
     status: 200 OK
     code: 200
     duration: ""
@@ -8249,10 +8975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:02:22.986688Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -8261,7 +8987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8271,7 +8997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc6c843e-58f0-429e-942d-761ae925a8c4
+      - ead21760-3832-40e8-bca7-d6bd9449896c
     status: 200 OK
     code: 200
     duration: ""
@@ -8282,10 +9008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:39:00.469752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:07:29.088260Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "671"
@@ -8294,7 +9020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8304,7 +9030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d95aa416-1f13-4520-8493-d9d700d08b66
+      - 30f4ad0a-ec85-4d69-a765-ccd74d7148e6
     status: 200 OK
     code: 200
     duration: ""
@@ -8315,10 +9041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:36:06.187965Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:02:22.986688Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -8327,7 +9053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8337,7 +9063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce212e4e-6abd-4f48-8949-8886c0e94ce9
+      - 7828a962-8e27-4dc2-95bb-3da81c6938fc
     status: 200 OK
     code: 200
     duration: ""
@@ -8348,10 +9074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/6d767778-3717-4398-83d6-1afdf4935a54
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/5950daa2-7826-4eab-b245-35eb5dd2aba8
     method: GET
   response:
-    body: '{"placement_group":{"id":"6d767778-3717-4398-83d6-1afdf4935a54","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"placement_group":{"id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -8360,7 +9086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8370,7 +9096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8c2bbc4-c1de-46b2-98ac-6867f72d419d
+      - c233ce21-bd0e-4990-978c-791bf99b7c40
     status: 200 OK
     code: 200
     duration: ""
@@ -8381,10 +9107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRYcFJNVTlHYjFoRVZFMTZUVlJGZDA5VVJYcE5lbEV4VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbTVQQ20xelZ6WkpTelZCZFdKVk1UWmlTbFJsUm5aeWNETlpjekZQSzI5UVNuQlJWR0pNYWtnNUsxcHpZMFJqYVVwaGVqY3JTV1pGTXpoUlNuRkRVR0kzVW1RS0wxazVaazFOT0RsdFFVeFlORTR3VVhsNFN6SnpaVVZtY1doSlVETkpOWFJEVUU5bllVNTFaMjExUmpadVkzcFVSSE5OY1dkc1R5OHJWRk4yZEdsNGR3cHBhaTlEZVhVd01IZzFObmxRV0dweGRtSjBaVmxvU2t4VldYSllSVWxtZEZCU01qWXpTemd3TVU1RlZuWnFhV0Y2ZFZOclN6QjNjM2hQWld0b2RYVnhDbFowT1ROUFkwaExha1pzTUdsWllYWnZOREE0YzFJek1XNUtTa1YyU1RSUWRWWndRMFI0UW5CclVIQjJSbnAwTlRkUk5YcHlUR050V1U1MVV6VlFTWElLZGtGNmVHODVVaXRYWmpoTGFHeDRWRWc1YUdGbkswNXdXWEl3VURaVk0wOVBaRXMxVkV4MFZWTlpSRmRtV2psSlRIbHhiRzVtVTJOS1ZHVkhNalZ6YkFwS2Qxb3djVUZDYUdkT2NGQkphSEpzUkVJNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2VWbzVPVFZaUmxKYVRHcEplbXBrUWk4MVJqTTNlWGRsYUhSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1JsQjVUMFpZZWtKaFdHTjNkWG9yYWxKUWVtY3lORTFYY1UxVU5VaDZiRVYxUjJSaFkwcHdjV1ZTVG5ScWRqUmpUQXA0YWtkckswUndNSGRRVm04Mk9UTktNelE1Wmxab2MwczVXRnBJVVZadmFHeG1ia2s1V1ROVGR6QktWMGRLVjJGeWJrTjVWbFpOTW14Uk5uaFRPWEpvQ2t0UlZHcG5VVTB4VmpoT2QyMXlUR2xrT1dWck5uazRSV3REZUVVNFpraHVia2RGZVRGcmRqZDNVbTFSVkRnNE5ETlJNbWxMYVZnd1prVnJSV3NyY1UwS2VUaE1XbkJSVEVGVWFGVlBaRkU0VjJKTWEwdG9ORGhNV25kcVpISmhMMHgwUlV0UVJ6TnJVME4xTWxRclZFbDNNblk1WVZaS05qRm9VVWxJZFhkbWNncGxUbGN4VW01blZsVTBPVXRXUm5SM1J6QktabUZhUW5sWmFUY3JTMjFtTTJSNFlteGpVelJtU1U5dlVUbFZUakpSVFRCT1YxcG1XRXhRUm5SRFpHZGFDbkYxYjI5RlNYTndNVkZ3Ym1kRlMyeDNiWHBoYzBzNFRtc3hkV1J4ZUZOeWVFWkJTUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTNhYWM4ZmItZDY1Ni00ODY0LWI1MGItNmU5YzIxMDhlMTBkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBhcFBnS1lnblRoZTgyeGEyQjRqR0pTSzNBYVdza2JkUE1aV212bUd4WVcxNGM5VWd1RVRkQjh4Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtVd1RVUkZlRTFzYjFoRVZFMTZUVlJGZUUxcVJUQk5SRVY0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVEJqQ25GVFlYZFlVMWszU25ObWNIWkxURTFGYURCSlptdFhRM1ppUWs1U1RHaEVVM05QWW5rMk1taE5OblJtTmtsSlZrdDNOMGhpUzBwWU5rMWtPWFJ3TmpFS1pVbEZLMHN6ZFZscFFrWmxibkZOVUVoR1MwOU5aaXRyVjNOMU1HSk1WRVF6VEN0TVF6UldRVTlXTkVjcloyRmhZVGxtVERndlJEWm5XbEZTZW5sa01RcHNVbmRxSzJ4dGJHZHJVVVJXYTJzNFFWUTVWVkpzWkRFcmNHZzVWMHBFZFZCTlJsQmtSVEpyWjJnMVdFd3ZRMU5wU2xSc1VqZHdSRzl2ZFZsVE1tSXpDbE5zZVRSSE0wZzBha2xhV0VKVVRteHNia3hKVG10WVZIQTFNM1p2UnpKWWJqQTFRelF3U1dkcWEwWjNiRGRRTW5JNVlYTkZNRWhtV205a01qQjJieXNLU25WUFVHbHhla0l5WVhCdVVUUTFVeXRzTUZCU1dXY3ZRMWgyTmpSTFVHWTNaVVp5V1ZjNU1VcDRhREJ0ZUhGbloyRktTVTlTUVVOT01YSkxRWE4zYkFwQmFITlFSbEEwV1ROS1VrbzRTbU5rYzFvd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT2VrcDVVMWt6U3k5UU1IUXZRVFExYWtoMldHUjVNVFo1ZGsxTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ05VRnlkMEZYT0ZscE5GVjBOak5rYTJScE1rcEZLMG8zZFN0cGIwRlNhSEZRTTNoblpXZDJTbHBUVVVoQlRGcFhiZ280VWpCTmF5dHhhVEoyVWpGdlVtNTFXbnBxT1hoRVlXOUthbUYwZFRKUU1sSmhkRkpoTjBKcFIyTjNOQ3RqYjJKNFZFdzJUWFZhU2xjM1dtaFZSa0V2Q2tWUWJreHJVR2hUWjA4dmFTOXlTVzFuYTFacWNXNWlhRFY0VERVd1IzRjJOVFEyUVVsM1VHRTVSekJGY1dGUVNHSkJhME5LU2tOT1lsQkZPVUo0UmtVS1pFRjFXVGhPWXpSdWNVMVVOek5sV21ab05VTmFOR3QwTWtrMVUya3daSE5pUzJkb1NIVm9ibGR6Y2sxS00zcGthalUzU3pRd1prdHdWM1ZqYUcxcE13cDRlWGt3VjJSdWJXcFNNRFozYmtzeFNISjZhRmhUZG1kRFFYaFhWMjUxY1hSdmFraHRLMWxwVHprNGQzTnhWMGcxT0U1RldHUXZUalZIVFROck4wRmtDbTFRUVVadU1VSXJOVWRpWjNReE9IaFFUR3h3ZERKNlpYRlNSR1VyZFdONEswbDFkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMTk3NWVlZDEtM2YwMC00ODI0LThlZWItMDc5ZTg1MWEyMGE1LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBDSnpqUTZwd3BDZ0NOUHZtYjlQTHVNejBGRmthWmJyRnQ4S2FzN2lONEM5TWNDdXZHNmtuNUNTcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -8393,7 +9119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8403,7 +9129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9041f7e6-1fd7-4476-abae-2c96dc0944a0
+      - 099abf11-1098-4f8a-8cd6-e3d31dca72a4
     status: 200 OK
     code: 200
     duration: ""
@@ -8414,10 +9140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:39:00.469752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:07:29.088260Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "671"
@@ -8426,7 +9152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:01 GMT
+      - Mon, 13 Nov 2023 14:07:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8436,7 +9162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c179702-4ac0-4bd8-9d58-2965b6e0821f
+      - 4146831f-4dbb-4792-ba23-daae7bddd3fe
     status: 200 OK
     code: 200
     duration: ""
@@ -8447,10 +9173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d/nodes?order_by=created_at_asc&page=1&pool_id=0dcdff54-d609-4715-9d67-ec96bc263841&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5/nodes?order_by=created_at_asc&page=1&pool_id=548fbd02-d615-4a4a-b949-afcd80e2095a&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-10T13:36:09.259332Z","error_message":null,"id":"805f244b-2f21-429d-bd92-de1a17a75f48","name":"scw-test-pool-placeme-test-pool-placeme-805f24","pool_id":"0dcdff54-d609-4715-9d67-ec96bc263841","provider_id":"scaleway://instance/nl-ams-1/062e03c2-60a7-4b65-9eca-c189b2964d8f","public_ip_v4":"51.15.60.254","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:39:00.456279Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-13T14:04:58.407357Z","error_message":null,"id":"7d8e7d14-48e8-422a-9650-f915682a8c8a","name":"scw-test-pool-placeme-test-pool-placeme-7d8e7d","pool_id":"548fbd02-d615-4a4a-b949-afcd80e2095a","provider_id":"scaleway://instance/nl-ams-1/08842a06-1018-4284-9746-0af02ed7edfd","public_ip_v4":"51.15.60.254","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:07:29.072452Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "620"
@@ -8459,7 +9185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:02 GMT
+      - Mon, 13 Nov 2023 14:07:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8469,7 +9195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b164311c-275b-4296-9292-1a89c76ab265
+      - 995dde04-eed0-4a0a-930b-9aff3d7fa1a3
     status: 200 OK
     code: 200
     duration: ""
@@ -8480,10 +9206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838546593Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:07:34.097731803Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "677"
@@ -8492,7 +9218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:02 GMT
+      - Mon, 13 Nov 2023 14:07:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8502,7 +9228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 477875cf-1380-4e18-b840-e8ebc4ee936c
+      - f6063126-9c00-4b93-8626-23445bc2f441
     status: 200 OK
     code: 200
     duration: ""
@@ -8513,10 +9239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838547Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:07:34.097732Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "674"
@@ -8525,7 +9251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:02 GMT
+      - Mon, 13 Nov 2023 14:07:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8535,7 +9261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22f63d8e-6a1c-49de-87ad-57a1c4cbbe82
+      - abe1bd11-fa0a-4e91-b0da-0445810d54d4
     status: 200 OK
     code: 200
     duration: ""
@@ -8546,10 +9272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838547Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:07:34.097732Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "674"
@@ -8558,7 +9284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:07 GMT
+      - Mon, 13 Nov 2023 14:07:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8568,7 +9294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98dcc426-3bc5-474e-a1b8-50f19594432d
+      - 78a56628-1cbb-48c8-92e2-291db81e1c58
     status: 200 OK
     code: 200
     duration: ""
@@ -8579,10 +9305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838547Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:07:34.097732Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "674"
@@ -8591,7 +9317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:13 GMT
+      - Mon, 13 Nov 2023 14:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8601,7 +9327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15143f18-6c7e-4878-b699-71cb3ff24597
+      - 080cf58b-1acc-49cb-9459-70e00b59583b
     status: 200 OK
     code: 200
     duration: ""
@@ -8612,10 +9338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","container_runtime":"containerd","created_at":"2023-11-10T13:36:08.711401Z","id":"0dcdff54-d609-4715-9d67-ec96bc263841","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"6d767778-3717-4398-83d6-1afdf4935a54","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:39:02.838547Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:07:34.097732Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "674"
@@ -8624,7 +9350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:18 GMT
+      - Mon, 13 Nov 2023 14:07:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8634,7 +9360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1330a03-caec-4dc1-a6c0-e13b13f90dc3
+      - 2fca180f-504d-4ae3-809f-e8c1997df18b
     status: 200 OK
     code: 200
     duration: ""
@@ -8645,10 +9371,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"0dcdff54-d609-4715-9d67-ec96bc263841","type":"not_found"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:07:34.097732Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "674"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7168ba55-581f-4741-a6d8-beb19b6f3582
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:07:34.097732Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "674"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df5962cd-8eb5-4688-bb3a-cf072b8cff1a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","container_runtime":"containerd","created_at":"2023-11-13T14:02:27.678801Z","id":"548fbd02-d615-4a4a-b949-afcd80e2095a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"5950daa2-7826-4eab-b245-35eb5dd2aba8","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:07:34.097732Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "674"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77f370e6-d822-430a-bac2-33066be16a12
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"548fbd02-d615-4a4a-b949-afcd80e2095a","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -8657,7 +9482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:23 GMT
+      - Mon, 13 Nov 2023 14:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8667,7 +9492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3349aec5-5c79-419b-8c6d-05a055a2bef9
+      - fc787685-9ac1-4c2f-ad75-e90392473b22
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8678,10 +9503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269282Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:08:09.550142800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1488"
@@ -8690,7 +9515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:23 GMT
+      - Mon, 13 Nov 2023 14:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8700,7 +9525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5c54e23-b6a1-4582-b0ae-9ca5f90aa491
+      - 6256773e-0d3a-4cc7-97b7-e65f2bbcfa8f
     status: 200 OK
     code: 200
     duration: ""
@@ -8711,15 +9536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/6d767778-3717-4398-83d6-1afdf4935a54
-    method: DELETE
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
+    method: GET
   response:
-    body: ""
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:08:09.550143Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
+      Content-Length:
+      - "1485"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:23 GMT
+      - Mon, 13 Nov 2023 14:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8729,7 +9558,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48e5aa5f-241c-4631-8609-b2e8b749d221
+      - 76bf2ca3-49a6-4a3b-8256-34304fcb8f3b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/5950daa2-7826-4eab-b245-35eb5dd2aba8
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Mon, 13 Nov 2023 14:08:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9b8fd045-6b3a-4511-8ef5-3c9eb97d58b0
     status: 204 No Content
     code: 204
     duration: ""
@@ -8740,10 +9598,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1975eed1-3f00-4824-8eeb-079e851a20a5.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:01:11.288522Z","created_at":"2023-11-13T14:01:11.288522Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1975eed1-3f00-4824-8eeb-079e851a20a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1975eed1-3f00-4824-8eeb-079e851a20a5","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-13T14:08:09.550143Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -8752,7 +9610,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:23 GMT
+      - Mon, 13 Nov 2023 14:08:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8762,7 +9620,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bf42dd7-0fbe-41c4-9690-c59b7b9a4ff9
+      - 484ac430-4266-42a6-bc9a-9668bf37b5cf
     status: 200 OK
     code: 200
     duration: ""
@@ -8773,208 +9631,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1485"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:39:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19be9516-9f0c-448e-93ef-850789569be4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1485"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:39:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4a360e14-f80a-4bf8-90c7-8f07d420eebf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1485"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:39:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9be2a5c5-79c7-4fb5-8db7-16eb7859e59b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1485"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:39:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 49915e88-61e0-46b7-8830-00b533c0276c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1485"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:39:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a04f74b1-ff97-4dcf-85fa-c3061437c9d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a3aac8fb-d656-4864-b50b-6e9c2108e10d.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:34:57.299917Z","created_at":"2023-11-10T13:34:57.299917Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a3aac8fb-d656-4864-b50b-6e9c2108e10d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-10T13:39:23.157269Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1485"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:39:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 68f75d85-b5bb-4ee1-85e3-1cab803bd965
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -8983,7 +9643,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:58 GMT
+      - Mon, 13 Nov 2023 14:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8993,7 +9653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 304d31e6-27de-4fa5-a864-678542eb24ec
+      - 3d5f8ca2-f2b8-4114-b777-3c2d1eb32e7a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -9004,43 +9664,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a3aac8fb-d656-4864-b50b-6e9c2108e10d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/548fbd02-d615-4a4a-b949-afcd80e2095a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a3aac8fb-d656-4864-b50b-6e9c2108e10d","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:39:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cfe19342-7d85-474e-8247-fcb2efd1a963
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0dcdff54-d609-4715-9d67-ec96bc263841
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"0dcdff54-d609-4715-9d67-ec96bc263841","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"548fbd02-d615-4a4a-b949-afcd80e2095a","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -9049,7 +9676,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:39:58 GMT
+      - Mon, 13 Nov 2023 14:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9059,7 +9686,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90a71784-1190-48c3-ac99-f82f8ca6404e
+      - 075e63ce-a9ed-4f76-be7f-a1d82b406e56
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1975eed1-3f00-4824-8eeb-079e851a20a5
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1975eed1-3f00-4824-8eeb-079e851a20a5","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 23610f0d-9b43-4256-8a44-ea975449689d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-public-ip-disabled.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-public-ip-disabled.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acd5ee4e-0ff3-4afe-9662-60d3ae11da63
+      - 2bfdde8f-6196-4677-8871-bfe099b4e1a6
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:29.268912Z","dhcp_enabled":true,"id":"201d62ac-4232-462f-b8a8-e5767d25d71e","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:29.268912Z","id":"3c4b55f2-5c0a-4da2-834a-cbd20cdb7556","subnet":"172.16.60.0/22","updated_at":"2023-11-13T13:52:29.268912Z"},{"created_at":"2023-11-13T13:52:29.268912Z","id":"d1260a3d-1dff-478b-8f0b-c4be2e6dc3ec","subnet":"fd63:256c:45f7:dedd::/64","updated_at":"2023-11-13T13:52:29.268912Z"}],"tags":[],"updated_at":"2023-11-13T13:52:29.268912Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "719"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:41 GMT
+      - Mon, 13 Nov 2023 13:52:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28165b32-a9d4-4348-aa44-c4d3638c624d
+      - a4da160d-e9f7-448e-b102-fa2016850338
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201d62ac-4232-462f-b8a8-e5767d25d71e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:29.268912Z","dhcp_enabled":true,"id":"201d62ac-4232-462f-b8a8-e5767d25d71e","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:29.268912Z","id":"3c4b55f2-5c0a-4da2-834a-cbd20cdb7556","subnet":"172.16.60.0/22","updated_at":"2023-11-13T13:52:29.268912Z"},{"created_at":"2023-11-13T13:52:29.268912Z","id":"d1260a3d-1dff-478b-8f0b-c4be2e6dc3ec","subnet":"fd63:256c:45f7:dedd::/64","updated_at":"2023-11-13T13:52:29.268912Z"}],"tags":[],"updated_at":"2023-11-13T13:52:29.268912Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "719"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:41 GMT
+      - Mon, 13 Nov 2023 13:52:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e978506e-7cab-4cd2-95c2-702343f13abf
+      - 72993812-ff3c-488a-a86e-00a16c7cde3b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-k8s-public-ip","description":"","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-k8s-public-ip","description":"","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361150Z","created_at":"2023-11-10T13:17:42.433361150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:42.486698803Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691065904Z","created_at":"2023-11-13T13:52:34.691065904Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:52:34.708783492Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:42 GMT
+      - Mon, 13 Nov 2023 13:52:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b63151c0-2f3b-4262-a1f1-3184263f6d5b
+      - 7c27bc03-09d8-48d6-9dae-fac20a9037d4
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:42.486699Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:52:34.708783Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:42 GMT
+      - Mon, 13 Nov 2023 13:52:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eb0ec7c-08ab-4957-99a1-42f2e783ff68
+      - 36f3dee6-c09e-4ef4-bb2c-928ed16f6696
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:44.329052Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:52:34.708783Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1503"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:52:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7f90e4af-bdb3-46e5-bafb-00f2ff8ebcb0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:52:41.893066Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -193,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:47 GMT
+      - Mon, 13 Nov 2023 13:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0420261-ccda-4617-a3f8-079ab646a780
+      - f686bac3-f040-4b2c-bdc0-67e406a693dc
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:44.329052Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:52:41.893066Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -226,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:47 GMT
+      - Mon, 13 Nov 2023 13:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2606e37-8996-4696-a7c9-e92d74a67852
+      - b4c2e1ab-7d00-4963-9cd8-39a84adfb345
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTh4Q2t0NVUyMDFNa1phVTJwT1UxbEVTWFZ1WlVNeGFFWmxUVzlvVlROQlkxVk5VRTF4WW5aUVlYWTNaMm8xYm05TFpHcEhOMjFHVGpkWWRqbHRWbTV2VWpFS05pc3hiSFo2VEVkVk5YZFhTM2hPZHpJeGRYaDVNSEp0YzJSTGEzZEZZak01Y21wTlEwOXpPVWxuTDBac05EQklTR2RTVlRjMlUyMUphbFZsZVN0c1ZncEVlamhYZUZVeGRVd3ZkVEE0TjBFdlNrNWhSamR3TUhseWNEbE5WWGhPVFZaQ2FYSllVWGR2VVZGVmJ6WnNXalUxV1RWdGJURlFWblEyVm5wMlIwWm5DbVpYT1hJeVdWVlRZamR0Y21GS2MwdE1WVWhHU2pJcmREQXhTMGR0UkVNMU9WTTRhVVZxT0dOblRtTlVaa2xrZDFOR1duVmpObmRYT1ZSR1pHZ3hjMllLYlRZdk1VRXdOVXMxWm1sWWQxRnJVWGR5VkRkak4xTnhTa1Z1TTFKR2FFWmtOMlIyVDJGb1Nta3JlR3A2VUVrMFNWcEVWRWRYVW1wbFR6bEhMMlY0Tndwak0xWkpMelZsZUZObE4yUTFWR0ZzVXpNNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlNGUm9WQzlQWW1oclQxQjZSRlI0V0ZFeWJqRjNWVFJ6UkhaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZVOWhkVWh0WW5OeE5XaHFWSEZGVkZaV2RtNVRTbWhWWVhCWldqZHllbFpoY1U0d2QxcHZlbHBsWmxadmIwUnZTZ3BJUzJ0dFdqWlBhbUZQYkRWemFrcEpaMHRWYkZaRWNIRnVSMW8xV1dFd2RUWldOWGMwYXl0eGMySndWV1pzY1hSdFIwNHpXR1pyUzNKM1V6VXJaV1I1Q210M2QwRnZNa1pGY25oU00zUnlXRVl3WTJ3MWNHaEtPVTVzVm1KeFNVb3hPVlJMZWtWTVR6RmpXamc1TkhWT1UzSmljVWQ2YjFCdWRGZDZhMEpHU2pjS1FsQkdVM0p1VEV0aVZWSTJUVVJyVTJkNVExVlBiMWRyVEhVNU1HeG1VVXhIZW5oS05FMTJSbGNyZDJSdFYxaHlOSHB4VDI1aE9ETkdjRmhsYW1GbmN3cDJla2wzYTFKUWN6Qm5PVXhRU200dlRrOTBlR3hCVldkV1ZtWk5hQ3RsV0hGRE5sQnRSM0k1VkROTWNrRndTRFJ5U0hVME0wbG5UVGRVT1VwMWVHbHZDazlZYm5KUllXdG5RVlpXU25vemNHUjVObkJ5ZUVReFFtRlZhVzk2WWxGNlZsTjZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNzQwMWRhNWUtMDk3My00Y2I2LTg0OGItZmZkM2Q4MmI3MDg4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoUEJVVEs3M0ZWaHQ2bEY2RFhodFp2aTZ2REU0Z2xtUjk2dndUbW44SFlpRm94ZWZNbUVrWGcycw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkpNRTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRWt3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE5QQ214VWF6WllNMVZNU0daVmEzUmplWFJCYlM5SmJIQnBSMGRRYjI5b1lsUlhjekptY3pBeWMxaHVWRTUzTWtGWFVXSktRbWR3VGtGcVYyaGtXVkZvU1djS1FUVk5OV3AzVDFabU5rZFZWVFo0YTBoVFozRkxaVEZRV0hSc1NYVkhUekF2YlhGaFJWUk9RMFpoV0dKV2RsRkxSa0p3U1U1dVJ6VjZUbkJsYm1VeU9BbzVUR1pCV0dGYVYwdHpiVE5PY0VKTUwxcHJhRkpITW5OSk1YQnlVVmxSVFcwMldVbHFSRVZ2U1U1S2VtTTFjamxWVEdGSWVqbFJRbk0wTTFobVdFVnNDamxTS3pabFZWVnpTa0YyWkUxTVQyVTJlamd4TVRVdmFrWTFiMFY1ZWtNMVkwOXNSR2RKUjJNMGJraGpSVUl6WkVsa04waGpWbFJDUjNOTlRETlpXVTRLYVdjeVFrWnFjRFp4VnpONVlsbDJSV3hHYWpWeGQyVXhUVXN4WW1KR056YzBVekJRVWtsWk1HMTVaM0JWVWpOeFdYUkxiRUpXU2tKRk1qQXpVRTlUYWdwdk9FRnBkWFpaVlhVdmEzUXpaekZyT0hkalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1ZFNVhjMDA0TXpKNmRGQXlMMWhYVjJKdWEzbE1WRzFHYmk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRE1TdFlURkI0YVROR1FrZEZhWGhCVkdJNVVreEVNRU54TUZSdkt6ZFhVRlpoUkdKQ05reHVSblpFZFhSck1rNUxPUXB2UWs4MVlVUkhjbEZZVDNCSU0wUnBSbU5LY0hGaUt6Sm1WbmRTVlRod2MwRnhlakJUWlVvMVUyTXlXVWczUW5OMlNqWlBaQ3RMV0ZSaFdFb3ZaRWQzQ2xsSlZqRkhUV0kzTW0xRVRubGxhWEJaUkhFMmJuWTJkVE5LTUhkNGRXWXlUSEZPZWxWMVVUVjFOazVwYUZGbGIwazRiMkozUVdwTFVYSnRjelV4ZEVZS2MwZ3lNVzVZS3psYVEybExXQ3RZWjJ4WE0zTkRja3BrT1RsdlpGWkVhelZIVGpnclozSnVha3hSYlZkc2NISTFhbGxYU1d4c1dDOWFTekJSYjNWb0x3cFFOMDEyU1U1WU1YTkhLekZCTVhsM2MzaHZZa1JNV2taNFJ6aHdiSEZ4VTBGb1Jsa3pVMWRpTmxKUFFXTk5XVUpWVGtJeU5XRnhabFpvT0VaVEswbEZDa1EwWm10dlNIVnRhQzlUUTFBNU1qZGhiSGhwWlRORU4yVjNkMmxWUkRCU1RpdFJZd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTI1MzcwNGQtOTkzYy00MTkzLTgwMjItMDdhNzExZjBmMDE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFNG9CRVI4Z1dSOUtaNjFmdWRrYXRadzV1bTVsOFRBTlRTU29ibk03SFFpMnlGYWN1VVZuSHNjNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -259,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:48 GMT
+      - Mon, 13 Nov 2023 13:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccd96a6e-4f84-4921-aa4b-32a038a9922a
+      - 1a16c065-f519-419b-8110-f48e7e11cc35
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +313,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:17:44.329052Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:52:41.893066Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -292,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:48 GMT
+      - Mon, 13 Nov 2023 13:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9619d8f-3f00-4100-a125-c7a080158437
+      - dea99413-56cc-4d24-86f6-8bafda6f98c7
     status: 200 OK
     code: 200
     duration: ""
@@ -315,10 +348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512107808Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388056649Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "632"
@@ -327,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:48 GMT
+      - Mon, 13 Nov 2023 13:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a128f68f-cda9-450d-a1b9-a6e60253be9d
+      - f40bd8d9-2d67-4a2e-a294-636832328570
     status: 200 OK
     code: 200
     duration: ""
@@ -348,10 +381,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -360,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:49 GMT
+      - Mon, 13 Nov 2023 13:52:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23949030-a16d-4bbb-bff8-a9a520516f94
+      - 93e1f739-f5e9-4250-bdc0-352a326a6f0e
     status: 200 OK
     code: 200
     duration: ""
@@ -381,10 +414,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -393,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:54 GMT
+      - Mon, 13 Nov 2023 13:52:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 897c5862-0b53-4ffe-8fdf-bd03d87cb85c
+      - db5e7099-2080-494c-8db8-a457649f107b
     status: 200 OK
     code: 200
     duration: ""
@@ -414,10 +447,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -426,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:59 GMT
+      - Mon, 13 Nov 2023 13:52:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35f96cab-cc20-4564-aec6-81b6e80c4dea
+      - 133c88fb-86e0-4286-b325-5dd93ce87944
     status: 200 OK
     code: 200
     duration: ""
@@ -447,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -459,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:04 GMT
+      - Mon, 13 Nov 2023 13:53:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46d1f55c-7e70-45f3-a205-5891f3dd6495
+      - 809c2784-92d0-4d28-81b6-433fcdb24069
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -492,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:09 GMT
+      - Mon, 13 Nov 2023 13:53:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6735d5a7-a6fd-45fd-9b30-cbbb0b248596
+      - 26f72568-94e2-4c97-9b71-b0acc85f1f25
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -525,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:14 GMT
+      - Mon, 13 Nov 2023 13:53:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 023985f0-ae20-4ea4-bd36-dd7c550d25bd
+      - d30ad943-0b1c-4694-b1de-dd32f24eef2b
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -558,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:19 GMT
+      - Mon, 13 Nov 2023 13:53:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1ccc2e1-47c7-4571-a402-9e8bfdd8eb01
+      - c3835912-8a83-4910-bbb2-5f96f86b1708
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -591,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:24 GMT
+      - Mon, 13 Nov 2023 13:53:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4d4df98-0bd1-4057-b84b-20b2a31886ff
+      - 51b6fc15-043a-409f-8b95-b009b29ade64
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -624,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:29 GMT
+      - Mon, 13 Nov 2023 13:53:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8d106e2-5a70-4312-b1d9-330d35052ced
+      - 65aa9204-2cce-4975-b3fc-fc1150381a5e
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -657,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:34 GMT
+      - Mon, 13 Nov 2023 13:53:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac2a0ad9-90e0-4cf8-8a63-e5a1d6cb60c2
+      - 613d11b1-8d6f-4b98-bc1c-182ac63ffea9
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -690,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:39 GMT
+      - Mon, 13 Nov 2023 13:53:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6320cd69-d736-4c56-b74e-f79e4f0a647e
+      - f990bdbd-45a8-4d60-835f-8e9c3128a90c
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -723,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:44 GMT
+      - Mon, 13 Nov 2023 13:53:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb3ee496-c538-45bd-b192-485777267b30
+      - 5cf990ff-ecfd-47cc-a772-b92484d7c686
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -756,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:49 GMT
+      - Mon, 13 Nov 2023 13:53:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f739e59d-96b1-44e2-85a1-011dae760dfb
+      - 2496feda-bec9-4c35-aa62-1f5ec8fd51e6
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -789,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:54 GMT
+      - Mon, 13 Nov 2023 13:53:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdbff53f-d923-4615-9244-8c9d079ee50e
+      - 6303e8b7-5efa-4e78-a702-8821b6b9bc58
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -822,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:59 GMT
+      - Mon, 13 Nov 2023 13:53:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae74532e-c01e-4775-8e69-204b104d7774
+      - 3fae9df9-fdf1-410e-aafd-afd341992658
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -855,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:05 GMT
+      - Mon, 13 Nov 2023 13:54:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34e724de-b012-4fdb-8bfe-01c3cff63f4e
+      - 6bed715d-67ec-4d0b-b7b0-b7a1e599b226
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -888,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:10 GMT
+      - Mon, 13 Nov 2023 13:54:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3a59f21-1ba1-45a1-a1b8-cd3be5a863b7
+      - 0182d7d0-9796-4c49-a5a9-a92a168f4f06
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -921,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:15 GMT
+      - Mon, 13 Nov 2023 13:54:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f80a5e2-eec1-41fd-8e41-5032d08ea557
+      - b4c37a4c-f71b-47d9-8a2a-c56d31633310
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -954,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:20 GMT
+      - Mon, 13 Nov 2023 13:54:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acc1382f-754b-40d7-9b6d-056d8b4784e9
+      - 3ec20ed7-7db7-492d-9148-4f146aba2261
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -987,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:25 GMT
+      - Mon, 13 Nov 2023 13:54:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10f930d0-cbf0-4895-addd-f109b4343778
+      - a34e0fd5-f352-4c04-8656-3ff2b55c7201
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1020,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:30 GMT
+      - Mon, 13 Nov 2023 13:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf9a9010-27f4-40e2-ba96-dffc96b4b205
+      - 859d4436-d7ed-4f7a-b9a9-9d1b2a9fa878
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1053,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:35 GMT
+      - Mon, 13 Nov 2023 13:54:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba62faec-06c6-4723-925e-14195aae5c5c
+      - 99dd27b6-6604-4040-a554-a46304d3be22
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1086,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:40 GMT
+      - Mon, 13 Nov 2023 13:54:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcccadd9-e6c1-4487-acaa-0d194d0e154d
+      - c17399bb-189c-4f7a-bb95-4ab0d5e77932
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1119,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:45 GMT
+      - Mon, 13 Nov 2023 13:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23825918-59d2-4fbd-bf82-9512c7acc717
+      - 7bbfd280-0ce2-4576-8418-9532d35c35b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1152,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:50 GMT
+      - Mon, 13 Nov 2023 13:54:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93fffdd1-394a-4908-ba05-9d6db83468d5
+      - 117da9fd-4a90-45ee-86ae-2b3306d65b89
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1185,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:55 GMT
+      - Mon, 13 Nov 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f90dea47-948a-4557-8afe-e48ba48b5018
+      - 67205dfa-f257-43de-b38c-414c78fa719a
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1218,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:00 GMT
+      - Mon, 13 Nov 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4aaff480-776c-470e-b270-b249146fb6a9
+      - 06b57706-5ef9-4223-876b-e550e6d4a96a
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1251,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:05 GMT
+      - Mon, 13 Nov 2023 13:55:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b854d8d8-351e-4d10-881a-60d878a9b947
+      - cb0ddd9b-2827-4e57-9143-638d7bd253d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1284,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:10 GMT
+      - Mon, 13 Nov 2023 13:55:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f34fc08-e9b9-4e29-9b69-0bbdffed8de3
+      - a84b67ad-3ba4-4a1c-96ed-8150cda543b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1317,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:15 GMT
+      - Mon, 13 Nov 2023 13:55:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b95efec0-3a53-41f9-ab03-cc7e75433d83
+      - 5a61ed53-92de-4232-8055-cd27f068363f
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1350,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:20 GMT
+      - Mon, 13 Nov 2023 13:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46a17917-201d-4b9f-a88e-829e9fac9d81
+      - 85545609-7287-4a03-8365-cc91b5e622d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1383,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:25 GMT
+      - Mon, 13 Nov 2023 13:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 148ff5bb-e596-4578-9ccc-1bdd13709f6a
+      - a255d051-2ff9-4386-a25d-59af0f7a438f
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1416,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:30 GMT
+      - Mon, 13 Nov 2023 13:55:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05aff1ae-33df-48ec-b34b-cf9fc608283b
+      - 1f1c4c28-0d61-4a7c-b78a-84189fd9916d
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1449,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:35 GMT
+      - Mon, 13 Nov 2023 13:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0e7216b-9149-4f12-8a98-e852cfbca6a4
+      - 2671428d-f456-469f-993e-851a19560e61
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1482,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:40 GMT
+      - Mon, 13 Nov 2023 13:55:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3af8f76-e139-478a-9a19-e51686db5086
+      - 385e8a3c-f5f1-42dd-af87-eed7883e50ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1515,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:46 GMT
+      - Mon, 13 Nov 2023 13:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91b79f3d-f985-408a-88b6-354917a8a5a2
+      - 24fd6c60-ebbb-44c7-8afe-3a7aef851c2d
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1548,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:51 GMT
+      - Mon, 13 Nov 2023 13:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3df13436-71ef-4059-bc48-b3d7121ef2ac
+      - ebedcc8e-d9ff-418d-b2c5-2400564ea434
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1581,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:56 GMT
+      - Mon, 13 Nov 2023 13:55:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f5fbd50-ab20-46b2-a2d4-74cb2dd734ef
+      - 79aeafc6-431b-4dd3-9874-7d8e0f5df913
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1614,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:01 GMT
+      - Mon, 13 Nov 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48ddc086-dd6d-4834-85fa-82420f575f49
+      - 3a63b0ae-8c3d-406a-81d3-69da9d4257da
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1647,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:06 GMT
+      - Mon, 13 Nov 2023 13:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba38b196-4e24-4b72-a85f-6b010dbdec80
+      - 9ce2a5a7-d111-474d-9687-e029e54914fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1680,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:11 GMT
+      - Mon, 13 Nov 2023 13:56:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20a28a0d-bcf7-41b3-b499-d117d4c02859
+      - 4a20bed8-3919-4f1c-87c9-407c582c6ae7
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1713,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:16 GMT
+      - Mon, 13 Nov 2023 13:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 145a55e8-6c7b-405e-a590-bdbd88d62e9c
+      - 873b157b-c378-43cf-8395-0b2108eb7d01
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1746,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:21 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe4f7ee2-6e48-4410-950b-f825c4f15820
+      - 0651a9d7-e035-436a-a710-a96697042702
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1779,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:26 GMT
+      - Mon, 13 Nov 2023 13:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44c6297c-e479-4161-b43d-fabf2b9e4fd8
+      - b4f961b6-213b-4a5b-a7f3-2e859e461f9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1812,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:31 GMT
+      - Mon, 13 Nov 2023 13:56:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7c9d958-1d72-4095-89e0-f01934a212d1
+      - 254d6c27-c973-423e-9247-c83a0fcaed97
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1845,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:36 GMT
+      - Mon, 13 Nov 2023 13:56:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed9dd236-3dce-46fe-bd9a-b26766b1bb96
+      - 6d317ae8-5de2-495d-82da-41db160c3035
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1878,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:41 GMT
+      - Mon, 13 Nov 2023 13:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ad22eeb-909f-4239-a4fa-1fe156c64bb4
+      - 1e45dea4-28b5-41a9-9ab1-c8d382c99280
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1911,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:46 GMT
+      - Mon, 13 Nov 2023 13:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5af3c997-ff10-4d20-bcc9-d407f3627305
+      - 487959a3-cc91-4ffc-933c-9643f240211d
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1944,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:51 GMT
+      - Mon, 13 Nov 2023 13:56:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 688230b2-b011-4284-98f7-26e5f7645f42
+      - 6aa6208e-4b2b-4517-9d33-7272c7020b86
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -1977,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:56 GMT
+      - Mon, 13 Nov 2023 13:56:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3da54714-b5fa-4927-bdae-4e31435d25f3
+      - 228a396d-2c21-48af-9f7f-a57dc8c86511
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +2031,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -2010,7 +2043,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:01 GMT
+      - Mon, 13 Nov 2023 13:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8197ad39-c47d-4ce0-93a0-44d095c4e066
+      - 8e24e94d-3883-468b-a252-2a9c2e7f17ca
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2064,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -2043,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:06 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 299e7ff5-f86c-4e01-bb8c-e0dea194947f
+      - 6ed7099e-edb2-48f9-abf6-974a489f7995
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,10 +2097,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -2076,7 +2109,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:11 GMT
+      - Mon, 13 Nov 2023 13:57:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d686bd2a-4020-42ee-b937-e230267d0861
+      - 48a4487f-2456-4575-ae09-ec500040000f
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,10 +2130,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -2109,7 +2142,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:16 GMT
+      - Mon, 13 Nov 2023 13:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5daa6758-6c2e-44b0-8b31-3be144985cf7
+      - f7ac1e26-963b-4bc2-97c2-7df5a07e833b
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,10 +2163,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -2142,7 +2175,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:21 GMT
+      - Mon, 13 Nov 2023 13:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ddbcb69-544c-45b4-94e0-7262ded5f98c
+      - beb697fe-c4e3-4090-ba36-6a4eb64d1cf8
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,10 +2196,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -2175,7 +2208,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:27 GMT
+      - Mon, 13 Nov 2023 13:57:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a500c4d-d767-4d62-84f0-0b786251b919
+      - 8a461686-773b-4759-9ac0-10ce494c2e63
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,10 +2229,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:48.512108Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -2208,7 +2241,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:32 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09fbfcf9-0344-446a-a2ce-5c393187c235
+      - 4ecd1653-0649-4f57-a2f1-1aadcb273b14
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,10 +2262,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3572e6ee-8d7c-4521-91d6-e0a7cbe00617
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff8e1844-63f6-4881-8d8a-00ddda10d450
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:45.388057Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5fe3e1b-a895-4554-9a95-bd47a3acf324
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:57:48.806091Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2241,7 +2373,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97a09eab-2633-4055-b31d-76210009fabf
+      - a4dfc46f-4f21-4762-b017-9862e1b18d0e
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,10 +2394,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:19:02.453998Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:54:22.539011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -2274,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4485591-5779-4e3f-80ab-c44f228eefc0
+      - 595d7af4-a093-4040-a211-5e8899be5523
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2427,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:57:48.806091Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2307,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2a9aad6-82e1-4d29-bcc5-76022cf43f24
+      - 2b583e10-3588-4881-adff-bd09039b794d
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=cde5d791-3c55-43cc-8e1e-6c72b195deef&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/nodes?order_by=created_at_asc&page=1&pool_id=c9e09286-7234-4cee-b778-8c329b183bb3&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:30.897296Z","error_message":null,"id":"9a91c1ff-74dc-41eb-8101-da96273fc049","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","pool_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","provider_id":"scaleway://instance/fr-par-1/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","public_ip_v4":"163.172.156.119","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:33.967615Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:54:46.754812Z","error_message":null,"id":"695f4767-96d4-4c42-8260-2d47930f4805","name":"scw-test-k8s-public-i-test-k8s-public-i-695f47","pool_id":"c9e09286-7234-4cee-b778-8c329b183bb3","provider_id":"scaleway://instance/fr-par-1/9ce74004-fe13-4f71-b92d-d9a7379e34f1","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:57:48.705995Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d693352c-a540-4e9e-b257-e2084eee2a23
+      - ac16dfa7-a370-413b-bb3f-6ee8adef4617
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,10 +2493,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:19:02.453998Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:54:22.539011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -2373,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60ffb27f-df04-490a-b8a6-31c7ed00a36a
+      - 92783d2c-e183-46ae-9fe5-889b2f80d915
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,10 +2526,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201d62ac-4232-462f-b8a8-e5767d25d71e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:29.268912Z","dhcp_enabled":true,"id":"201d62ac-4232-462f-b8a8-e5767d25d71e","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:29.268912Z","id":"3c4b55f2-5c0a-4da2-834a-cbd20cdb7556","subnet":"172.16.60.0/22","updated_at":"2023-11-13T13:52:29.268912Z"},{"created_at":"2023-11-13T13:52:29.268912Z","id":"d1260a3d-1dff-478b-8f0b-c4be2e6dc3ec","subnet":"fd63:256c:45f7:dedd::/64","updated_at":"2023-11-13T13:52:29.268912Z"}],"tags":[],"updated_at":"2023-11-13T13:52:29.268912Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "719"
@@ -2406,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 688219e4-773a-4cbd-84bb-84b11d60585f
+      - aa8ba596-c5ce-4057-8b21-b73412c1ac29
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,10 +2559,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:57:48.806091Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2439,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 450cd6b0-338a-4461-9ff7-d8da5c95ff06
+      - 46d7a10c-1cb9-4e87-bed0-ab0f553d664a
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&pool_id=cde5d791-3c55-43cc-8e1e-6c72b195deef&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/nodes?order_by=created_at_asc&pool_id=c9e09286-7234-4cee-b778-8c329b183bb3&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:30.897296Z","error_message":null,"id":"9a91c1ff-74dc-41eb-8101-da96273fc049","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","pool_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","provider_id":"scaleway://instance/fr-par-1/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","public_ip_v4":"163.172.156.119","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:33.967615Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:54:46.754812Z","error_message":null,"id":"695f4767-96d4-4c42-8260-2d47930f4805","name":"scw-test-k8s-public-i-test-k8s-public-i-695f47","pool_id":"c9e09286-7234-4cee-b778-8c329b183bb3","provider_id":"scaleway://instance/fr-par-1/9ce74004-fe13-4f71-b92d-d9a7379e34f1","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:57:48.705995Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0fcf951-4700-42b8-9c80-455bd30283a9
+      - c478e7e8-02c0-4023-8c62-d32d030cf663
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,23 +2625,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9ce74004-fe13-4f71-b92d-d9a7379e34f1
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-10T13:19:31.379643+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","id":"650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:660:1000::1","gateway":"2001:bc8:660:1000::","netmask":"64"},"location":{"cluster_id":"90","hypervisor_id":"501","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:e4:41","maintenances":[],"modification_date":"2023-11-10T13:19:51.232798+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.66.252.1","private_nics":[{"creation_date":"2023-11-10T13:19:32.369675+00:00","id":"41a374e9-b564-471a-aef6-d6895a8bee4c","mac_address":"02:00:00:14:b3:b7","modification_date":"2023-11-10T13:19:33.548970+00:00","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","server_id":"650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"163.172.156.119","dynamic":true,"family":"inet","gateway":null,"id":"65b0aefe-db56-4c20-a811-61f69dbb375b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.119","dynamic":true,"family":"inet","gateway":null,"id":"65b0aefe-db56-4c20-a811-61f69dbb375b","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"08cfdf0c-43d9-4724-aae4-9b83ce62f24f","name":"kubernetes
-      7401da5e-0973-4cb6-848b-ffd3d82b7088"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=7401da5e-0973-4cb6-848b-ffd3d82b7088","pool=cde5d791-3c55-43cc-8e1e-6c72b195deef","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=9a91c1ff-74dc-41eb-8101-da96273fc049"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-10T13:19:31.379643+00:00","export_uri":null,"id":"36361446-d28a-4571-9644-764b97088dff","modification_date":"2023-11-10T13:19:31.379643+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-13T13:54:47.524934+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-695f47","id":"9ce74004-fe13-4f71-b92d-d9a7379e34f1","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:610:9105::1","gateway":"2001:bc8:610:9105::","netmask":"64"},"location":{"cluster_id":"52","hypervisor_id":"703","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2d:50:93","maintenances":[],"modification_date":"2023-11-13T13:55:06.294975+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-695f47","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.194.91.11","private_nics":[{"creation_date":"2023-11-13T13:54:48.305494+00:00","id":"dd9af198-169d-4615-b172-ce7986f14352","mac_address":"02:00:00:14:bd:91","modification_date":"2023-11-13T13:54:49.135948+00:00","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","server_id":"9ce74004-fe13-4f71-b92d-d9a7379e34f1","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.15.216.28","dynamic":true,"family":"inet","gateway":null,"id":"9a742e28-6d72-4774-98e2-e9116edc5bbf","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.216.28","dynamic":true,"family":"inet","gateway":null,"id":"9a742e28-6d72-4774-98e2-e9116edc5bbf","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"cbc09d40-13ee-4639-88d8-041bbc840a9d","name":"kubernetes
+      a253704d-993c-4193-8022-07a711f0f014"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=a253704d-993c-4193-8022-07a711f0f014","pool=c9e09286-7234-4cee-b778-8c329b183bb3","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=695f4767-96d4-4c42-8260-2d47930f4805"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-13T13:54:47.524934+00:00","export_uri":null,"id":"b03d2a12-70b8-4863-bdfb-f685eeb431c9","modification_date":"2023-11-13T13:54:47.524934+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"9ce74004-fe13-4f71-b92d-d9a7379e34f1","name":"scw-test-k8s-public-i-test-k8s-public-i-695f47"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3969"
+      - "3964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 13:57:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2519,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ed9a36a-7b50-46e0-904c-d92be339c0e7
+      - 5db06a1f-b06b-447a-8511-2a542e7ac43a
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,10 +2662,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201d62ac-4232-462f-b8a8-e5767d25d71e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:29.268912Z","dhcp_enabled":true,"id":"201d62ac-4232-462f-b8a8-e5767d25d71e","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:29.268912Z","id":"3c4b55f2-5c0a-4da2-834a-cbd20cdb7556","subnet":"172.16.60.0/22","updated_at":"2023-11-13T13:52:29.268912Z"},{"created_at":"2023-11-13T13:52:29.268912Z","id":"d1260a3d-1dff-478b-8f0b-c4be2e6dc3ec","subnet":"fd63:256c:45f7:dedd::/64","updated_at":"2023-11-13T13:52:29.268912Z"}],"tags":[],"updated_at":"2023-11-13T13:52:29.268912Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "719"
@@ -2542,7 +2674,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:38 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2552,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5edd1f1-9ab5-47e7-988f-f2bb613d2b5b
+      - ee2934e3-ea8d-4bf1-b4cc-d7adba754b0d
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,10 +2695,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:19:02.453998Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:54:22.539011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -2575,7 +2707,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:38 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2585,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f60c5a2d-8395-440b-a0f4-96f953f2ce5a
+      - c1005c11-1352-4571-9542-090992bf1afb
     status: 200 OK
     code: 200
     duration: ""
@@ -2596,10 +2728,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTh4Q2t0NVUyMDFNa1phVTJwT1UxbEVTWFZ1WlVNeGFFWmxUVzlvVlROQlkxVk5VRTF4WW5aUVlYWTNaMm8xYm05TFpHcEhOMjFHVGpkWWRqbHRWbTV2VWpFS05pc3hiSFo2VEVkVk5YZFhTM2hPZHpJeGRYaDVNSEp0YzJSTGEzZEZZak01Y21wTlEwOXpPVWxuTDBac05EQklTR2RTVlRjMlUyMUphbFZsZVN0c1ZncEVlamhYZUZVeGRVd3ZkVEE0TjBFdlNrNWhSamR3TUhseWNEbE5WWGhPVFZaQ2FYSllVWGR2VVZGVmJ6WnNXalUxV1RWdGJURlFWblEyVm5wMlIwWm5DbVpYT1hJeVdWVlRZamR0Y21GS2MwdE1WVWhHU2pJcmREQXhTMGR0UkVNMU9WTTRhVVZxT0dOblRtTlVaa2xrZDFOR1duVmpObmRYT1ZSR1pHZ3hjMllLYlRZdk1VRXdOVXMxWm1sWWQxRnJVWGR5VkRkak4xTnhTa1Z1TTFKR2FFWmtOMlIyVDJGb1Nta3JlR3A2VUVrMFNWcEVWRWRYVW1wbFR6bEhMMlY0Tndwak0xWkpMelZsZUZObE4yUTFWR0ZzVXpNNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlNGUm9WQzlQWW1oclQxQjZSRlI0V0ZFeWJqRjNWVFJ6UkhaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZVOWhkVWh0WW5OeE5XaHFWSEZGVkZaV2RtNVRTbWhWWVhCWldqZHllbFpoY1U0d2QxcHZlbHBsWmxadmIwUnZTZ3BJUzJ0dFdqWlBhbUZQYkRWemFrcEpaMHRWYkZaRWNIRnVSMW8xV1dFd2RUWldOWGMwYXl0eGMySndWV1pzY1hSdFIwNHpXR1pyUzNKM1V6VXJaV1I1Q210M2QwRnZNa1pGY25oU00zUnlXRVl3WTJ3MWNHaEtPVTVzVm1KeFNVb3hPVlJMZWtWTVR6RmpXamc1TkhWT1UzSmljVWQ2YjFCdWRGZDZhMEpHU2pjS1FsQkdVM0p1VEV0aVZWSTJUVVJyVTJkNVExVlBiMWRyVEhVNU1HeG1VVXhIZW5oS05FMTJSbGNyZDJSdFYxaHlOSHB4VDI1aE9ETkdjRmhsYW1GbmN3cDJla2wzYTFKUWN6Qm5PVXhRU200dlRrOTBlR3hCVldkV1ZtWk5hQ3RsV0hGRE5sQnRSM0k1VkROTWNrRndTRFJ5U0hVME0wbG5UVGRVT1VwMWVHbHZDazlZYm5KUllXdG5RVlpXU25vemNHUjVObkJ5ZUVReFFtRlZhVzk2WWxGNlZsTjZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNzQwMWRhNWUtMDk3My00Y2I2LTg0OGItZmZkM2Q4MmI3MDg4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoUEJVVEs3M0ZWaHQ2bEY2RFhodFp2aTZ2REU0Z2xtUjk2dndUbW44SFlpRm94ZWZNbUVrWGcycw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkpNRTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRWt3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE5QQ214VWF6WllNMVZNU0daVmEzUmplWFJCYlM5SmJIQnBSMGRRYjI5b1lsUlhjekptY3pBeWMxaHVWRTUzTWtGWFVXSktRbWR3VGtGcVYyaGtXVkZvU1djS1FUVk5OV3AzVDFabU5rZFZWVFo0YTBoVFozRkxaVEZRV0hSc1NYVkhUekF2YlhGaFJWUk9RMFpoV0dKV2RsRkxSa0p3U1U1dVJ6VjZUbkJsYm1VeU9BbzVUR1pCV0dGYVYwdHpiVE5PY0VKTUwxcHJhRkpITW5OSk1YQnlVVmxSVFcwMldVbHFSRVZ2U1U1S2VtTTFjamxWVEdGSWVqbFJRbk0wTTFobVdFVnNDamxTS3pabFZWVnpTa0YyWkUxTVQyVTJlamd4TVRVdmFrWTFiMFY1ZWtNMVkwOXNSR2RKUjJNMGJraGpSVUl6WkVsa04waGpWbFJDUjNOTlRETlpXVTRLYVdjeVFrWnFjRFp4VnpONVlsbDJSV3hHYWpWeGQyVXhUVXN4WW1KR056YzBVekJRVWtsWk1HMTVaM0JWVWpOeFdYUkxiRUpXU2tKRk1qQXpVRTlUYWdwdk9FRnBkWFpaVlhVdmEzUXpaekZyT0hkalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1ZFNVhjMDA0TXpKNmRGQXlMMWhYVjJKdWEzbE1WRzFHYmk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRE1TdFlURkI0YVROR1FrZEZhWGhCVkdJNVVreEVNRU54TUZSdkt6ZFhVRlpoUkdKQ05reHVSblpFZFhSck1rNUxPUXB2UWs4MVlVUkhjbEZZVDNCSU0wUnBSbU5LY0hGaUt6Sm1WbmRTVlRod2MwRnhlakJUWlVvMVUyTXlXVWczUW5OMlNqWlBaQ3RMV0ZSaFdFb3ZaRWQzQ2xsSlZqRkhUV0kzTW0xRVRubGxhWEJaUkhFMmJuWTJkVE5LTUhkNGRXWXlUSEZPZWxWMVVUVjFOazVwYUZGbGIwazRiMkozUVdwTFVYSnRjelV4ZEVZS2MwZ3lNVzVZS3psYVEybExXQ3RZWjJ4WE0zTkRja3BrT1RsdlpGWkVhelZIVGpnclozSnVha3hSYlZkc2NISTFhbGxYU1d4c1dDOWFTekJSYjNWb0x3cFFOMDEyU1U1WU1YTkhLekZCTVhsM2MzaHZZa1JNV2taNFJ6aHdiSEZ4VTBGb1Jsa3pVMWRpTmxKUFFXTk5XVUpWVGtJeU5XRnhabFpvT0VaVEswbEZDa1EwWm10dlNIVnRhQzlUUTFBNU1qZGhiSGhwWlRORU4yVjNkMmxWUkRCU1RpdFJZd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTI1MzcwNGQtOTkzYy00MTkzLTgwMjItMDdhNzExZjBmMDE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFNG9CRVI4Z1dSOUtaNjFmdWRrYXRadzV1bTVsOFRBTlRTU29ibk03SFFpMnlGYWN1VVZuSHNjNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -2608,7 +2740,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:38 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2618,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42d3290e-232c-41ae-bc08-c3fff940622b
+      - 608a9d1a-fd4b-416a-8c8b-d9216f40ffdb
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,10 +2761,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:57:48.806091Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2641,7 +2773,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:38 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2651,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b965d305-f9f8-4843-a093-68db0b7e6528
+      - 7382e8fd-4ff4-4926-82db-2eaf8d9bed15
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,19 +2794,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=cde5d791-3c55-43cc-8e1e-6c72b195deef&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/nodes?order_by=created_at_asc&page=1&pool_id=c9e09286-7234-4cee-b778-8c329b183bb3&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:30.897296Z","error_message":null,"id":"9a91c1ff-74dc-41eb-8101-da96273fc049","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","pool_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","provider_id":"scaleway://instance/fr-par-1/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","public_ip_v4":"163.172.156.119","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:33.967615Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:54:46.754812Z","error_message":null,"id":"695f4767-96d4-4c42-8260-2d47930f4805","name":"scw-test-k8s-public-i-test-k8s-public-i-695f47","pool_id":"c9e09286-7234-4cee-b778-8c329b183bb3","provider_id":"scaleway://instance/fr-par-1/9ce74004-fe13-4f71-b92d-d9a7379e34f1","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:57:48.705995Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:38 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2684,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b95d7998-15d4-4784-b715-f59df7b0395c
+      - c26ec50f-8f37-4627-80c3-2ca6530ef00d
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,10 +2827,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201d62ac-4232-462f-b8a8-e5767d25d71e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"172.16.24.0/22","updated_at":"2023-11-10T13:17:40.815416Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:17:40.815416Z"}],"tags":[],"updated_at":"2023-11-10T13:17:40.815416Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:29.268912Z","dhcp_enabled":true,"id":"201d62ac-4232-462f-b8a8-e5767d25d71e","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:29.268912Z","id":"3c4b55f2-5c0a-4da2-834a-cbd20cdb7556","subnet":"172.16.60.0/22","updated_at":"2023-11-13T13:52:29.268912Z"},{"created_at":"2023-11-13T13:52:29.268912Z","id":"d1260a3d-1dff-478b-8f0b-c4be2e6dc3ec","subnet":"fd63:256c:45f7:dedd::/64","updated_at":"2023-11-13T13:52:29.268912Z"}],"tags":[],"updated_at":"2023-11-13T13:52:29.268912Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "719"
@@ -2707,7 +2839,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:39 GMT
+      - Mon, 13 Nov 2023 13:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2717,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed3bb9e5-2114-4b2c-8c0d-1a64573fd48e
+      - 5238c242-916d-4176-bbc1-5b2866f9dc8f
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,10 +2860,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:19:02.453998Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:54:22.539011Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -2740,7 +2872,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:39 GMT
+      - Mon, 13 Nov 2023 13:57:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2750,7 +2882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fc91f7b-959a-41af-a4eb-5bab088b03bd
+      - d8f9a9c9-bf37-4d1b-a698-918abaab5987
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,10 +2893,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTh4Q2t0NVUyMDFNa1phVTJwT1UxbEVTWFZ1WlVNeGFFWmxUVzlvVlROQlkxVk5VRTF4WW5aUVlYWTNaMm8xYm05TFpHcEhOMjFHVGpkWWRqbHRWbTV2VWpFS05pc3hiSFo2VEVkVk5YZFhTM2hPZHpJeGRYaDVNSEp0YzJSTGEzZEZZak01Y21wTlEwOXpPVWxuTDBac05EQklTR2RTVlRjMlUyMUphbFZsZVN0c1ZncEVlamhYZUZVeGRVd3ZkVEE0TjBFdlNrNWhSamR3TUhseWNEbE5WWGhPVFZaQ2FYSllVWGR2VVZGVmJ6WnNXalUxV1RWdGJURlFWblEyVm5wMlIwWm5DbVpYT1hJeVdWVlRZamR0Y21GS2MwdE1WVWhHU2pJcmREQXhTMGR0UkVNMU9WTTRhVVZxT0dOblRtTlVaa2xrZDFOR1duVmpObmRYT1ZSR1pHZ3hjMllLYlRZdk1VRXdOVXMxWm1sWWQxRnJVWGR5VkRkak4xTnhTa1Z1TTFKR2FFWmtOMlIyVDJGb1Nta3JlR3A2VUVrMFNWcEVWRWRYVW1wbFR6bEhMMlY0Tndwak0xWkpMelZsZUZObE4yUTFWR0ZzVXpNNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlNGUm9WQzlQWW1oclQxQjZSRlI0V0ZFeWJqRjNWVFJ6UkhaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZVOWhkVWh0WW5OeE5XaHFWSEZGVkZaV2RtNVRTbWhWWVhCWldqZHllbFpoY1U0d2QxcHZlbHBsWmxadmIwUnZTZ3BJUzJ0dFdqWlBhbUZQYkRWemFrcEpaMHRWYkZaRWNIRnVSMW8xV1dFd2RUWldOWGMwYXl0eGMySndWV1pzY1hSdFIwNHpXR1pyUzNKM1V6VXJaV1I1Q210M2QwRnZNa1pGY25oU00zUnlXRVl3WTJ3MWNHaEtPVTVzVm1KeFNVb3hPVlJMZWtWTVR6RmpXamc1TkhWT1UzSmljVWQ2YjFCdWRGZDZhMEpHU2pjS1FsQkdVM0p1VEV0aVZWSTJUVVJyVTJkNVExVlBiMWRyVEhVNU1HeG1VVXhIZW5oS05FMTJSbGNyZDJSdFYxaHlOSHB4VDI1aE9ETkdjRmhsYW1GbmN3cDJla2wzYTFKUWN6Qm5PVXhRU200dlRrOTBlR3hCVldkV1ZtWk5hQ3RsV0hGRE5sQnRSM0k1VkROTWNrRndTRFJ5U0hVME0wbG5UVGRVT1VwMWVHbHZDazlZYm5KUllXdG5RVlpXU25vemNHUjVObkJ5ZUVReFFtRlZhVzk2WWxGNlZsTjZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNzQwMWRhNWUtMDk3My00Y2I2LTg0OGItZmZkM2Q4MmI3MDg4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoUEJVVEs3M0ZWaHQ2bEY2RFhodFp2aTZ2REU0Z2xtUjk2dndUbW44SFlpRm94ZWZNbUVrWGcycw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkpNRTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRWt3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE5QQ214VWF6WllNMVZNU0daVmEzUmplWFJCYlM5SmJIQnBSMGRRYjI5b1lsUlhjekptY3pBeWMxaHVWRTUzTWtGWFVXSktRbWR3VGtGcVYyaGtXVkZvU1djS1FUVk5OV3AzVDFabU5rZFZWVFo0YTBoVFozRkxaVEZRV0hSc1NYVkhUekF2YlhGaFJWUk9RMFpoV0dKV2RsRkxSa0p3U1U1dVJ6VjZUbkJsYm1VeU9BbzVUR1pCV0dGYVYwdHpiVE5PY0VKTUwxcHJhRkpITW5OSk1YQnlVVmxSVFcwMldVbHFSRVZ2U1U1S2VtTTFjamxWVEdGSWVqbFJRbk0wTTFobVdFVnNDamxTS3pabFZWVnpTa0YyWkUxTVQyVTJlamd4TVRVdmFrWTFiMFY1ZWtNMVkwOXNSR2RKUjJNMGJraGpSVUl6WkVsa04waGpWbFJDUjNOTlRETlpXVTRLYVdjeVFrWnFjRFp4VnpONVlsbDJSV3hHYWpWeGQyVXhUVXN4WW1KR056YzBVekJRVWtsWk1HMTVaM0JWVWpOeFdYUkxiRUpXU2tKRk1qQXpVRTlUYWdwdk9FRnBkWFpaVlhVdmEzUXpaekZyT0hkalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1ZFNVhjMDA0TXpKNmRGQXlMMWhYVjJKdWEzbE1WRzFHYmk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRE1TdFlURkI0YVROR1FrZEZhWGhCVkdJNVVreEVNRU54TUZSdkt6ZFhVRlpoUkdKQ05reHVSblpFZFhSck1rNUxPUXB2UWs4MVlVUkhjbEZZVDNCSU0wUnBSbU5LY0hGaUt6Sm1WbmRTVlRod2MwRnhlakJUWlVvMVUyTXlXVWczUW5OMlNqWlBaQ3RMV0ZSaFdFb3ZaRWQzQ2xsSlZqRkhUV0kzTW0xRVRubGxhWEJaUkhFMmJuWTJkVE5LTUhkNGRXWXlUSEZPZWxWMVVUVjFOazVwYUZGbGIwazRiMkozUVdwTFVYSnRjelV4ZEVZS2MwZ3lNVzVZS3psYVEybExXQ3RZWjJ4WE0zTkRja3BrT1RsdlpGWkVhelZIVGpnclozSnVha3hSYlZkc2NISTFhbGxYU1d4c1dDOWFTekJSYjNWb0x3cFFOMDEyU1U1WU1YTkhLekZCTVhsM2MzaHZZa1JNV2taNFJ6aHdiSEZ4VTBGb1Jsa3pVMWRpTmxKUFFXTk5XVUpWVGtJeU5XRnhabFpvT0VaVEswbEZDa1EwWm10dlNIVnRhQzlUUTFBNU1qZGhiSGhwWlRORU4yVjNkMmxWUkRCU1RpdFJZd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTI1MzcwNGQtOTkzYy00MTkzLTgwMjItMDdhNzExZjBmMDE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFNG9CRVI4Z1dSOUtaNjFmdWRrYXRadzV1bTVsOFRBTlRTU29ibk03SFFpMnlGYWN1VVZuSHNjNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -2773,7 +2905,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:39 GMT
+      - Mon, 13 Nov 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2783,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b003c0af-1e9b-412b-9097-574b52428492
+      - 44073691-91d9-4fbb-aacd-1f4086051f28
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,10 +2926,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:22:33.981180Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:57:48.806091Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -2806,7 +2938,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:39 GMT
+      - Mon, 13 Nov 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2816,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 284745e1-eca8-49a2-987e-54bcb09afbc6
+      - de1be935-1e3d-486c-b666-a35c7f962459
     status: 200 OK
     code: 200
     duration: ""
@@ -2827,19 +2959,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=cde5d791-3c55-43cc-8e1e-6c72b195deef&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/nodes?order_by=created_at_asc&page=1&pool_id=c9e09286-7234-4cee-b778-8c329b183bb3&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:30.897296Z","error_message":null,"id":"9a91c1ff-74dc-41eb-8101-da96273fc049","name":"scw-test-k8s-public-i-test-k8s-public-i-9a91c1","pool_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","provider_id":"scaleway://instance/fr-par-1/650a5f2c-74fd-4ba0-b1c4-e2aafc677de7","public_ip_v4":"163.172.156.119","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:33.967615Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:54:46.754812Z","error_message":null,"id":"695f4767-96d4-4c42-8260-2d47930f4805","name":"scw-test-k8s-public-i-test-k8s-public-i-695f47","pool_id":"c9e09286-7234-4cee-b778-8c329b183bb3","provider_id":"scaleway://instance/fr-par-1/9ce74004-fe13-4f71-b92d-d9a7379e34f1","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:57:48.705995Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:39 GMT
+      - Mon, 13 Nov 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2849,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0508aee-e377-4a2a-91ee-eaf3cf884c90
+      - 17a7e872-6a7a-40d7-8af6-fa3a992e4789
     status: 200 OK
     code: 200
     duration: ""
@@ -2860,10 +2992,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261201Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562201556Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "633"
@@ -2872,7 +3004,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:40 GMT
+      - Mon, 13 Nov 2023 13:57:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2882,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4acec69b-1c26-4e49-9ff5-93dd8655e091
+      - 8b08b688-015a-4578-a7a4-96289039458b
     status: 200 OK
     code: 200
     duration: ""
@@ -2893,10 +3025,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562202Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "630"
@@ -2905,7 +3037,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:40 GMT
+      - Mon, 13 Nov 2023 13:57:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2915,7 +3047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b6355ba-1071-4b3e-a5ad-f69c7818de6d
+      - 0c5258e3-c383-4d6e-b8b6-ac8ba513aa46
     status: 200 OK
     code: 200
     duration: ""
@@ -2926,10 +3058,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562202Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "630"
@@ -2938,7 +3070,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:45 GMT
+      - Mon, 13 Nov 2023 13:58:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2948,7 +3080,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6be4f56d-77a6-49f3-8a7e-bc16e75244f7
+      - 2daabe0f-7385-4f36-957b-4597dc20d1f5
     status: 200 OK
     code: 200
     duration: ""
@@ -2959,10 +3091,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562202Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "630"
@@ -2971,7 +3103,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:50 GMT
+      - Mon, 13 Nov 2023 13:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2981,7 +3113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f10996f6-991b-4272-ab92-c47098e7d4e3
+      - e86286ef-13b4-47b5-8526-d6fcc174d1ae
     status: 200 OK
     code: 200
     duration: ""
@@ -2992,10 +3124,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:17:48.438606Z","id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:22:40.319261Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562202Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "630"
@@ -3004,7 +3136,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:55 GMT
+      - Mon, 13 Nov 2023 13:58:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3014,7 +3146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf6fba0f-ace3-4295-9999-7d5a6b5aa854
+      - 98fe10c8-8128-43ab-bb74-1cff07a5559c
     status: 200 OK
     code: 200
     duration: ""
@@ -3025,10 +3157,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde5d791-3c55-43cc-8e1e-6c72b195deef
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"cde5d791-3c55-43cc-8e1e-6c72b195deef","type":"not_found"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562202Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "630"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - de448d69-26fd-4856-b21e-d263dabd334a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562202Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "630"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5f0500e-325e-4543-8f62-d2e8c10861fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562202Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "630"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ceb76170-1d72-4460-bd78-3fda39c44395
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:52:45.378303Z","id":"c9e09286-7234-4cee-b778-8c329b183bb3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:57:58.562202Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "630"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e841c79d-670e-4881-81f3-8d5e04083ecd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c9e09286-7234-4cee-b778-8c329b183bb3
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"c9e09286-7234-4cee-b778-8c329b183bb3","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3037,7 +3301,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:00 GMT
+      - Mon, 13 Nov 2023 13:58:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3047,7 +3311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9349bbf-e6cf-4536-b265-68a0002653a2
+      - 4c10f099-0cf2-4393-9e72-fabb7b406e27
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3063,7 +3327,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -3072,7 +3336,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:00 GMT
+      - Mon, 13 Nov 2023 13:58:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3082,7 +3346,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bede240c-ae94-4d40-9d94-ce9671509940
+      - 40171d41-42ef-4c86-900f-bd1328fb4d4c
     status: 200 OK
     code: 200
     duration: ""
@@ -3093,10 +3357,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08348404-aed3-4b73-9f45-3c428b1836f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/d5a14f97-3df0-40ed-8173-f6138ded8f52
     method: GET
   response:
-    body: '{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -3105,7 +3369,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:00 GMT
+      - Mon, 13 Nov 2023 13:58:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3115,7 +3379,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 788e05b5-a5cd-4cc9-9068-5daaed9db2ce
+      - 60469fe2-c600-459b-85ef-1000a10f7fe1
     status: 200 OK
     code: 200
     duration: ""
@@ -3131,16 +3395,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:01.508994Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:40.056542Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "977"
+      - "979"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:01 GMT
+      - Mon, 13 Nov 2023 13:58:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3150,7 +3414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aac37600-84e5-4862-835d-c38297f303bb
+      - 9cb63b41-ce87-4fa1-9b08-1ab38da62632
     status: 200 OK
     code: 200
     duration: ""
@@ -3161,19 +3425,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:01.551192Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:40.108038Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "980"
+      - "982"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:01 GMT
+      - Mon, 13 Nov 2023 13:58:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3183,7 +3447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efcb809a-cfc6-48d7-9a8d-df656e151253
+      - 63332ee2-728b-43c3-821b-e4eacb5e1c59
     status: 200 OK
     code: 200
     duration: ""
@@ -3194,19 +3458,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:02.338389Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:40.749102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "977"
+      - "979"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:06 GMT
+      - Mon, 13 Nov 2023 13:58:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3216,7 +3480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a19ee2b-632c-4b93-b6c8-36f510065e36
+      - ae02bfa6-e7fc-4129-b9ce-2a10ad29d719
     status: 200 OK
     code: 200
     duration: ""
@@ -3227,19 +3491,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:02.338389Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:40.749102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "977"
+      - "979"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:06 GMT
+      - Mon, 13 Nov 2023 13:58:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3249,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a5be9e2-486d-4a4a-a2ea-df808b6aef0a
+      - ec5826e6-0e87-419b-ba3a-031bbd135a3c
     status: 200 OK
     code: 200
     duration: ""
@@ -3260,19 +3524,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:02.338389Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:40.749102Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "977"
+      - "979"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:06 GMT
+      - Mon, 13 Nov 2023 13:58:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3282,12 +3546,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 059e6fcc-8ab0-4e56-a8c6-65a478641dfe
+      - 0836ff8a-5c6c-49b3-93ea-619dedbbc4f4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"08348404-aed3-4b73-9f45-3c428b1836f2"}'
+    body: '{"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"d5a14f97-3df0-40ed-8173-f6138ded8f52"}'
     form: {}
     headers:
       Content-Type:
@@ -3298,7 +3562,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":null,"private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"created","updated_at":"2023-11-10T13:23:07.676263Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":null,"private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"created","updated_at":"2023-11-13T13:58:46.412374Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "983"
@@ -3307,7 +3571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 13:58:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3317,7 +3581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c004484-e457-432c-a874-5f3954b1c7d4
+      - 1f0fbf48-b8f7-4e53-b57e-e650f45de5b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3328,19 +3592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":null,"private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"created","updated_at":"2023-11-10T13:23:07.676263Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:07.857150Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":null,"private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"created","updated_at":"2023-11-13T13:58:46.412374Z","zone":"fr-par-1"}],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:46.596118Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1963"
+      - "1965"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:07 GMT
+      - Mon, 13 Nov 2023 13:58:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3350,7 +3614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28c62b9f-99c2-48c7-959d-74d96e0f7330
+      - 4bd0bbf1-e278-48da-a075-de7a88ae93ee
     status: 200 OK
     code: 200
     duration: ""
@@ -3361,19 +3625,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":null,"private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"created","updated_at":"2023-11-10T13:23:07.676263Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:07.857150Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":null,"private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"created","updated_at":"2023-11-13T13:58:46.412374Z","zone":"fr-par-1"}],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:46.596118Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1963"
+      - "1965"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:12 GMT
+      - Mon, 13 Nov 2023 13:58:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3383,7 +3647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b614ea9-287c-445f-af03-854747f2b8df
+      - f680f43c-f7b1-460d-9a71-a64fef0ed5c2
     status: 200 OK
     code: 200
     duration: ""
@@ -3394,19 +3658,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:55.989598Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1972"
+      - "1974"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:17 GMT
+      - Mon, 13 Nov 2023 13:58:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3416,7 +3680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4cdcc56-3d99-4b65-9cd0-dfe77585bb64
+      - 7d976da1-442b-4861-90e1-217eb1796276
     status: 200 OK
     code: 200
     duration: ""
@@ -3427,43 +3691,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "996"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3743cef3-6f32-4206-9455-0958710b68d6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -3472,7 +3703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
+      - Mon, 13 Nov 2023 13:58:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3482,7 +3713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14c51f2e-a1ea-4b30-82d1-fb761da36d3a
+      - eefbf8cf-f752-4902-b6d3-1b45420b8d59
     status: 200 OK
     code: 200
     duration: ""
@@ -3493,43 +3724,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1972"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 02628363-732f-4d6e-b9b4-bc8f9b4ad693
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -3538,7 +3736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
+      - Mon, 13 Nov 2023 13:58:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3548,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c70cb89-7efc-4844-9722-beb4026289b5
+      - cf92c70f-9d89-4a76-bd18-51af6cfc94f8
     status: 200 OK
     code: 200
     duration: ""
@@ -3559,10 +3757,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:22:59.664556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:55.989598Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1974"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f33df809-5da2-4ff2-ac87-a44b1cd93b08
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - adb46781-4166-4117-bc3f-957489197c07
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T13:58:36.765767Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -3571,7 +3835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
+      - Mon, 13 Nov 2023 13:58:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3581,7 +3845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 848c3707-f14c-4f91-bee8-1521cae82c51
+      - 034c8b18-dbab-4e89-9f0f-814c5209f23f
     status: 200 OK
     code: 200
     duration: ""
@@ -3594,10 +3858,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405142865Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201140925Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "631"
@@ -3606,7 +3870,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
+      - Mon, 13 Nov 2023 13:58:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3616,7 +3880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4488e081-7029-4809-9f3b-cb49272c102b
+      - 04c68730-becf-4b64-9ff2-01f7d6cec96f
     status: 200 OK
     code: 200
     duration: ""
@@ -3627,10 +3891,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3639,7 +3903,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
+      - Mon, 13 Nov 2023 13:58:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3649,7 +3913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96975d63-3494-47c1-a0e7-e573e6dc803c
+      - 54735773-7d96-4f6c-bd91-7cc9a39c85b7
     status: 200 OK
     code: 200
     duration: ""
@@ -3660,10 +3924,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3672,7 +3936,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:23 GMT
+      - Mon, 13 Nov 2023 13:59:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3682,7 +3946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3544067-a1e7-4a7e-842e-b34b1e012d59
+      - 56990773-cd1a-4971-a1f8-710856f3bf91
     status: 200 OK
     code: 200
     duration: ""
@@ -3693,10 +3957,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3705,7 +3969,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:28 GMT
+      - Mon, 13 Nov 2023 13:59:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3715,7 +3979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52487d29-49c0-44ec-8095-4ddce9fbcc15
+      - 6f85ad74-c52b-4a78-a948-18092ea20402
     status: 200 OK
     code: 200
     duration: ""
@@ -3726,10 +3990,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3738,7 +4002,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:33 GMT
+      - Mon, 13 Nov 2023 13:59:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3748,7 +4012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a69f0d0f-67f6-4445-b304-89497db1dd79
+      - 3240ab15-4ba8-4853-b33a-a3fb9a30e7c1
     status: 200 OK
     code: 200
     duration: ""
@@ -3759,10 +4023,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3771,7 +4035,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:38 GMT
+      - Mon, 13 Nov 2023 13:59:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3781,7 +4045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9afe37a7-16a3-4a26-96b9-9c5a9066127e
+      - 4156a323-97a7-4fac-8c3a-32ef2263d268
     status: 200 OK
     code: 200
     duration: ""
@@ -3792,10 +4056,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3804,7 +4068,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:44 GMT
+      - Mon, 13 Nov 2023 13:59:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3814,7 +4078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61c21fc1-7b99-4772-8498-a0740ddf21c9
+      - 6bfe0818-d9b1-46ba-b74b-31c23df22e70
     status: 200 OK
     code: 200
     duration: ""
@@ -3825,10 +4089,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3837,7 +4101,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:49 GMT
+      - Mon, 13 Nov 2023 13:59:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3847,7 +4111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f5726a5-d0f2-4f25-845e-9dc6a087d690
+      - 192d9c1a-71da-4a08-9d5b-724d3d314ceb
     status: 200 OK
     code: 200
     duration: ""
@@ -3858,10 +4122,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3870,7 +4134,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:54 GMT
+      - Mon, 13 Nov 2023 13:59:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3880,7 +4144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66f22b03-93e1-4bb2-b8db-06c7ff6b070e
+      - 8a319289-7644-4cde-9b50-7dcfc9b1d322
     status: 200 OK
     code: 200
     duration: ""
@@ -3891,10 +4155,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3903,7 +4167,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:59 GMT
+      - Mon, 13 Nov 2023 13:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3913,7 +4177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae8a0eea-19c4-4213-b4bc-6f292a8d83a1
+      - 2551fbe4-43b6-4a75-b374-18da89c08c89
     status: 200 OK
     code: 200
     duration: ""
@@ -3924,10 +4188,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3936,7 +4200,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:04 GMT
+      - Mon, 13 Nov 2023 13:59:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3946,7 +4210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1957524e-2542-433e-abb2-5df553a8041c
+      - 1bc0524d-480d-4aaa-a753-cb7daa0972e2
     status: 200 OK
     code: 200
     duration: ""
@@ -3957,10 +4221,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3969,7 +4233,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:09 GMT
+      - Mon, 13 Nov 2023 13:59:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3979,7 +4243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7cbe535-94d7-4efd-8ebe-f272eee603d1
+      - 0178db18-bac4-4e07-baae-cb3a45a82ace
     status: 200 OK
     code: 200
     duration: ""
@@ -3990,10 +4254,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4002,7 +4266,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:14 GMT
+      - Mon, 13 Nov 2023 13:59:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4012,7 +4276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d1d68bc-6ff7-4bfe-9194-b9a4f20e4514
+      - 5e8f8f71-052e-4edd-acbe-13c5976dd935
     status: 200 OK
     code: 200
     duration: ""
@@ -4023,10 +4287,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4035,7 +4299,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:19 GMT
+      - Mon, 13 Nov 2023 14:00:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4045,7 +4309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a93cf67-aed7-4525-bcfc-9e7e390be259
+      - 4de8b159-86f6-4feb-a9a8-8b0a8f6e9885
     status: 200 OK
     code: 200
     duration: ""
@@ -4056,10 +4320,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4068,7 +4332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:24 GMT
+      - Mon, 13 Nov 2023 14:00:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4078,7 +4342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20fbc479-1a1c-457d-8552-49f8c042dbf7
+      - 74dc041b-5c3f-4f37-ad2a-f2de7fcda9dc
     status: 200 OK
     code: 200
     duration: ""
@@ -4089,10 +4353,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4101,7 +4365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:29 GMT
+      - Mon, 13 Nov 2023 14:00:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4111,7 +4375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b06b7c90-2ff1-4f23-9b9f-1ad34dcf1718
+      - a9ad9b66-45f7-4d87-976a-506173a3ccd8
     status: 200 OK
     code: 200
     duration: ""
@@ -4122,10 +4386,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4134,7 +4398,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:34 GMT
+      - Mon, 13 Nov 2023 14:00:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4144,7 +4408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - daee81d2-6f16-4150-83c3-90a4438da978
+      - 767cf06d-0ff2-40a2-b2ff-dec14e152b61
     status: 200 OK
     code: 200
     duration: ""
@@ -4155,10 +4419,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4167,7 +4431,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:39 GMT
+      - Mon, 13 Nov 2023 14:00:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4177,7 +4441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f209b95-7fa9-4fca-a5e8-7aa1a0a389ed
+      - 08a38050-3634-483d-9ec9-0cfb108b76c6
     status: 200 OK
     code: 200
     duration: ""
@@ -4188,10 +4452,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4200,7 +4464,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:44 GMT
+      - Mon, 13 Nov 2023 14:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4210,7 +4474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab43c5b6-8f57-4ccb-80f8-cc8787aae075
+      - 6d490a1d-4dc0-4316-a957-c8601150353c
     status: 200 OK
     code: 200
     duration: ""
@@ -4221,10 +4485,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4233,7 +4497,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:49 GMT
+      - Mon, 13 Nov 2023 14:00:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4243,7 +4507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 981ffede-8ecf-4f80-8995-6b6bd81ad672
+      - 9ae000b6-6b03-4329-9edf-486428fc5596
     status: 200 OK
     code: 200
     duration: ""
@@ -4254,10 +4518,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4266,7 +4530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:55 GMT
+      - Mon, 13 Nov 2023 14:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4276,7 +4540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c27d3d7-d21c-4b9d-b05d-4343b75c7abf
+      - 5e2a0a9f-30ae-4fd5-aa32-a4a9b7d7fcda
     status: 200 OK
     code: 200
     duration: ""
@@ -4287,10 +4551,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4299,7 +4563,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:00 GMT
+      - Mon, 13 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4309,7 +4573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 920b81a0-7169-4b24-a7a1-36a385266e5a
+      - 054dde42-d561-4dbd-8c4f-ac57b2aef678
     status: 200 OK
     code: 200
     duration: ""
@@ -4320,10 +4584,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4332,7 +4596,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:05 GMT
+      - Mon, 13 Nov 2023 14:00:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4342,7 +4606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3c0fcd9-7866-4426-a129-3717f1e64055
+      - 22b3f952-67d3-45ab-bc8e-89a35cdd850e
     status: 200 OK
     code: 200
     duration: ""
@@ -4353,10 +4617,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4365,7 +4629,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:10 GMT
+      - Mon, 13 Nov 2023 14:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4375,7 +4639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abdb0a8c-ed69-4fee-b4a8-92993a3ff9e6
+      - d0ad06ee-5484-499d-86e3-62b8af988317
     status: 200 OK
     code: 200
     duration: ""
@@ -4386,10 +4650,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4398,7 +4662,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:15 GMT
+      - Mon, 13 Nov 2023 14:00:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4408,7 +4672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34126772-8e33-445a-a1f9-7be97aa0eaa1
+      - 3f9c2d22-bb3e-439d-af43-894cb89de653
     status: 200 OK
     code: 200
     duration: ""
@@ -4419,10 +4683,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4431,7 +4695,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:20 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4441,7 +4705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95360ce0-60af-4aa0-926a-b82a22fb6613
+      - 124bb3e9-9ecf-4155-8dd4-9cae03eb3740
     status: 200 OK
     code: 200
     duration: ""
@@ -4452,10 +4716,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4464,7 +4728,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 14:01:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4474,7 +4738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7000a316-0b4c-4cb8-83b2-76943681b71a
+      - 92caabba-f004-4337-94a1-2e74fc5441b3
     status: 200 OK
     code: 200
     duration: ""
@@ -4485,10 +4749,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4497,7 +4761,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:30 GMT
+      - Mon, 13 Nov 2023 14:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4507,7 +4771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8041e704-12b9-4e7a-94e4-0e57f0142781
+      - e5bc30a0-271d-42c4-839d-01419640f414
     status: 200 OK
     code: 200
     duration: ""
@@ -4518,10 +4782,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4530,7 +4794,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:35 GMT
+      - Mon, 13 Nov 2023 14:01:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4540,7 +4804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77b72e25-79a1-418c-93d7-42a62c0a57af
+      - d90ad0ab-b481-4162-8cd4-782a8141286e
     status: 200 OK
     code: 200
     duration: ""
@@ -4551,10 +4815,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4563,7 +4827,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:40 GMT
+      - Mon, 13 Nov 2023 14:01:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4573,7 +4837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d130038-b49f-4b58-b61b-26315f2dd0f1
+      - 345edfa4-5b64-4cd9-9fcf-c36f1d49c996
     status: 200 OK
     code: 200
     duration: ""
@@ -4584,10 +4848,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4596,7 +4860,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:45 GMT
+      - Mon, 13 Nov 2023 14:01:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4606,7 +4870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0edacd73-0939-49f9-a852-5b1b92199be8
+      - ea0c89bb-dfcb-4281-81b6-132489c496a5
     status: 200 OK
     code: 200
     duration: ""
@@ -4617,10 +4881,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4629,7 +4893,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:50 GMT
+      - Mon, 13 Nov 2023 14:01:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4639,7 +4903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 090d06a8-3c42-44b2-9ac3-39d5a8cdaaf1
+      - 7483dea0-aad5-4250-a355-072fb9a43031
     status: 200 OK
     code: 200
     duration: ""
@@ -4650,10 +4914,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4662,7 +4926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:55 GMT
+      - Mon, 13 Nov 2023 14:01:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4672,7 +4936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3a80a03-8319-4c56-b773-bb6f20ba431f
+      - fea1b5bc-c5e9-433b-8559-ac2234918dbd
     status: 200 OK
     code: 200
     duration: ""
@@ -4683,10 +4947,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4695,7 +4959,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:00 GMT
+      - Mon, 13 Nov 2023 14:01:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4705,7 +4969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0537d11-7a85-430b-8611-a14d2167386a
+      - 91886404-a86c-4458-ac39-9afe46390fba
     status: 200 OK
     code: 200
     duration: ""
@@ -4716,10 +4980,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4728,7 +4992,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:05 GMT
+      - Mon, 13 Nov 2023 14:01:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4738,7 +5002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 992de3d6-79c0-40ea-80e1-f105d2e9c149
+      - b6fab31b-6493-461e-84a8-7a19d686a6e3
     status: 200 OK
     code: 200
     duration: ""
@@ -4749,10 +5013,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4761,7 +5025,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:10 GMT
+      - Mon, 13 Nov 2023 14:01:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4771,7 +5035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e087cab1-cb6e-4e6b-a4d6-d766fb9ac681
+      - 2b9f8f89-0475-4ed7-bdd2-9d7367b38fdd
     status: 200 OK
     code: 200
     duration: ""
@@ -4782,10 +5046,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4794,7 +5058,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:15 GMT
+      - Mon, 13 Nov 2023 14:01:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4804,7 +5068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61734d1c-0f7f-4178-8573-c514b88c5c13
+      - 0b8f03d6-bfca-45d6-9004-415edb1abd6d
     status: 200 OK
     code: 200
     duration: ""
@@ -4815,10 +5079,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4827,7 +5091,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:21 GMT
+      - Mon, 13 Nov 2023 14:02:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4837,7 +5101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b0a122e-daaf-4c18-9ca0-ad4d90f83911
+      - fabff5f4-f5c5-42ce-973a-c403bc7f88fc
     status: 200 OK
     code: 200
     duration: ""
@@ -4848,10 +5112,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4860,7 +5124,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:26 GMT
+      - Mon, 13 Nov 2023 14:02:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4870,7 +5134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4aea49fa-5c27-43e4-a386-ac8a8459d918
+      - 86fed211-d1c3-4c67-9d52-c22b9774b332
     status: 200 OK
     code: 200
     duration: ""
@@ -4881,10 +5145,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4893,7 +5157,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:31 GMT
+      - Mon, 13 Nov 2023 14:02:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4903,7 +5167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd3b1436-85f7-4274-8a9a-917d64021e04
+      - 71d97e3c-65ee-48f9-a432-1a030df34af2
     status: 200 OK
     code: 200
     duration: ""
@@ -4914,10 +5178,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4926,7 +5190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:36 GMT
+      - Mon, 13 Nov 2023 14:02:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4936,7 +5200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0f46acb-d2a4-4cc6-a53b-8835210e99e0
+      - b60ef5fa-b32c-4012-8ad1-165c6a666520
     status: 200 OK
     code: 200
     duration: ""
@@ -4947,10 +5211,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4959,7 +5223,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:41 GMT
+      - Mon, 13 Nov 2023 14:02:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4969,7 +5233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7751b3ee-850f-42f5-aded-736ec9b22615
+      - e8f029b3-caeb-4065-888a-70cec8213b5e
     status: 200 OK
     code: 200
     duration: ""
@@ -4980,10 +5244,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4992,7 +5256,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 14:02:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5002,7 +5266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c798d246-514d-469c-83a8-d8da485d6a83
+      - a85e91f8-063a-45ee-99c9-6cd99adb162e
     status: 200 OK
     code: 200
     duration: ""
@@ -5013,10 +5277,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5025,7 +5289,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:51 GMT
+      - Mon, 13 Nov 2023 14:02:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5035,7 +5299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03b53144-a3fa-4dd6-b18d-26723164ac7c
+      - a7d00e64-e38b-4273-8ec1-d5c941dbbf8a
     status: 200 OK
     code: 200
     duration: ""
@@ -5046,10 +5310,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5058,7 +5322,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:56 GMT
+      - Mon, 13 Nov 2023 14:02:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5068,7 +5332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c15b4a81-9864-4db4-a490-13a4d49827ac
+      - 275dd0c8-14bb-4e23-a550-42931ea0cc36
     status: 200 OK
     code: 200
     duration: ""
@@ -5079,10 +5343,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5091,7 +5355,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:01 GMT
+      - Mon, 13 Nov 2023 14:02:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5101,7 +5365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3f2c024-2b64-431c-ad8f-5ba37d43ffad
+      - 70b9ac28-0a9f-49f8-bd27-95d4d8adaf96
     status: 200 OK
     code: 200
     duration: ""
@@ -5112,10 +5376,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5124,7 +5388,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:06 GMT
+      - Mon, 13 Nov 2023 14:02:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5134,7 +5398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a06d9e4-a68c-41f3-b26e-c9be4f82ab94
+      - 6f4649c5-4e45-4886-baf3-43a19ed511be
     status: 200 OK
     code: 200
     duration: ""
@@ -5145,10 +5409,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5157,7 +5421,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:11 GMT
+      - Mon, 13 Nov 2023 14:02:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5167,7 +5431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af82a086-5610-4f16-8152-adde7d53bec1
+      - 64a4f2a0-e61b-4cee-bf13-0a54bcccbecf
     status: 200 OK
     code: 200
     duration: ""
@@ -5178,10 +5442,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5190,7 +5454,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:16 GMT
+      - Mon, 13 Nov 2023 14:02:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5200,7 +5464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40955248-d410-43fa-9eca-3987b452d722
+      - e41552db-a8ce-42f3-a882-b62fe5a4dc67
     status: 200 OK
     code: 200
     duration: ""
@@ -5211,10 +5475,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5223,7 +5487,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:21 GMT
+      - Mon, 13 Nov 2023 14:03:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5233,7 +5497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd8762a6-de91-4f4e-a448-5932a46b064d
+      - d70927eb-03bc-4f07-8567-36a667c6f2e0
     status: 200 OK
     code: 200
     duration: ""
@@ -5244,10 +5508,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5256,7 +5520,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:26 GMT
+      - Mon, 13 Nov 2023 14:03:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5266,7 +5530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a05ed6b-4944-4a4d-a0ae-049b34951fe1
+      - 73eaf2d8-c3c1-4630-a00e-c1d88b21a75f
     status: 200 OK
     code: 200
     duration: ""
@@ -5277,10 +5541,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5289,7 +5553,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:31 GMT
+      - Mon, 13 Nov 2023 14:03:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5299,7 +5563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89f516a4-d48a-4248-b64a-adf640837e1f
+      - 8a9513d1-a7cc-46fb-b372-da5636fa7f59
     status: 200 OK
     code: 200
     duration: ""
@@ -5310,10 +5574,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5322,7 +5586,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:36 GMT
+      - Mon, 13 Nov 2023 14:03:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5332,7 +5596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e8a1b83-7073-4a83-9926-84afb92c11ee
+      - 09e04bb6-cf36-4034-ae6b-855842bd6223
     status: 200 OK
     code: 200
     duration: ""
@@ -5343,10 +5607,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5355,7 +5619,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:41 GMT
+      - Mon, 13 Nov 2023 14:03:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5365,7 +5629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37e252a7-e918-4c32-b7d3-26a8c8ad7172
+      - c0a0d27d-edee-4ecc-b19f-4aec0d84c680
     status: 200 OK
     code: 200
     duration: ""
@@ -5376,10 +5640,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:18.405143Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5388,7 +5652,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:46 GMT
+      - Mon, 13 Nov 2023 14:03:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5398,7 +5662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99eb4ab4-3cbd-4496-a8b7-aa1133565aac
+      - 320c1988-aa57-4cf5-bd61-44294f63de92
     status: 200 OK
     code: 200
     duration: ""
@@ -5409,10 +5673,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:47.506901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a2dc57f-d4e2-4d17-95dc-df080fb8586f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:57.201141Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a3da320-aaeb-445e-a4eb-aaaf89554b04
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:03:38.431597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -5421,7 +5751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:51 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5431,7 +5761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4eb0d4d3-d034-4f40-93b5-50e8527b8bd9
+      - 530fcb8f-166b-4e54-9100-46ada7b812cd
     status: 200 OK
     code: 200
     duration: ""
@@ -5442,10 +5772,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:25:10.450835Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T14:00:41.393676Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -5454,7 +5784,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:51 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5464,7 +5794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd13331f-0302-4c00-a9af-9a03b457739d
+      - cba01ed8-5c48-4d8a-b46e-48611fc2deb7
     status: 200 OK
     code: 200
     duration: ""
@@ -5475,10 +5805,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:47.506901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:03:38.431597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -5487,7 +5817,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:51 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5497,7 +5827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2894cda5-ebbd-4301-8b99-522012af7176
+      - 867f8842-fe27-4a62-8fc8-50b02874431f
     status: 200 OK
     code: 200
     duration: ""
@@ -5508,10 +5838,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=87fd8bd2-12e9-4f7b-ab31-d9d617a3099d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/nodes?order_by=created_at_asc&page=1&pool_id=a69311ee-4867-49c5-85da-c4633fb8693d&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:34.112136Z","error_message":null,"id":"0b722196-710e-49dd-8c90-6b4bc0d656ca","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","pool_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","provider_id":"scaleway://instance/fr-par-1/297e5d54-9b93-4e61-9723-750675a5cf6b","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:47.491253Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:00:46.803987Z","error_message":null,"id":"4e07bd6c-a990-4eab-a29f-b84960556314","name":"scw-test-k8s-public-i-test-k8s-public-i-4e07bd","pool_id":"a69311ee-4867-49c5-85da-c4633fb8693d","provider_id":"scaleway://instance/fr-par-1/5b3876b7-4310-49af-b057-c8ea39b95e82","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:03:38.415246Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "645"
@@ -5520,7 +5850,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:52 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5530,7 +5860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42d47a34-3f86-4154-b9db-3a15fa38b15f
+      - 07eaad42-20b0-4749-8aa3-134061463c3b
     status: 200 OK
     code: 200
     duration: ""
@@ -5541,10 +5871,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:25:10.450835Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T14:00:41.393676Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -5553,7 +5883,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:52 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5563,7 +5893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fc76268-354f-4ed4-a549-c7e38112ed9b
+      - 3e8de5c2-d8ac-4201-b81a-38be8ca64fed
     status: 200 OK
     code: 200
     duration: ""
@@ -5574,10 +5904,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201d62ac-4232-462f-b8a8-e5767d25d71e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:07.135324Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:23:07.137733Z"}],"tags":[],"updated_at":"2023-11-10T13:23:14.602149Z","vpc_id":"8a7826ee-a226-40fc-9878-4e533272333b"}'
+    body: '{"created_at":"2023-11-13T13:52:29.268912Z","dhcp_enabled":true,"id":"201d62ac-4232-462f-b8a8-e5767d25d71e","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:29.268912Z","id":"3c4b55f2-5c0a-4da2-834a-cbd20cdb7556","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:45.832050Z"},{"created_at":"2023-11-13T13:52:29.268912Z","id":"d1260a3d-1dff-478b-8f0b-c4be2e6dc3ec","subnet":"fd63:256c:45f7:dedd::/64","updated_at":"2023-11-13T13:58:45.841502Z"}],"tags":[],"updated_at":"2023-11-13T13:58:53.093194Z","vpc_id":"6b685238-8de3-48e6-8724-6eacc489ca0c"}'
     headers:
       Content-Length:
       - "719"
@@ -5586,7 +5916,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:52 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5596,7 +5926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55bdcd42-546e-4571-9728-c6ed99ebb400
+      - 29b24be0-3587-4797-8f00-ecc5a1a68b8e
     status: 200 OK
     code: 200
     duration: ""
@@ -5607,10 +5937,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:47.506901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:03:38.431597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -5619,7 +5949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:52 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5629,7 +5959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82bbdced-4191-4d7e-8bbc-0684ab7bde31
+      - 7c4b0eb9-199c-43f9-a79f-f27a431f10ea
     status: 200 OK
     code: 200
     duration: ""
@@ -5640,10 +5970,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&pool_id=87fd8bd2-12e9-4f7b-ab31-d9d617a3099d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/nodes?order_by=created_at_asc&pool_id=a69311ee-4867-49c5-85da-c4633fb8693d&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:34.112136Z","error_message":null,"id":"0b722196-710e-49dd-8c90-6b4bc0d656ca","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","pool_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","provider_id":"scaleway://instance/fr-par-1/297e5d54-9b93-4e61-9723-750675a5cf6b","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:47.491253Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:00:46.803987Z","error_message":null,"id":"4e07bd6c-a990-4eab-a29f-b84960556314","name":"scw-test-k8s-public-i-test-k8s-public-i-4e07bd","pool_id":"a69311ee-4867-49c5-85da-c4633fb8693d","provider_id":"scaleway://instance/fr-par-1/5b3876b7-4310-49af-b057-c8ea39b95e82","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:03:38.415246Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "645"
@@ -5652,7 +5982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:52 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5662,7 +5992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ed0c8d1-167a-4f5e-b5c9-34becfa1f522
+      - ed70b861-035d-4fa1-ae4b-c0bb93141ad2
     status: 200 OK
     code: 200
     duration: ""
@@ -5673,14 +6003,14 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/297e5d54-9b93-4e61-9723-750675a5cf6b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5b3876b7-4310-49af-b057-c8ea39b95e82
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-10T13:25:34.774686+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","id":"297e5d54-9b93-4e61-9723-750675a5cf6b","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"51","hypervisor_id":"702","node_id":"3","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:e4:8f","maintenances":[],"modification_date":"2023-11-10T13:25:50.100477+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.194.82.69","private_nics":[{"creation_date":"2023-11-10T13:25:35.773485+00:00","id":"9bda0dbf-764c-494b-b030-24c96fa080eb","mac_address":"02:00:00:14:b3:c6","modification_date":"2023-11-10T13:25:36.671669+00:00","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","server_id":"297e5d54-9b93-4e61-9723-750675a5cf6b","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"08cfdf0c-43d9-4724-aae4-9b83ce62f24f","name":"kubernetes
-      7401da5e-0973-4cb6-848b-ffd3d82b7088"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=7401da5e-0973-4cb6-848b-ffd3d82b7088","pool=87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=0b722196-710e-49dd-8c90-6b4bc0d656ca"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-10T13:25:34.774686+00:00","export_uri":null,"id":"f0d6725d-cec7-4a0d-b68a-53acb9b80d37","modification_date":"2023-11-10T13:25:34.774686+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"297e5d54-9b93-4e61-9723-750675a5cf6b","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-13T14:00:47.668695+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-4e07bd","id":"5b3876b7-4310-49af-b057-c8ea39b95e82","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"55","hypervisor_id":"102","node_id":"2","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2d:51:07","maintenances":[],"modification_date":"2023-11-13T14:01:05.582505+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-4e07bd","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.194.98.67","private_nics":[{"creation_date":"2023-11-13T14:00:48.269032+00:00","id":"b9eec8d3-5859-4c5c-aecc-c9c10a896437","mac_address":"02:00:00:14:bd:a3","modification_date":"2023-11-13T14:00:49.063476+00:00","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","server_id":"5b3876b7-4310-49af-b057-c8ea39b95e82","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"cbc09d40-13ee-4639-88d8-041bbc840a9d","name":"kubernetes
+      a253704d-993c-4193-8022-07a711f0f014"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=a253704d-993c-4193-8022-07a711f0f014","pool=a69311ee-4867-49c5-85da-c4633fb8693d","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=4e07bd6c-a990-4eab-a29f-b84960556314"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-13T14:00:47.668695+00:00","export_uri":null,"id":"c9d00e7c-a2a0-4228-8ba1-b78e4cf33875","modification_date":"2023-11-13T14:00:47.668695+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"5b3876b7-4310-49af-b057-c8ea39b95e82","name":"scw-test-k8s-public-i-test-k8s-public-i-4e07bd"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "3480"
@@ -5689,7 +6019,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:52 GMT
+      - Mon, 13 Nov 2023 14:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5699,7 +6029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 352b7b7f-4de4-4a86-bcfa-ea3a3ab15def
+      - 33ce18a5-5eff-4786-a29f-65e4ea0f101e
     status: 200 OK
     code: 200
     duration: ""
@@ -5710,76 +6040,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/d5a14f97-3df0-40ed-8173-f6138ded8f52
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:40.815416Z","dhcp_enabled":true,"id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:40.815416Z","id":"f9586c0b-fc89-4550-95a4-c3c031f0629b","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:07.135324Z"},{"created_at":"2023-11-10T13:17:40.815416Z","id":"29e602a9-f317-49b4-8ee9-d957558a788d","subnet":"fd63:256c:45f7:d041::/64","updated_at":"2023-11-10T13:23:07.137733Z"}],"tags":[],"updated_at":"2023-11-10T13:23:14.602149Z","vpc_id":"8a7826ee-a226-40fc-9878-4e533272333b"}'
-    headers:
-      Content-Length:
-      - "719"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2bc8b914-ae1f-462b-aec3-251930ab2000
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1972"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ba3910a2-f31a-4e8f-965f-0705be08983e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08348404-aed3-4b73-9f45-3c428b1836f2
-    method: GET
-  response:
-    body: '{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -5788,7 +6052,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
+      - Mon, 13 Nov 2023 14:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5798,7 +6062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24378792-9ea1-4d3d-ac79-eb28efea1169
+      - b526b34c-897d-430b-a1a4-4daabd875f30
     status: 200 OK
     code: 200
     duration: ""
@@ -5809,10 +6073,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201d62ac-4232-462f-b8a8-e5767d25d71e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-13T13:52:29.268912Z","dhcp_enabled":true,"id":"201d62ac-4232-462f-b8a8-e5767d25d71e","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:29.268912Z","id":"3c4b55f2-5c0a-4da2-834a-cbd20cdb7556","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:45.832050Z"},{"created_at":"2023-11-13T13:52:29.268912Z","id":"d1260a3d-1dff-478b-8f0b-c4be2e6dc3ec","subnet":"fd63:256c:45f7:dedd::/64","updated_at":"2023-11-13T13:58:45.841502Z"}],"tags":[],"updated_at":"2023-11-13T13:58:53.093194Z","vpc_id":"6b685238-8de3-48e6-8724-6eacc489ca0c"}'
+    headers:
+      Content-Length:
+      - "719"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5905f98-3969-4771-be4b-79637c21432d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:55.989598Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1974"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b938048d-2f5f-4927-a08e-ea9e3fd19c78
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -5821,7 +6151,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
+      - Mon, 13 Nov 2023 14:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5831,7 +6161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a2b30c0-1f5b-48ad-8cb6-3b854e39df54
+      - 145c2221-a66c-4e4f-b881-e85550596413
     status: 200 OK
     code: 200
     duration: ""
@@ -5842,19 +6172,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:55.989598Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1972"
+      - "1974"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
+      - Mon, 13 Nov 2023 14:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5864,7 +6194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 563dbec5-40ca-4c09-811f-cf48f76a8473
+      - 625d28fb-29c6-4b11-a7fd-75d5f0f8be1c
     status: 200 OK
     code: 200
     duration: ""
@@ -5875,10 +6205,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -5887,7 +6217,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
+      - Mon, 13 Nov 2023 14:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5897,7 +6227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83110573-92b4-4f0d-b061-78a26d561de8
+      - aa75d3eb-71d0-438f-b45f-b33e31a6c7ce
     status: 200 OK
     code: 200
     duration: ""
@@ -5908,10 +6238,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:25:10.450835Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T14:00:41.393676Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -5920,7 +6250,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
+      - Mon, 13 Nov 2023 14:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5930,7 +6260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4f68248-a4ed-4798-a8e5-3a3adf481770
+      - aca1eb43-2075-4a35-bf01-ab635975d158
     status: 200 OK
     code: 200
     duration: ""
@@ -5941,10 +6271,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmpNRTVHYjFoRVZFMTZUVlJGZDA5VVJYcE5WR013VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVTh4Q2t0NVUyMDFNa1phVTJwT1UxbEVTWFZ1WlVNeGFFWmxUVzlvVlROQlkxVk5VRTF4WW5aUVlYWTNaMm8xYm05TFpHcEhOMjFHVGpkWWRqbHRWbTV2VWpFS05pc3hiSFo2VEVkVk5YZFhTM2hPZHpJeGRYaDVNSEp0YzJSTGEzZEZZak01Y21wTlEwOXpPVWxuTDBac05EQklTR2RTVlRjMlUyMUphbFZsZVN0c1ZncEVlamhYZUZVeGRVd3ZkVEE0TjBFdlNrNWhSamR3TUhseWNEbE5WWGhPVFZaQ2FYSllVWGR2VVZGVmJ6WnNXalUxV1RWdGJURlFWblEyVm5wMlIwWm5DbVpYT1hJeVdWVlRZamR0Y21GS2MwdE1WVWhHU2pJcmREQXhTMGR0UkVNMU9WTTRhVVZxT0dOblRtTlVaa2xrZDFOR1duVmpObmRYT1ZSR1pHZ3hjMllLYlRZdk1VRXdOVXMxWm1sWWQxRnJVWGR5VkRkak4xTnhTa1Z1TTFKR2FFWmtOMlIyVDJGb1Nta3JlR3A2VUVrMFNWcEVWRWRYVW1wbFR6bEhMMlY0Tndwak0xWkpMelZsZUZObE4yUTFWR0ZzVXpNNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlNGUm9WQzlQWW1oclQxQjZSRlI0V0ZFeWJqRjNWVFJ6UkhaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZVOWhkVWh0WW5OeE5XaHFWSEZGVkZaV2RtNVRTbWhWWVhCWldqZHllbFpoY1U0d2QxcHZlbHBsWmxadmIwUnZTZ3BJUzJ0dFdqWlBhbUZQYkRWemFrcEpaMHRWYkZaRWNIRnVSMW8xV1dFd2RUWldOWGMwYXl0eGMySndWV1pzY1hSdFIwNHpXR1pyUzNKM1V6VXJaV1I1Q210M2QwRnZNa1pGY25oU00zUnlXRVl3WTJ3MWNHaEtPVTVzVm1KeFNVb3hPVlJMZWtWTVR6RmpXamc1TkhWT1UzSmljVWQ2YjFCdWRGZDZhMEpHU2pjS1FsQkdVM0p1VEV0aVZWSTJUVVJyVTJkNVExVlBiMWRyVEhVNU1HeG1VVXhIZW5oS05FMTJSbGNyZDJSdFYxaHlOSHB4VDI1aE9ETkdjRmhsYW1GbmN3cDJla2wzYTFKUWN6Qm5PVXhRU200dlRrOTBlR3hCVldkV1ZtWk5hQ3RsV0hGRE5sQnRSM0k1VkROTWNrRndTRFJ5U0hVME0wbG5UVGRVT1VwMWVHbHZDazlZYm5KUllXdG5RVlpXU25vemNHUjVObkJ5ZUVReFFtRlZhVzk2WWxGNlZsTjZhd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNzQwMWRhNWUtMDk3My00Y2I2LTg0OGItZmZkM2Q4MmI3MDg4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoUEJVVEs3M0ZWaHQ2bEY2RFhodFp2aTZ2REU0Z2xtUjk2dndUbW44SFlpRm94ZWZNbUVrWGcycw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkpNRTFXYjFoRVZFMTZUVlJGZUUxcVJYcE9WRWt3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE5QQ214VWF6WllNMVZNU0daVmEzUmplWFJCYlM5SmJIQnBSMGRRYjI5b1lsUlhjekptY3pBeWMxaHVWRTUzTWtGWFVXSktRbWR3VGtGcVYyaGtXVkZvU1djS1FUVk5OV3AzVDFabU5rZFZWVFo0YTBoVFozRkxaVEZRV0hSc1NYVkhUekF2YlhGaFJWUk9RMFpoV0dKV2RsRkxSa0p3U1U1dVJ6VjZUbkJsYm1VeU9BbzVUR1pCV0dGYVYwdHpiVE5PY0VKTUwxcHJhRkpITW5OSk1YQnlVVmxSVFcwMldVbHFSRVZ2U1U1S2VtTTFjamxWVEdGSWVqbFJRbk0wTTFobVdFVnNDamxTS3pabFZWVnpTa0YyWkUxTVQyVTJlamd4TVRVdmFrWTFiMFY1ZWtNMVkwOXNSR2RKUjJNMGJraGpSVUl6WkVsa04waGpWbFJDUjNOTlRETlpXVTRLYVdjeVFrWnFjRFp4VnpONVlsbDJSV3hHYWpWeGQyVXhUVXN4WW1KR056YzBVekJRVWtsWk1HMTVaM0JWVWpOeFdYUkxiRUpXU2tKRk1qQXpVRTlUYWdwdk9FRnBkWFpaVlhVdmEzUXpaekZyT0hkalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1ZFNVhjMDA0TXpKNmRGQXlMMWhYVjJKdWEzbE1WRzFHYmk5TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRE1TdFlURkI0YVROR1FrZEZhWGhCVkdJNVVreEVNRU54TUZSdkt6ZFhVRlpoUkdKQ05reHVSblpFZFhSck1rNUxPUXB2UWs4MVlVUkhjbEZZVDNCSU0wUnBSbU5LY0hGaUt6Sm1WbmRTVlRod2MwRnhlakJUWlVvMVUyTXlXVWczUW5OMlNqWlBaQ3RMV0ZSaFdFb3ZaRWQzQ2xsSlZqRkhUV0kzTW0xRVRubGxhWEJaUkhFMmJuWTJkVE5LTUhkNGRXWXlUSEZPZWxWMVVUVjFOazVwYUZGbGIwazRiMkozUVdwTFVYSnRjelV4ZEVZS2MwZ3lNVzVZS3psYVEybExXQ3RZWjJ4WE0zTkRja3BrT1RsdlpGWkVhelZIVGpnclozSnVha3hSYlZkc2NISTFhbGxYU1d4c1dDOWFTekJSYjNWb0x3cFFOMDEyU1U1WU1YTkhLekZCTVhsM2MzaHZZa1JNV2taNFJ6aHdiSEZ4VTBGb1Jsa3pVMWRpTmxKUFFXTk5XVUpWVGtJeU5XRnhabFpvT0VaVEswbEZDa1EwWm10dlNIVnRhQzlUUTFBNU1qZGhiSGhwWlRORU4yVjNkMmxWUkRCU1RpdFJZd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTI1MzcwNGQtOTkzYy00MTkzLTgwMjItMDdhNzExZjBmMDE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFNG9CRVI4Z1dSOUtaNjFmdWRrYXRadzV1bTVsOFRBTlRTU29ibk03SFFpMnlGYWN1VVZuSHNjNA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2638"
@@ -5953,7 +6283,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
+      - Mon, 13 Nov 2023 14:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5963,7 +6293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a426fba-621b-432b-b8b1-b5c20342cc14
+      - 62f95fee-6775-49d5-868b-4d870541edc4
     status: 200 OK
     code: 200
     duration: ""
@@ -5974,10 +6304,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:47.506901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:03:38.431597Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -5986,7 +6316,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:54 GMT
+      - Mon, 13 Nov 2023 14:03:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5996,7 +6326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7a2eb2a-2948-468c-8e9c-ceebf2b61c09
+      - 02e64006-8f16-4e1f-b46d-7d3331ef4e3a
     status: 200 OK
     code: 200
     duration: ""
@@ -6007,10 +6337,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088/nodes?order_by=created_at_asc&page=1&pool_id=87fd8bd2-12e9-4f7b-ab31-d9d617a3099d&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014/nodes?order_by=created_at_asc&page=1&pool_id=a69311ee-4867-49c5-85da-c4633fb8693d&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:25:34.112136Z","error_message":null,"id":"0b722196-710e-49dd-8c90-6b4bc0d656ca","name":"scw-test-k8s-public-i-test-k8s-public-i-0b7221","pool_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","provider_id":"scaleway://instance/fr-par-1/297e5d54-9b93-4e61-9723-750675a5cf6b","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:47.491253Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:00:46.803987Z","error_message":null,"id":"4e07bd6c-a990-4eab-a29f-b84960556314","name":"scw-test-k8s-public-i-test-k8s-public-i-4e07bd","pool_id":"a69311ee-4867-49c5-85da-c4633fb8693d","provider_id":"scaleway://instance/fr-par-1/5b3876b7-4310-49af-b057-c8ea39b95e82","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:03:38.415246Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "645"
@@ -6019,7 +6349,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:54 GMT
+      - Mon, 13 Nov 2023 14:03:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6029,7 +6359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8492f994-9582-4511-8641-7d8651bc3e6a
+      - 13087f89-46a4-45cc-9d66-d2479b1f186d
     status: 200 OK
     code: 200
     duration: ""
@@ -6040,10 +6370,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226096880Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:46.261061640Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "632"
@@ -6052,7 +6382,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:55 GMT
+      - Mon, 13 Nov 2023 14:03:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6062,7 +6392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51913075-52fc-40d1-b63b-61356be1c5b8
+      - 9706de74-bd32-43e0-b55e-6e6b02c39bf3
     status: 200 OK
     code: 200
     duration: ""
@@ -6073,10 +6403,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:46.261062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -6085,7 +6415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:55 GMT
+      - Mon, 13 Nov 2023 14:03:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6095,7 +6425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcb199bc-9272-4105-b62d-ff5a3accfb5f
+      - 5c191a54-edf5-449b-9077-71416461cc6b
     status: 200 OK
     code: 200
     duration: ""
@@ -6106,10 +6436,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:46.261062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -6118,7 +6448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:00 GMT
+      - Mon, 13 Nov 2023 14:03:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6128,7 +6458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c3aea9d-c398-48c9-85ac-885883e2255f
+      - 7c9296ae-b955-423d-999b-549ff9bb014e
     status: 200 OK
     code: 200
     duration: ""
@@ -6139,10 +6469,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:46.261062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -6151,7 +6481,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:05 GMT
+      - Mon, 13 Nov 2023 14:03:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6161,7 +6491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db9c180e-80ea-4230-ad83-55637b7fe6d2
+      - fadf6d93-60a0-4d47-9f80-503b37f51f5b
     status: 200 OK
     code: 200
     duration: ""
@@ -6172,10 +6502,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:46.261062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -6184,7 +6514,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:10 GMT
+      - Mon, 13 Nov 2023 14:04:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6194,7 +6524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cfaa77b-b7c3-420e-9df6-44e0ad7d6bfd
+      - 6f94d276-f16f-4388-9fa0-1d9b178d31b9
     status: 200 OK
     code: 200
     duration: ""
@@ -6205,10 +6535,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:46.261062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -6217,7 +6547,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:15 GMT
+      - Mon, 13 Nov 2023 14:04:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6227,7 +6557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfc58697-c852-4457-840f-69427a98aeb6
+      - 5f3c6a9d-7a65-467e-8bd5-3a4d05a99fc6
     status: 200 OK
     code: 200
     duration: ""
@@ -6238,10 +6568,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:46.261062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -6250,7 +6580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:20 GMT
+      - Mon, 13 Nov 2023 14:04:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6260,7 +6590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2565b371-ae6e-4e2c-a630-310d62da298e
+      - ef33d42c-bb75-4646-98c6-c712b52fa211
     status: 200 OK
     code: 200
     duration: ""
@@ -6271,10 +6601,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","container_runtime":"containerd","created_at":"2023-11-10T13:23:18.393335Z","id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:27:55.226097Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"a253704d-993c-4193-8022-07a711f0f014","container_runtime":"containerd","created_at":"2023-11-13T13:58:57.189804Z","id":"a69311ee-4867-49c5-85da-c4633fb8693d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:03:46.261062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -6283,7 +6613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:25 GMT
+      - Mon, 13 Nov 2023 14:04:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6293,7 +6623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ffc2705-293a-4664-b115-6c67a3934f54
+      - 9f09f885-fba9-4507-9bc1-559071d55a40
     status: 200 OK
     code: 200
     duration: ""
@@ -6304,10 +6634,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"a69311ee-4867-49c5-85da-c4633fb8693d","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -6316,7 +6646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:30 GMT
+      - Mon, 13 Nov 2023 14:04:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6326,7 +6656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 983aa022-2ba3-4d29-8913-33678235d3bc
+      - 10638a73-bbac-438c-bac7-bf4801a0210f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6337,10 +6667,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:28:30.651777855Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T14:04:21.817896051Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1506"
@@ -6349,7 +6679,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:30 GMT
+      - Mon, 13 Nov 2023 14:04:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6359,7 +6689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5fd3b26-0c78-40dd-b409-d0ed45513c69
+      - f73230b3-4d2b-4414-ad6a-40a5d03cd37b
     status: 200 OK
     code: 200
     duration: ""
@@ -6370,10 +6700,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:28:30.651778Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T14:04:21.817896Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -6382,7 +6712,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:30 GMT
+      - Mon, 13 Nov 2023 14:04:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6392,7 +6722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcb3e6d0-fd6c-49be-b682-ceef53e8aa1c
+      - 80c62d46-ef68-4f56-96fd-585de84ffdee
     status: 200 OK
     code: 200
     duration: ""
@@ -6403,10 +6733,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://7401da5e-0973-4cb6-848b-ffd3d82b7088.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:42.433361Z","created_at":"2023-11-10T13:17:42.433361Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.7401da5e-0973-4cb6-848b-ffd3d82b7088.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-10T13:28:30.651778Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a253704d-993c-4193-8022-07a711f0f014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:34.691066Z","created_at":"2023-11-13T13:52:34.691066Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a253704d-993c-4193-8022-07a711f0f014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a253704d-993c-4193-8022-07a711f0f014","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-13T14:04:21.817896Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -6415,7 +6745,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 14:04:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6425,7 +6755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5090017-acc2-4ff2-973a-4b404ff7eb9d
+      - d8821702-8920-4493-a4a0-aefb2765440f
     status: 200 OK
     code: 200
     duration: ""
@@ -6436,10 +6766,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a253704d-993c-4193-8022-07a711f0f014","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6448,7 +6778,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:40 GMT
+      - Mon, 13 Nov 2023 14:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6458,7 +6788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aa6a066-b8fd-42fc-8599-fd0ab34b5a46
+      - 332fd746-60bf-4cb1-8830-338cf6cd8a44
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6469,10 +6799,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"ready","updated_at":"2023-11-10T13:23:17.262590Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"ready","updated_at":"2023-11-13T13:58:55.867833Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -6481,7 +6811,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:40 GMT
+      - Mon, 13 Nov 2023 14:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6491,7 +6821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81728329-35d4-48e2-9b64-f1f0b009449c
+      - 5e9b9529-a174-4141-a3dd-4693b12674f8
     status: 200 OK
     code: 200
     duration: ""
@@ -6502,7 +6832,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -6512,7 +6842,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:40 GMT
+      - Mon, 13 Nov 2023 14:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6522,7 +6852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95a01fef-1e77-42f8-8295-55bd21faeb85
+      - a68d68ac-8408-4ea4-897c-f4ff7e53bc41
     status: 204 No Content
     code: 204
     duration: ""
@@ -6533,10 +6863,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-10T13:23:07.676263Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-10T13:23:00.796835Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08348404-aed3-4b73-9f45-3c428b1836f2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-10T13:23:00.796835Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","ipam_config":null,"mac_address":"02:00:00:14:B3:C1","private_network_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","status":"detaching","updated_at":"2023-11-10T13:28:40.951242Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-13T13:58:46.412374Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-13T13:58:39.400750Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-13T13:58:39.400750Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","ipam_config":null,"mac_address":"02:00:00:14:BD:9C","private_network_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","status":"detaching","updated_at":"2023-11-13T14:04:32.361010Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1000"
@@ -6545,7 +6875,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:41 GMT
+      - Mon, 13 Nov 2023 14:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6555,7 +6885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 204730d2-1d28-4004-8087-47ac1403520f
+      - 116b0534-d383-4ff2-b48b-7467a722251f
     status: 200 OK
     code: 200
     duration: ""
@@ -6566,10 +6896,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -6578,7 +6908,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6588,7 +6918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 918b98f9-cecd-4465-9e57-9cf42bcbb7d1
+      - b7865ec9-4a1b-48dc-9867-663b8210b89e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6599,19 +6929,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:55.989598Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "976"
+      - "978"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6621,7 +6951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0deefb2f-7b3d-4c72-ab43-a120a5f8d0a2
+      - 0729c1e0-e8a4-466c-a243-eee6e45fad6d
     status: 200 OK
     code: 200
     duration: ""
@@ -6632,19 +6962,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-10T13:23:01.508994Z","gateway_networks":[],"id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","ip":{"address":"51.15.130.8","created_at":"2023-11-10T13:23:01.485304Z","gateway_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","id":"ce58b485-d737-4a49-89b2-a5d3ebecab8d","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"8-130-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-10T13:23:01.485304Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-10T13:23:17.363432Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T13:58:55.989598Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "976"
+      - "978"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6654,7 +6984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d51b6445-a8ff-4784-adbe-07499f0cee63
+      - 99d6a3f0-1107-429a-9a49-49f1bc4d7175
     status: 200 OK
     code: 200
     duration: ""
@@ -6665,7 +6995,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08348404-aed3-4b73-9f45-3c428b1836f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/d5a14f97-3df0-40ed-8173-f6138ded8f52
     method: DELETE
   response:
     body: ""
@@ -6675,7 +7005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6685,7 +7015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a845c606-4336-4a59-928a-9a93a218b945
+      - 22037cae-d899-4e5d-9d9d-8750a69178e1
     status: 204 No Content
     code: 204
     duration: ""
@@ -6696,7 +7026,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -6706,7 +7036,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6716,7 +7046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62aaa626-1cfa-47a3-8ed1-184135e7d51d
+      - 284bb7c3-e169-4296-a05c-da547fd272d0
     status: 204 No Content
     code: 204
     duration: ""
@@ -6727,10 +7057,74 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","type":"not_found"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-13T13:58:40.056542Z","gateway_networks":[],"id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","ip":{"address":"51.15.214.66","created_at":"2023-11-13T13:58:40.018551Z","gateway_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","id":"9d0f7d75-592b-4f39-93c8-4847bde4ddee","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"66-214-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-13T13:58:40.018551Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-13T14:04:37.592514Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "979"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 66e6be7f-8194-40ee-b892-a2862f9ea1f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201d62ac-4232-462f-b8a8-e5767d25d71e
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:04:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6e956cb1-d9f9-4bf8-ad57-6a9aca0e100d
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6739,7 +7133,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6749,7 +7143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 340ab44a-c530-4daf-b7d6-83f0e7814100
+      - 3412d3bc-9ba5-42f3-a6d6-b999e57883e2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6760,107 +7154,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04b4de15-6e7f-478d-9102-d9ddcfb8a191
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5fb3260f-c0f4-4d87-bafa-a4e3dd39d690
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a69311ee-4867-49c5-85da-c4633fb8693d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"5fb3260f-c0f4-4d87-bafa-a4e3dd39d690","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0fa34a0f-9206-40bd-bb9c-86d53952035b
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"0f0a2afc-a8e3-47a2-8e8c-5c37d48442cb","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae97cb85-974e-4afa-a217-d194b29891da
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08348404-aed3-4b73-9f45-3c428b1836f2
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"08348404-aed3-4b73-9f45-3c428b1836f2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"a69311ee-4867-49c5-85da-c4633fb8693d","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -6869,7 +7166,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6879,7 +7176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6785ffe-21c9-4650-b414-c3ee8a2b9ab3
+      - 049b7998-59de-4978-923b-5b913fab8008
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6890,43 +7187,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/475cf7dd-0d24-4df6-b1b2-ee143a4184da
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a253704d-993c-4193-8022-07a711f0f014
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"475cf7dd-0d24-4df6-b1b2-ee143a4184da","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2cc2d951-20bd-4c01-a03a-44f77c9b7fbd
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7401da5e-0973-4cb6-848b-ffd3d82b7088
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"7401da5e-0973-4cb6-848b-ffd3d82b7088","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a253704d-993c-4193-8022-07a711f0f014","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6935,7 +7199,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6945,7 +7209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb59d151-1e20-4c35-8d4a-5a33965ae272
+      - 05d855d4-e99a-4331-8256-7a0b7381bfe6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6956,19 +7220,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/87fd8bd2-12e9-4f7b-ab31-d9d617a3099d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b6bc61b5-446f-48ed-b273-d6aa67dd43e2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"87fd8bd2-12e9-4f7b-ab31-d9d617a3099d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"b6bc61b5-446f-48ed-b273-d6aa67dd43e2","type":"not_found"}'
     headers:
       Content-Length:
-      - "125"
+      - "136"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:46 GMT
+      - Mon, 13 Nov 2023 14:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6978,7 +7242,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e45ed8a-a451-4604-8f65-0e94912ffec5
+      - ae69d269-bc0b-4312-9f91-1fd220deacf1
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/d5a14f97-3df0-40ed-8173-f6138ded8f52
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"d5a14f97-3df0-40ed-8173-f6138ded8f52","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c328c9e6-d7eb-4b3f-83f5-ec9033c240f3
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/4eae3d30-edfe-40b3-b67e-50b9760f2459
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"4eae3d30-edfe-40b3-b67e-50b9760f2459","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08ca247d-a310-4d78-8cd1-10f99dca9200
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/201d62ac-4232-462f-b8a8-e5767d25d71e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"201d62ac-4232-462f-b8a8-e5767d25d71e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a547d7f2-fa6a-4163-a318-b4828d941d66
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-size.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-size.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aec85d74-aa65-4b49-a1dc-43ba0be89695
+      - df20cb54-4d52-4127-b419-7016fb5e09fe
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:12.541187Z","dhcp_enabled":true,"id":"b0f61662-2be0-45f7-9348-462f77e21e73","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:12.541187Z","id":"dd4a2384-4ff8-4592-8b5c-6af909f6f789","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:52:12.541187Z"},{"created_at":"2023-11-13T13:52:12.541187Z","id":"b9483813-0f12-4103-a33a-d9b47b2ebe46","subnet":"fd63:256c:45f7:f41d::/64","updated_at":"2023-11-13T13:52:12.541187Z"}],"tags":[],"updated_at":"2023-11-13T13:52:12.541187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "714"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:57 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b083d2e9-e472-4316-9eaa-3ed693f3b9e1
+      - 1b37394d-f818-423f-909f-bc49b4ce20cf
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b0f61662-2be0-45f7-9348-462f77e21e73
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:12.541187Z","dhcp_enabled":true,"id":"b0f61662-2be0-45f7-9348-462f77e21e73","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:12.541187Z","id":"dd4a2384-4ff8-4592-8b5c-6af909f6f789","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:52:12.541187Z"},{"created_at":"2023-11-13T13:52:12.541187Z","id":"b9483813-0f12-4103-a33a-d9b47b2ebe46","subnet":"fd63:256c:45f7:f41d::/64","updated_at":"2023-11-13T13:52:12.541187Z"}],"tags":[],"updated_at":"2023-11-13T13:52:12.541187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "714"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:57 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd08a2ea-9f20-4f68-ba50-79ee7faa677c
+      - 73ba9142-8ccb-426a-bf71-9962f9abd1e7
     status: 200 OK
     code: 200
     duration: ""
@@ -129,7 +129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:57 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,12 +139,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afc8971a-5e2a-4888-b79f-686010eed7c5
+      - 334bbf2a-ea59-4e04-b01e-5be16cd0650c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-size","description":"","tags":null,"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":true,"maintenance_window":{"start_hour":12,"day":"monday"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-size","description":"","tags":null,"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":true,"maintenance_window":{"start_hour":12,"day":"monday"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73"}'
     form: {}
     headers:
       Content-Type:
@@ -155,7 +155,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138060Z","created_at":"2023-11-10T13:22:57.814138060Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:57.826254485Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442239780Z","created_at":"2023-11-13T13:52:13.442239780Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:52:13.452796501Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1458"
@@ -164,7 +164,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:57 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -174,7 +174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c41ee47b-f03d-4fd7-be4c-fe2aab7a1c32
+      - 36a617c9-d441-43fd-9a64-277812b1f8ab
     status: 200 OK
     code: 200
     duration: ""
@@ -185,10 +185,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:57.826254Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:52:13.452797Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1449"
@@ -197,7 +197,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:58 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f9ef933-edd0-44c4-a202-22273fedbbee
+      - 8692275f-3e21-44d2-aaac-c05a23090656
     status: 200 OK
     code: 200
     duration: ""
@@ -218,10 +218,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:59.485973Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:52:17.982853Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1454"
@@ -230,7 +230,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:03 GMT
+      - Mon, 13 Nov 2023 13:52:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e7f1eb4-85ce-469d-9bab-1a385cc0981a
+      - 130c98ce-60c6-4c17-ad15-75552dd29ba3
     status: 200 OK
     code: 200
     duration: ""
@@ -251,10 +251,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:59.485973Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:52:17.982853Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1454"
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:03 GMT
+      - Mon, 13 Nov 2023 13:52:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aef15ec7-1aae-46b3-8458-caad0c6fe1b2
+      - 45841bb3-65a7-480b-9ba9-e51566e1e502
     status: 200 OK
     code: 200
     duration: ""
@@ -284,10 +284,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwSk1VOVdiMWhFVkUxNlRWUkZkMDlVUlhwTmFra3hUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRIaDNDamgzUW1Jdk9EQnBaakF6Tm5wcGIyUmxSRlUxVW0xa1RYSlBObUkxYWxSblNteHRiWFpKTkZRNVZGQlZhMDlqVTNOM09FeFFRVFJ3VVVORFozTkdXVGdLZEdkTGJGVnBTMlZVT0VaelUwUm5LelZKU0dRNWNGWTRZbFJxWTJOQlltMXdWMmxpV0hWVU0wZDBZaTlxWkUxSVkydEhRMUpWYjBoTVJYbHJRa05oY1Fwd2VtTkpXRU14YXpsalNGVkViMGxuWlZwWFpqaDNabTQyTUZKdGFHOXBUbWhRWmt0d05XbFBVREZvY2xaUlJGWmhNVEJpUkRFclUyeG1jVnBFWjBKeENrRk5aRE5rTmpaWUswVmpiVkppUzBNelZrTkdXRlJLWWxoWU4yVjZlbGMwTUdSdWJrRlRVSFl3YUVKaGRuWnNaRlJXT1ZkdE5XeFBjVkkyUkN0aVZFTUtSM0F6WnpscVEyZ3JkbE5yYjJwMGJXSnVhWEV5UkdkUU5tZGllVTRyU2poc1ZFZDBMMlpLWWpWT0wxVmxVamhETjFobFIxcHBZMHgyTkhVMWEzRnlXUXBDYWxadmF5dEhjbmhqVDB3d0swaGFLMlpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWTA5QksyUm1kREZxZDFKSVVraFVVVE5IYW5JM1JETjVSMDFOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDUVZaRFUyeDZkbmsyYWpaVFNuUXZSREpwZUhWemFUWjNWMk5hTldOV1RGUjRMeXQwWkZGRGJYQlJXWGR5WlZsalVncEZkMUYzYUhSd2JsVjFhSFp6T0ZOUVpXeElTVmhGVVhNNVVHTnZOVlpUUjJKRFdrcDJRbXBOVDI0eE9HOTJVelpHTm1Fd2MwcFZhVE5hVmt4QmExWndDblF3UzNWV2FuSjZjM3BaYmxkTGFYVlJPRGhvWkRGVmFISlVlV1o0WlV3NVlYRTVaekZTYWtoU05VaFFiRWsySzNSbmJGTkVaVkEwYmk5R2JuUnhTMUlLUkRRcldGSTNXR2xHTTJ0UlpFeHZkRzFVZEc5dVJ6ZHVWQzk2THpWdGNHdGpPSEp0YVRObE5YZHhaamhhVTI1MWFpOW9WVXhqYmpJcmFFUnRNM3BhYlFwa01WbFJNbTlsYTBkNFZtdHdXRlJsYm5sV2ExTmpSRU4yTlZrd1dGSkpkMlV5VDI0d2RWTnVaRE4wUTNwb2EwUTFibEJSZGt0eE5uRnJhVUZIVVhCVkNtcEZhVkowYmpoYWEyODJkbmRRYTBWSlJIaEtTSEJVV21wRlJ6QjFaVlpTVTNSQ1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jYjdlZjE1NC1mY2IxLTRhZWItOWNmOC1mNWUxNGUyZmFjYzQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPc3R5aGVlQkhtempYckdLS1poWGpxY1JNdGFVY2xNdzlIemFwUllKWmd5ajdtbnVLOTFHWmFkdA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSSmVFNUdiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFbDRUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRVdExDbFpRVUVNeWNrZHlhbEpWTDNVeWMzQTRPRWsxTW5sWUwyVXphazlxUzFNclkzSm5MM1ZRTm1WamVFd3pLMmxXYXpGblFXTnFURmxVVFVaaFpsUjNRbG9LVGpSb1FXZFRVRTVqT0U5T05VYzNaUzlQT1hSVVVXNXBNRTlCZDBGT2J6UjRUM1ZHY0hKR1VrNVBUWHBXZUdOSlMxQlRNV1Z6VFUwMWEyOURaMGdyVEFwd2VESkxTM1EyUkRSMGFuZzNhSE56WWpGUU4wTm9hWGh5WTBaTVNtRmlkR2RIV1N0RldqUjViMk5oZEVGNGF6WjFORzlvTUZwc04wbHdUVmR1Y3poNUNsbERTVU5SZFc5bFpETnZlall4WXpWaFR6UnRXa3BYVjI1Qk9VTktOMlZZVUZCdEwwNXdRbWQ2WTNjeU1tUXdVVlY0YlZkTFJtdEpRbVp0U1V0S2RGVUtZaXN6VVU5dlp6VlVVbVJJY21SVmJHeDZOMGRKUlRkdE1qQmpkbWRhU2xkdGNGRjNZVGhUTmtGQ01XdGhLMVZSVDBWc01XMHJhMk5YZDFKVFEzTXdiQXBtTmxOMVRIUmFhMnhCYTFwUGMzQTFOMXBqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPUlU1V1J5ODJkRzFsY1ZnM1pHeG1XV1pWTVZsRFRYbzRjV2ROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYUM5MVNGSnVlbUp4VERSNVFVRm1SMGxqYzI1UEwwUXhXalpGYW1Fd2RYbDRLMFUxY0VORFZrTkNZV2hNYXpaWE5RbzNVVTQxV0dwSWFua3lNREprV0haS1pVVkVPVmRYTVU1RGQyOXdVV0Z3UTI4eFpEbEpZMmR0UzI5clZtRlFWVzgxWjJjNWN5dHFRaXRFYlRFMlREQlVDa3RCTWxweFdFRklWMDFSTW1NNWRXUXlUSGc0U1RWT1IyWktVRW93VlV0U1NrbHRPRkJpWlhOcmVVUjZXRWxMUTFkNlQxazRZVXB3YkdzNGFHZzNSbE1LYlRCbk9GY3lUa0ZHV1VSTmIwaHRjMFJSZG10RkszRnZjU3N6ZFdGR1JUSTBRelJNV0RKMVZFMXJTWEpHSzFVd0syNU9SMlJuTkdoVWJXYzRlSFpKYndwaVlXOHlWSGx3SzNsd04xQlFNbTR2TkVGa1RXRkNjbEJvVnpCU1l6TmhUVzlSYjFScVRsaFRXVWxvVDFoMVFUSkVUbVJHZDNCWVNsVmFWRmxrTURkcUNubzBaWE5EU1RGR1FsRkRVWE5wTUdaRVRtNXhPRUpYTld3eVpFZHJiemxMVTAxR1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lY2QwZDI3OC05NWQwLTQ1ZGMtOGY2Yi03MmJkYjcyODQ1YzguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYRGg0RGl4SkxpRUxJMmhsUEpSMjM1VHY2eVlBODZZQjdVTlF0WTN3OVR5dmM2NjlyWHoyeGRmSA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -296,7 +296,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:03 GMT
+      - Mon, 13 Nov 2023 13:52:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 895c8277-b6c1-4516-992a-67f98c0f2e49
+      - 354777f0-1140-4a13-ba82-c3b4c5da1e49
     status: 200 OK
     code: 200
     duration: ""
@@ -317,10 +317,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:22:59.485973Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:52:17.982853Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1454"
@@ -329,7 +329,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:03 GMT
+      - Mon, 13 Nov 2023 13:52:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29906876-0e10-4c27-a424-04743793bc3a
+      - df4df9c0-dea7-4482-9b1a-fa5622175b1b
     status: 200 OK
     code: 200
     duration: ""
@@ -352,10 +352,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468106Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919840937Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "618"
@@ -364,7 +364,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:03 GMT
+      - Mon, 13 Nov 2023 13:52:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -374,7 +374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ae31d64-3178-463c-aff5-ec3474961266
+      - c4d032f9-dd7f-4893-8d91-48c1c467ee16
     status: 200 OK
     code: 200
     duration: ""
@@ -385,10 +385,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -397,7 +397,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:03 GMT
+      - Mon, 13 Nov 2023 13:52:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -407,7 +407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12020088-f25f-444b-becd-720e36137262
+      - 7a839eec-ae0e-419d-82f8-042d901900b5
     status: 200 OK
     code: 200
     duration: ""
@@ -418,10 +418,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -430,7 +430,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:08 GMT
+      - Mon, 13 Nov 2023 13:52:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -440,7 +440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a33626b-4e6f-4fac-98c2-15845d00d8d9
+      - 89c8286c-b011-42be-96db-5d00cca7d7ee
     status: 200 OK
     code: 200
     duration: ""
@@ -451,10 +451,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -463,7 +463,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:13 GMT
+      - Mon, 13 Nov 2023 13:52:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc2c71c4-eac3-48e6-9f5a-e7221a3cb622
+      - 5e44348b-a15f-4cfc-8b96-f231455299b4
     status: 200 OK
     code: 200
     duration: ""
@@ -484,10 +484,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -496,7 +496,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
+      - Mon, 13 Nov 2023 13:52:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -506,7 +506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89f17f19-7978-400a-84ca-eba04bc77c9d
+      - 77df1a4d-7976-47f7-9f63-a1e6150bf027
     status: 200 OK
     code: 200
     duration: ""
@@ -517,10 +517,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -529,7 +529,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:23 GMT
+      - Mon, 13 Nov 2023 13:52:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -539,7 +539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1961c5b7-a878-44bd-89e8-4abd880333e4
+      - 62b03e06-f7c3-4c34-aadd-348554e61202
     status: 200 OK
     code: 200
     duration: ""
@@ -550,10 +550,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -562,7 +562,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:28 GMT
+      - Mon, 13 Nov 2023 13:52:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -572,7 +572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f883640-e65e-487c-8e65-27422297cbe3
+      - 0b5d1f59-856d-4ca1-9138-a3597ee245ad
     status: 200 OK
     code: 200
     duration: ""
@@ -583,10 +583,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -595,7 +595,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:33 GMT
+      - Mon, 13 Nov 2023 13:52:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27180872-a5cc-49bf-9ca4-14a5b596b32a
+      - c6198b31-a750-4181-8434-ded8dfce95c9
     status: 200 OK
     code: 200
     duration: ""
@@ -616,10 +616,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -628,7 +628,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:39 GMT
+      - Mon, 13 Nov 2023 13:52:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e81eb9f-db2c-4300-9d4c-3a189ad699e8
+      - 0ec45380-c81f-4b96-bb8b-25b208c919e0
     status: 200 OK
     code: 200
     duration: ""
@@ -649,10 +649,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -661,7 +661,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:44 GMT
+      - Mon, 13 Nov 2023 13:52:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c40b4be8-f316-41bb-9fb6-636302322d38
+      - 4652e3ce-1ac4-49e0-b576-9593e08b2261
     status: 200 OK
     code: 200
     duration: ""
@@ -682,10 +682,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -694,7 +694,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:49 GMT
+      - Mon, 13 Nov 2023 13:53:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -704,7 +704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3997e82-98e6-4eef-9e32-500dc554b18c
+      - 31719f53-f553-470f-9a2a-1797a9a6afd2
     status: 200 OK
     code: 200
     duration: ""
@@ -715,10 +715,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -727,7 +727,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:54 GMT
+      - Mon, 13 Nov 2023 13:53:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -737,7 +737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 346dae92-989d-4e0a-b3e9-14883ca1e9a9
+      - fd4d50c8-2840-41c9-9fbb-07834b3e9772
     status: 200 OK
     code: 200
     duration: ""
@@ -748,10 +748,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -760,7 +760,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:59 GMT
+      - Mon, 13 Nov 2023 13:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -770,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - beb63a14-3b7f-41fd-ab9f-72d1176030ad
+      - 7c874ee3-9cfb-47bd-bd9f-42c96ec6e044
     status: 200 OK
     code: 200
     duration: ""
@@ -781,10 +781,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -793,7 +793,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:04 GMT
+      - Mon, 13 Nov 2023 13:53:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -803,7 +803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5fe00b0-df93-4582-97ce-68c65f1a5fc2
+      - 6b064900-8194-4239-9cb0-fc46e3fceecb
     status: 200 OK
     code: 200
     duration: ""
@@ -814,10 +814,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -826,7 +826,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:09 GMT
+      - Mon, 13 Nov 2023 13:53:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 494a68ad-014b-4a01-b156-390e357c7ac7
+      - 002878a9-c5f3-4715-9312-877764a5d5c5
     status: 200 OK
     code: 200
     duration: ""
@@ -847,10 +847,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -859,7 +859,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:14 GMT
+      - Mon, 13 Nov 2023 13:53:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -869,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23ee9bb4-512a-4146-8d31-9f6b143cd409
+      - 91dd0417-30d5-4a6b-8953-0b0e583909e6
     status: 200 OK
     code: 200
     duration: ""
@@ -880,10 +880,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -892,7 +892,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:19 GMT
+      - Mon, 13 Nov 2023 13:53:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -902,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c09690c7-bafc-4fee-933c-fe6c239c295e
+      - 3be27d80-82ed-459d-bd8a-155cd71e8381
     status: 200 OK
     code: 200
     duration: ""
@@ -913,10 +913,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -925,7 +925,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:24 GMT
+      - Mon, 13 Nov 2023 13:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -935,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4088f29a-dd18-4320-8f20-e0bf254ea50a
+      - 31d46308-98bf-4bd0-a390-abf376baa8a9
     status: 200 OK
     code: 200
     duration: ""
@@ -946,10 +946,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -958,7 +958,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:29 GMT
+      - Mon, 13 Nov 2023 13:53:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -968,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e35ff14-f8b1-4c95-860f-0000e505c0d9
+      - d0227bc5-e762-40fb-a00d-09113c4046b1
     status: 200 OK
     code: 200
     duration: ""
@@ -979,10 +979,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -991,7 +991,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:34 GMT
+      - Mon, 13 Nov 2023 13:53:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1001,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce501c9e-f696-4dba-a218-ec8cb3526348
+      - 594b02c5-45ae-47fb-8fe6-b80d6c39195b
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,10 +1012,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1024,7 +1024,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:39 GMT
+      - Mon, 13 Nov 2023 13:53:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1034,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0edb59b2-0112-4749-a2dd-93e32dd37a01
+      - 4511c97f-0a4f-478e-a7fb-25f670b836d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,10 +1045,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1057,7 +1057,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:44 GMT
+      - Mon, 13 Nov 2023 13:54:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1067,7 +1067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fb84550-caaf-4127-bdfd-327fda855685
+      - 0e915e32-7588-4c3d-9a16-4b2ffef46aca
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,10 +1078,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1090,7 +1090,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:50 GMT
+      - Mon, 13 Nov 2023 13:54:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1100,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70330de7-733c-4d43-a23f-542a0200fa8c
+      - 2f589d04-6e26-453b-981b-e62a187e093e
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,10 +1111,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1123,7 +1123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:55 GMT
+      - Mon, 13 Nov 2023 13:54:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1133,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8dd9713-9f35-4c1b-9ff3-0d845f7cf011
+      - f9fa9a1c-3755-4d36-80ca-45f9805e91d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1144,10 +1144,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1156,7 +1156,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:00 GMT
+      - Mon, 13 Nov 2023 13:54:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 995c1b2d-fb6e-411f-8ce9-175f2fe57a1a
+      - e860db72-8ebd-4597-b4a2-9cdfdbeea0e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1177,10 +1177,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1189,7 +1189,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:05 GMT
+      - Mon, 13 Nov 2023 13:54:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 380cd98a-a3d4-44db-9041-c9f6f737d12e
+      - b31991ce-80c3-4f3f-a602-d411ab296eb2
     status: 200 OK
     code: 200
     duration: ""
@@ -1210,10 +1210,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1222,7 +1222,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:10 GMT
+      - Mon, 13 Nov 2023 13:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b884533c-fcbb-4a11-a901-9dd4d227a75f
+      - ee3fd982-4f60-4e6b-93d7-c5f3550ac141
     status: 200 OK
     code: 200
     duration: ""
@@ -1243,10 +1243,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1255,7 +1255,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:15 GMT
+      - Mon, 13 Nov 2023 13:54:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1265,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a47d3386-51aa-44a6-8d26-49ff83ced82f
+      - 7eee9aad-86b9-41c4-8da1-abc22d5ac03d
     status: 200 OK
     code: 200
     duration: ""
@@ -1276,10 +1276,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1288,7 +1288,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:20 GMT
+      - Mon, 13 Nov 2023 13:54:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1298,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e81c470b-fb35-4ec2-9815-cae94e7d4998
+      - 95f72d7c-f034-4a31-a11f-1b87ed58676a
     status: 200 OK
     code: 200
     duration: ""
@@ -1309,10 +1309,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1321,7 +1321,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:25 GMT
+      - Mon, 13 Nov 2023 13:54:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1331,7 +1331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfa6ec79-fc23-4156-8277-ff19ee50cd88
+      - ee60a32b-9081-4d69-8c09-48ad601f66d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1342,10 +1342,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1354,7 +1354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:30 GMT
+      - Mon, 13 Nov 2023 13:54:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1364,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73f6c5eb-5fbd-44ce-b6d8-16e8ceb7ac8c
+      - ebee93d8-7827-4a60-8dea-1c54738e1dc1
     status: 200 OK
     code: 200
     duration: ""
@@ -1375,10 +1375,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1387,7 +1387,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:35 GMT
+      - Mon, 13 Nov 2023 13:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1397,7 +1397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3536b32-ae8b-492b-a4da-3e441d7df011
+      - f283c695-3f59-4986-a8eb-892bb5707868
     status: 200 OK
     code: 200
     duration: ""
@@ -1408,10 +1408,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1420,7 +1420,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:40 GMT
+      - Mon, 13 Nov 2023 13:54:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1430,7 +1430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7e8fc3f-023d-4593-872b-794dc6e4f081
+      - 76f5efb6-409d-4922-808a-d24a7895579a
     status: 200 OK
     code: 200
     duration: ""
@@ -1441,10 +1441,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1453,7 +1453,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:45 GMT
+      - Mon, 13 Nov 2023 13:55:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1463,7 +1463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea9e9e51-1e60-4772-8867-843270ef7851
+      - a929b5e5-c42b-4d62-a54e-b20665b5214a
     status: 200 OK
     code: 200
     duration: ""
@@ -1474,10 +1474,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1486,7 +1486,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:50 GMT
+      - Mon, 13 Nov 2023 13:55:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1496,7 +1496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 503cf21e-9b26-417b-bdba-abdd63a96c11
+      - 129795ac-3a1c-4093-b684-527fbc5e4594
     status: 200 OK
     code: 200
     duration: ""
@@ -1507,10 +1507,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1519,7 +1519,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:55 GMT
+      - Mon, 13 Nov 2023 13:55:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1529,7 +1529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 596400f4-d37f-4ea1-96e1-a19688f7ef4d
+      - c51ac6cf-a54e-45b2-929e-8976cd7c21e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1540,10 +1540,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1552,7 +1552,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:00 GMT
+      - Mon, 13 Nov 2023 13:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,7 +1562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25bb3c47-b42e-4a52-bad4-d9fba1c65002
+      - f9988428-f326-4d7d-81fb-220b1ebd3ad1
     status: 200 OK
     code: 200
     duration: ""
@@ -1573,10 +1573,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1585,7 +1585,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:05 GMT
+      - Mon, 13 Nov 2023 13:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1595,7 +1595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9326bf1d-10a3-48d0-ac34-19824f5aaee1
+      - 6f079124-28c1-498f-95a0-91b5157b9668
     status: 200 OK
     code: 200
     duration: ""
@@ -1606,10 +1606,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1618,7 +1618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:10 GMT
+      - Mon, 13 Nov 2023 13:55:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1628,7 +1628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59f0bd3b-4c7e-4240-a00f-f79c2f3ed442
+      - 3327b8e0-a510-453a-bb59-4c3c0a12aa92
     status: 200 OK
     code: 200
     duration: ""
@@ -1639,10 +1639,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1651,7 +1651,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:16 GMT
+      - Mon, 13 Nov 2023 13:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1661,7 +1661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d01a300-ef5f-453e-89ba-ef38a3834843
+      - 5c56be0d-42d1-4394-a82e-702b35f33ce3
     status: 200 OK
     code: 200
     duration: ""
@@ -1672,10 +1672,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1684,7 +1684,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:21 GMT
+      - Mon, 13 Nov 2023 13:55:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1694,7 +1694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 469d2105-df0d-41f5-b34b-b2a78a8f897b
+      - 907c91c7-7b0b-4a76-ad4c-503d8e4b8cb6
     status: 200 OK
     code: 200
     duration: ""
@@ -1705,10 +1705,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1717,7 +1717,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:26 GMT
+      - Mon, 13 Nov 2023 13:55:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1727,7 +1727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5066ac00-e33f-4f1e-98a1-f98a7f772649
+      - 31bdeea9-a517-4f55-82e4-a4fb9f48ffa3
     status: 200 OK
     code: 200
     duration: ""
@@ -1738,10 +1738,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1750,7 +1750,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:31 GMT
+      - Mon, 13 Nov 2023 13:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1760,7 +1760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34f111e9-a10c-4634-bf73-01db44dbde4a
+      - 903afb5a-737a-4109-9d75-5476a923c865
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,10 +1771,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1783,7 +1783,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:36 GMT
+      - Mon, 13 Nov 2023 13:55:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1793,7 +1793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85680634-605b-4334-9ae1-b3d262a829d4
+      - e11131d6-0c21-4659-9f64-daba78da361d
     status: 200 OK
     code: 200
     duration: ""
@@ -1804,10 +1804,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1816,7 +1816,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:41 GMT
+      - Mon, 13 Nov 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1826,7 +1826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1afc1bfc-a913-47e5-a149-ed69281a877c
+      - 1cb34b42-549a-4932-9580-aab50787de39
     status: 200 OK
     code: 200
     duration: ""
@@ -1837,10 +1837,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1849,7 +1849,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1859,7 +1859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48d1e422-8437-4dc0-8b07-cbea631ff521
+      - c2756a42-368f-4b6f-8d9f-402fdcc12171
     status: 200 OK
     code: 200
     duration: ""
@@ -1870,10 +1870,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1882,7 +1882,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:51 GMT
+      - Mon, 13 Nov 2023 13:56:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1892,7 +1892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 596f5127-dd31-45a6-a164-f17c5cb039aa
+      - 3ff44d7d-fe1c-47d3-baca-91b24c965ed5
     status: 200 OK
     code: 200
     duration: ""
@@ -1903,10 +1903,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1915,7 +1915,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:56 GMT
+      - Mon, 13 Nov 2023 13:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1925,7 +1925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5816d6b8-a9a2-426a-a208-13025b7bb5ee
+      - 4041ea7d-9a28-4f45-b761-b6886bb8e50b
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,10 +1936,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:52:18.919841Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "615"
@@ -1948,7 +1948,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:01 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1958,7 +1958,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 098f9353-faf4-4c7b-aa4f-5e04c36ef440
+      - 8b832263-2850-42a9-9620-dd97ebf36fab
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,373 +1969,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d2a6eb97-dbe1-4760-a3f8-7fe9b6f6e0f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f10d2641-4d6d-4750-8fba-332e5287798b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 48b4ce6e-be07-47f8-b7b3-003a059c3432
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f37bc8dc-2c7c-451d-a933-0169514437be
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 86c58292-f28e-4ef2-8a67-990ab99eff10
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 94d79c09-6a22-45cc-ba25-df4f7bd3331e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c7e9fd0d-63d9-4050-af75-a40ee61db7bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 41b28b71-5e37-4ae5-8abb-f1a9640cf7c3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a1d1fe60-fafa-4e09-900f-e38d03575fb2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5db85b84-0922-4214-9bff-81dcd59de3aa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:03.316468Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 39e2322d-a395-4ee0-8765-694a5446b6f2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:23.938752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "613"
@@ -2344,7 +1981,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2354,7 +1991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7199eba6-efe8-4919-8bfd-6c940624867c
+      - 8841fd71-f983-4bf6-8b52-01733f2172be
     status: 200 OK
     code: 200
     duration: ""
@@ -2365,10 +2002,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:24:13.951599Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:54:13.346740Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1446"
@@ -2377,7 +2014,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2387,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95e32dca-c7e1-42b9-9a26-665b617fbddb
+      - 814e0b8a-307b-4256-8265-82f1312e359c
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,10 +2035,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:23.938752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "613"
@@ -2410,7 +2047,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2420,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ccdf688-9927-4829-ace2-c9d649f2e87e
+      - 5c2cc981-2c65-4b5d-b44d-578c38bd0f3f
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,19 +2068,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/nodes?order_by=created_at_asc&page=1&pool_id=4a9eca00-563a-4ef1-8820-97f4e075a2c6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/nodes?order_by=created_at_asc&page=1&pool_id=d62babd0-e846-403f-8db6-2d0b8337aba1&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:42.238344Z","error_message":null,"id":"dae1027a-49f4-4a66-969b-35e273b8473e","name":"scw-test-pool-size-pool-dae1027a49f44a66969b35","pool_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","provider_id":"scaleway://instance/fr-par-1/85284d71-2af4-4fa7-a9d6-9272328aef36","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:58.008278Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:29.924465Z","error_message":null,"id":"003b12c7-ec07-4494-9bd7-3321fae087ad","name":"scw-test-pool-size-pool-003b12c7ec0744949bd733","pool_id":"d62babd0-e846-403f-8db6-2d0b8337aba1","provider_id":"scaleway://instance/fr-par-1/70ea6cea-258f-4050-bb83-0853c72a6bb1","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:23.924018Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2453,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0feae9c-22d7-4a2c-b3b1-e20da5a237d2
+      - fe0f2035-e38a-46a6-9a32-6e855c11c255
     status: 200 OK
     code: 200
     duration: ""
@@ -2464,19 +2101,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b0f61662-2be0-45f7-9348-462f77e21e73
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:12.541187Z","dhcp_enabled":true,"id":"b0f61662-2be0-45f7-9348-462f77e21e73","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:12.541187Z","id":"dd4a2384-4ff8-4592-8b5c-6af909f6f789","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:52:12.541187Z"},{"created_at":"2023-11-13T13:52:12.541187Z","id":"b9483813-0f12-4103-a33a-d9b47b2ebe46","subnet":"fd63:256c:45f7:f41d::/64","updated_at":"2023-11-13T13:52:12.541187Z"}],"tags":[],"updated_at":"2023-11-13T13:52:12.541187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "714"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7fc6e3d-a2e6-4fc1-a453-2a89ab09d953
+      - eba9369b-8a68-4a82-82a3-421f3608b772
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,10 +2134,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:24:13.951599Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:54:13.346740Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1446"
@@ -2509,7 +2146,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2519,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1df84bc-69a3-40ab-9932-3bdb5469bd0c
+      - 8c4bda67-bff0-486f-9014-841677064bb9
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,10 +2167,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwSk1VOVdiMWhFVkUxNlRWUkZkMDlVUlhwTmFra3hUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRIaDNDamgzUW1Jdk9EQnBaakF6Tm5wcGIyUmxSRlUxVW0xa1RYSlBObUkxYWxSblNteHRiWFpKTkZRNVZGQlZhMDlqVTNOM09FeFFRVFJ3VVVORFozTkdXVGdLZEdkTGJGVnBTMlZVT0VaelUwUm5LelZKU0dRNWNGWTRZbFJxWTJOQlltMXdWMmxpV0hWVU0wZDBZaTlxWkUxSVkydEhRMUpWYjBoTVJYbHJRa05oY1Fwd2VtTkpXRU14YXpsalNGVkViMGxuWlZwWFpqaDNabTQyTUZKdGFHOXBUbWhRWmt0d05XbFBVREZvY2xaUlJGWmhNVEJpUkRFclUyeG1jVnBFWjBKeENrRk5aRE5rTmpaWUswVmpiVkppUzBNelZrTkdXRlJLWWxoWU4yVjZlbGMwTUdSdWJrRlRVSFl3YUVKaGRuWnNaRlJXT1ZkdE5XeFBjVkkyUkN0aVZFTUtSM0F6WnpscVEyZ3JkbE5yYjJwMGJXSnVhWEV5UkdkUU5tZGllVTRyU2poc1ZFZDBMMlpLWWpWT0wxVmxVamhETjFobFIxcHBZMHgyTkhVMWEzRnlXUXBDYWxadmF5dEhjbmhqVDB3d0swaGFLMlpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWTA5QksyUm1kREZxZDFKSVVraFVVVE5IYW5JM1JETjVSMDFOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDUVZaRFUyeDZkbmsyYWpaVFNuUXZSREpwZUhWemFUWjNWMk5hTldOV1RGUjRMeXQwWkZGRGJYQlJXWGR5WlZsalVncEZkMUYzYUhSd2JsVjFhSFp6T0ZOUVpXeElTVmhGVVhNNVVHTnZOVlpUUjJKRFdrcDJRbXBOVDI0eE9HOTJVelpHTm1Fd2MwcFZhVE5hVmt4QmExWndDblF3UzNWV2FuSjZjM3BaYmxkTGFYVlJPRGhvWkRGVmFISlVlV1o0WlV3NVlYRTVaekZTYWtoU05VaFFiRWsySzNSbmJGTkVaVkEwYmk5R2JuUnhTMUlLUkRRcldGSTNXR2xHTTJ0UlpFeHZkRzFVZEc5dVJ6ZHVWQzk2THpWdGNHdGpPSEp0YVRObE5YZHhaamhhVTI1MWFpOW9WVXhqYmpJcmFFUnRNM3BhYlFwa01WbFJNbTlsYTBkNFZtdHdXRlJsYm5sV2ExTmpSRU4yTlZrd1dGSkpkMlV5VDI0d2RWTnVaRE4wUTNwb2EwUTFibEJSZGt0eE5uRnJhVUZIVVhCVkNtcEZhVkowYmpoYWEyODJkbmRRYTBWSlJIaEtTSEJVV21wRlJ6QjFaVlpTVTNSQ1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jYjdlZjE1NC1mY2IxLTRhZWItOWNmOC1mNWUxNGUyZmFjYzQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPc3R5aGVlQkhtempYckdLS1poWGpxY1JNdGFVY2xNdzlIemFwUllKWmd5ajdtbnVLOTFHWmFkdA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSSmVFNUdiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFbDRUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRVdExDbFpRVUVNeWNrZHlhbEpWTDNVeWMzQTRPRWsxTW5sWUwyVXphazlxUzFNclkzSm5MM1ZRTm1WamVFd3pLMmxXYXpGblFXTnFURmxVVFVaaFpsUjNRbG9LVGpSb1FXZFRVRTVqT0U5T05VYzNaUzlQT1hSVVVXNXBNRTlCZDBGT2J6UjRUM1ZHY0hKR1VrNVBUWHBXZUdOSlMxQlRNV1Z6VFUwMWEyOURaMGdyVEFwd2VESkxTM1EyUkRSMGFuZzNhSE56WWpGUU4wTm9hWGh5WTBaTVNtRmlkR2RIV1N0RldqUjViMk5oZEVGNGF6WjFORzlvTUZwc04wbHdUVmR1Y3poNUNsbERTVU5SZFc5bFpETnZlall4WXpWaFR6UnRXa3BYVjI1Qk9VTktOMlZZVUZCdEwwNXdRbWQ2WTNjeU1tUXdVVlY0YlZkTFJtdEpRbVp0U1V0S2RGVUtZaXN6VVU5dlp6VlVVbVJJY21SVmJHeDZOMGRKUlRkdE1qQmpkbWRhU2xkdGNGRjNZVGhUTmtGQ01XdGhLMVZSVDBWc01XMHJhMk5YZDFKVFEzTXdiQXBtTmxOMVRIUmFhMnhCYTFwUGMzQTFOMXBqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPUlU1V1J5ODJkRzFsY1ZnM1pHeG1XV1pWTVZsRFRYbzRjV2ROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYUM5MVNGSnVlbUp4VERSNVFVRm1SMGxqYzI1UEwwUXhXalpGYW1Fd2RYbDRLMFUxY0VORFZrTkNZV2hNYXpaWE5RbzNVVTQxV0dwSWFua3lNREprV0haS1pVVkVPVmRYTVU1RGQyOXdVV0Z3UTI4eFpEbEpZMmR0UzI5clZtRlFWVzgxWjJjNWN5dHFRaXRFYlRFMlREQlVDa3RCTWxweFdFRklWMDFSTW1NNWRXUXlUSGc0U1RWT1IyWktVRW93VlV0U1NrbHRPRkJpWlhOcmVVUjZXRWxMUTFkNlQxazRZVXB3YkdzNGFHZzNSbE1LYlRCbk9GY3lUa0ZHV1VSTmIwaHRjMFJSZG10RkszRnZjU3N6ZFdGR1JUSTBRelJNV0RKMVZFMXJTWEpHSzFVd0syNU9SMlJuTkdoVWJXYzRlSFpKYndwaVlXOHlWSGx3SzNsd04xQlFNbTR2TkVGa1RXRkNjbEJvVnpCU1l6TmhUVzlSYjFScVRsaFRXVWxvVDFoMVFUSkVUbVJHZDNCWVNsVmFWRmxrTURkcUNubzBaWE5EU1RGR1FsRkRVWE5wTUdaRVRtNXhPRUpYTld3eVpFZHJiemxMVTAxR1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lY2QwZDI3OC05NWQwLTQ1ZGMtOGY2Yi03MmJkYjcyODQ1YzguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYRGg0RGl4SkxpRUxJMmhsUEpSMjM1VHY2eVlBODZZQjdVTlF0WTN3OVR5dmM2NjlyWHoyeGRmSA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -2542,7 +2179,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2552,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66328794-570c-41a1-838b-3ec10916e811
+      - 3cee82f9-460c-402e-a10c-e0298a257277
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,10 +2200,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:23.938752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "613"
@@ -2575,7 +2212,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2585,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61b8f39a-e6ed-4d08-8f1f-e64d44c55a98
+      - d1e61b64-7242-48e2-82fd-eaef349579ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2596,19 +2233,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/nodes?order_by=created_at_asc&page=1&pool_id=4a9eca00-563a-4ef1-8820-97f4e075a2c6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/nodes?order_by=created_at_asc&page=1&pool_id=d62babd0-e846-403f-8db6-2d0b8337aba1&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:42.238344Z","error_message":null,"id":"dae1027a-49f4-4a66-969b-35e273b8473e","name":"scw-test-pool-size-pool-dae1027a49f44a66969b35","pool_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","provider_id":"scaleway://instance/fr-par-1/85284d71-2af4-4fa7-a9d6-9272328aef36","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:58.008278Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:29.924465Z","error_message":null,"id":"003b12c7-ec07-4494-9bd7-3321fae087ad","name":"scw-test-pool-size-pool-003b12c7ec0744949bd733","pool_id":"d62babd0-e846-403f-8db6-2d0b8337aba1","provider_id":"scaleway://instance/fr-par-1/70ea6cea-258f-4050-bb83-0853c72a6bb1","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:23.924018Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:02 GMT
+      - Mon, 13 Nov 2023 13:56:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2618,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8651fcc8-5070-4fe9-9ee8-671a80e9902c
+      - 677a8a65-29ef-412f-8a41-4d15e3ff5215
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,19 +2266,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b0f61662-2be0-45f7-9348-462f77e21e73
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:12.541187Z","dhcp_enabled":true,"id":"b0f61662-2be0-45f7-9348-462f77e21e73","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:12.541187Z","id":"dd4a2384-4ff8-4592-8b5c-6af909f6f789","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:52:12.541187Z"},{"created_at":"2023-11-13T13:52:12.541187Z","id":"b9483813-0f12-4103-a33a-d9b47b2ebe46","subnet":"fd63:256c:45f7:f41d::/64","updated_at":"2023-11-13T13:52:12.541187Z"}],"tags":[],"updated_at":"2023-11-13T13:52:12.541187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "714"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:03 GMT
+      - Mon, 13 Nov 2023 13:56:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2651,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cdbb686-02e8-47fb-b512-1d0020820d27
+      - e7b979d6-817f-4cc5-b4f6-d8765065a014
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,10 +2299,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:24:13.951599Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:54:13.346740Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1446"
@@ -2674,7 +2311,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:03 GMT
+      - Mon, 13 Nov 2023 13:56:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2684,7 +2321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94f375f8-1996-4d1f-b153-26b515657516
+      - bf74af08-7d9c-4d6b-b6fb-1925fae7d780
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,10 +2332,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwSk1VOVdiMWhFVkUxNlRWUkZkMDlVUlhwTmFra3hUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRIaDNDamgzUW1Jdk9EQnBaakF6Tm5wcGIyUmxSRlUxVW0xa1RYSlBObUkxYWxSblNteHRiWFpKTkZRNVZGQlZhMDlqVTNOM09FeFFRVFJ3VVVORFozTkdXVGdLZEdkTGJGVnBTMlZVT0VaelUwUm5LelZKU0dRNWNGWTRZbFJxWTJOQlltMXdWMmxpV0hWVU0wZDBZaTlxWkUxSVkydEhRMUpWYjBoTVJYbHJRa05oY1Fwd2VtTkpXRU14YXpsalNGVkViMGxuWlZwWFpqaDNabTQyTUZKdGFHOXBUbWhRWmt0d05XbFBVREZvY2xaUlJGWmhNVEJpUkRFclUyeG1jVnBFWjBKeENrRk5aRE5rTmpaWUswVmpiVkppUzBNelZrTkdXRlJLWWxoWU4yVjZlbGMwTUdSdWJrRlRVSFl3YUVKaGRuWnNaRlJXT1ZkdE5XeFBjVkkyUkN0aVZFTUtSM0F6WnpscVEyZ3JkbE5yYjJwMGJXSnVhWEV5UkdkUU5tZGllVTRyU2poc1ZFZDBMMlpLWWpWT0wxVmxVamhETjFobFIxcHBZMHgyTkhVMWEzRnlXUXBDYWxadmF5dEhjbmhqVDB3d0swaGFLMlpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWTA5QksyUm1kREZxZDFKSVVraFVVVE5IYW5JM1JETjVSMDFOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDUVZaRFUyeDZkbmsyYWpaVFNuUXZSREpwZUhWemFUWjNWMk5hTldOV1RGUjRMeXQwWkZGRGJYQlJXWGR5WlZsalVncEZkMUYzYUhSd2JsVjFhSFp6T0ZOUVpXeElTVmhGVVhNNVVHTnZOVlpUUjJKRFdrcDJRbXBOVDI0eE9HOTJVelpHTm1Fd2MwcFZhVE5hVmt4QmExWndDblF3UzNWV2FuSjZjM3BaYmxkTGFYVlJPRGhvWkRGVmFISlVlV1o0WlV3NVlYRTVaekZTYWtoU05VaFFiRWsySzNSbmJGTkVaVkEwYmk5R2JuUnhTMUlLUkRRcldGSTNXR2xHTTJ0UlpFeHZkRzFVZEc5dVJ6ZHVWQzk2THpWdGNHdGpPSEp0YVRObE5YZHhaamhhVTI1MWFpOW9WVXhqYmpJcmFFUnRNM3BhYlFwa01WbFJNbTlsYTBkNFZtdHdXRlJsYm5sV2ExTmpSRU4yTlZrd1dGSkpkMlV5VDI0d2RWTnVaRE4wUTNwb2EwUTFibEJSZGt0eE5uRnJhVUZIVVhCVkNtcEZhVkowYmpoYWEyODJkbmRRYTBWSlJIaEtTSEJVV21wRlJ6QjFaVlpTVTNSQ1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jYjdlZjE1NC1mY2IxLTRhZWItOWNmOC1mNWUxNGUyZmFjYzQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPc3R5aGVlQkhtempYckdLS1poWGpxY1JNdGFVY2xNdzlIemFwUllKWmd5ajdtbnVLOTFHWmFkdA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSSmVFNUdiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFbDRUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRVdExDbFpRVUVNeWNrZHlhbEpWTDNVeWMzQTRPRWsxTW5sWUwyVXphazlxUzFNclkzSm5MM1ZRTm1WamVFd3pLMmxXYXpGblFXTnFURmxVVFVaaFpsUjNRbG9LVGpSb1FXZFRVRTVqT0U5T05VYzNaUzlQT1hSVVVXNXBNRTlCZDBGT2J6UjRUM1ZHY0hKR1VrNVBUWHBXZUdOSlMxQlRNV1Z6VFUwMWEyOURaMGdyVEFwd2VESkxTM1EyUkRSMGFuZzNhSE56WWpGUU4wTm9hWGh5WTBaTVNtRmlkR2RIV1N0RldqUjViMk5oZEVGNGF6WjFORzlvTUZwc04wbHdUVmR1Y3poNUNsbERTVU5SZFc5bFpETnZlall4WXpWaFR6UnRXa3BYVjI1Qk9VTktOMlZZVUZCdEwwNXdRbWQ2WTNjeU1tUXdVVlY0YlZkTFJtdEpRbVp0U1V0S2RGVUtZaXN6VVU5dlp6VlVVbVJJY21SVmJHeDZOMGRKUlRkdE1qQmpkbWRhU2xkdGNGRjNZVGhUTmtGQ01XdGhLMVZSVDBWc01XMHJhMk5YZDFKVFEzTXdiQXBtTmxOMVRIUmFhMnhCYTFwUGMzQTFOMXBqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPUlU1V1J5ODJkRzFsY1ZnM1pHeG1XV1pWTVZsRFRYbzRjV2ROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYUM5MVNGSnVlbUp4VERSNVFVRm1SMGxqYzI1UEwwUXhXalpGYW1Fd2RYbDRLMFUxY0VORFZrTkNZV2hNYXpaWE5RbzNVVTQxV0dwSWFua3lNREprV0haS1pVVkVPVmRYTVU1RGQyOXdVV0Z3UTI4eFpEbEpZMmR0UzI5clZtRlFWVzgxWjJjNWN5dHFRaXRFYlRFMlREQlVDa3RCTWxweFdFRklWMDFSTW1NNWRXUXlUSGc0U1RWT1IyWktVRW93VlV0U1NrbHRPRkJpWlhOcmVVUjZXRWxMUTFkNlQxazRZVXB3YkdzNGFHZzNSbE1LYlRCbk9GY3lUa0ZHV1VSTmIwaHRjMFJSZG10RkszRnZjU3N6ZFdGR1JUSTBRelJNV0RKMVZFMXJTWEpHSzFVd0syNU9SMlJuTkdoVWJXYzRlSFpKYndwaVlXOHlWSGx3SzNsd04xQlFNbTR2TkVGa1RXRkNjbEJvVnpCU1l6TmhUVzlSYjFScVRsaFRXVWxvVDFoMVFUSkVUbVJHZDNCWVNsVmFWRmxrTURkcUNubzBaWE5EU1RGR1FsRkRVWE5wTUdaRVRtNXhPRUpYTld3eVpFZHJiemxMVTAxR1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lY2QwZDI3OC05NWQwLTQ1ZGMtOGY2Yi03MmJkYjcyODQ1YzguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYRGg0RGl4SkxpRUxJMmhsUEpSMjM1VHY2eVlBODZZQjdVTlF0WTN3OVR5dmM2NjlyWHoyeGRmSA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -2707,7 +2344,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:03 GMT
+      - Mon, 13 Nov 2023 13:56:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2717,7 +2354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cd03bfa-b296-4461-a6f9-b4e8ff55e8bb
+      - 56294421-a02e-40c2-b92b-3108e51ad6bb
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,10 +2365,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:23.938752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "613"
@@ -2740,7 +2377,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:03 GMT
+      - Mon, 13 Nov 2023 13:56:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2750,7 +2387,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aad16ca1-f9f2-44e2-819d-94f58704a98c
+      - 4fbf8c08-4011-4af9-a1be-be28c80e249e
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,19 +2398,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/nodes?order_by=created_at_asc&page=1&pool_id=4a9eca00-563a-4ef1-8820-97f4e075a2c6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/nodes?order_by=created_at_asc&page=1&pool_id=d62babd0-e846-403f-8db6-2d0b8337aba1&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:42.238344Z","error_message":null,"id":"dae1027a-49f4-4a66-969b-35e273b8473e","name":"scw-test-pool-size-pool-dae1027a49f44a66969b35","pool_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","provider_id":"scaleway://instance/fr-par-1/85284d71-2af4-4fa7-a9d6-9272328aef36","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:58.008278Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:29.924465Z","error_message":null,"id":"003b12c7-ec07-4494-9bd7-3321fae087ad","name":"scw-test-pool-size-pool-003b12c7ec0744949bd733","pool_id":"d62babd0-e846-403f-8db6-2d0b8337aba1","provider_id":"scaleway://instance/fr-par-1/70ea6cea-258f-4050-bb83-0853c72a6bb1","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:23.924018Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:03 GMT
+      - Mon, 13 Nov 2023 13:56:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2783,7 +2420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7894594f-829a-4057-85cf-0830d9106ef7
+      - 4b44a621-64da-4616-8bd5-cc7fa48e810c
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,19 +2431,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b0f61662-2be0-45f7-9348-462f77e21e73
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:22:56.872222Z","dhcp_enabled":true,"id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:22:56.872222Z","id":"d1099108-a433-466d-9494-a5e522def3e5","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:22:56.872222Z"},{"created_at":"2023-11-10T13:22:56.872222Z","id":"5682d4cd-1763-41e2-8068-77c8ca314138","subnet":"fd63:256c:45f7:8e5a::/64","updated_at":"2023-11-10T13:22:56.872222Z"}],"tags":[],"updated_at":"2023-11-10T13:22:56.872222Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:52:12.541187Z","dhcp_enabled":true,"id":"b0f61662-2be0-45f7-9348-462f77e21e73","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:52:12.541187Z","id":"dd4a2384-4ff8-4592-8b5c-6af909f6f789","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:52:12.541187Z"},{"created_at":"2023-11-13T13:52:12.541187Z","id":"b9483813-0f12-4103-a33a-d9b47b2ebe46","subnet":"fd63:256c:45f7:f41d::/64","updated_at":"2023-11-13T13:52:12.541187Z"}],"tags":[],"updated_at":"2023-11-13T13:52:12.541187Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "714"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:04 GMT
+      - Mon, 13 Nov 2023 13:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2816,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70e66139-35ae-483c-b4fe-313a488a447c
+      - 44192498-543c-4bfe-8fbe-b1d55afdfd90
     status: 200 OK
     code: 200
     duration: ""
@@ -2827,10 +2464,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:24:13.951599Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:54:13.346740Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1446"
@@ -2839,7 +2476,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:04 GMT
+      - Mon, 13 Nov 2023 13:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2849,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 576f22b0-800d-4ef7-b346-d30c7d8aea49
+      - a9fe4e0c-11d3-462f-9690-4ddd5798b916
     status: 200 OK
     code: 200
     duration: ""
@@ -2860,10 +2497,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFdwSk1VOVdiMWhFVkUxNlRWUkZkMDlVUlhwTmFra3hUMVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRIaDNDamgzUW1Jdk9EQnBaakF6Tm5wcGIyUmxSRlUxVW0xa1RYSlBObUkxYWxSblNteHRiWFpKTkZRNVZGQlZhMDlqVTNOM09FeFFRVFJ3VVVORFozTkdXVGdLZEdkTGJGVnBTMlZVT0VaelUwUm5LelZKU0dRNWNGWTRZbFJxWTJOQlltMXdWMmxpV0hWVU0wZDBZaTlxWkUxSVkydEhRMUpWYjBoTVJYbHJRa05oY1Fwd2VtTkpXRU14YXpsalNGVkViMGxuWlZwWFpqaDNabTQyTUZKdGFHOXBUbWhRWmt0d05XbFBVREZvY2xaUlJGWmhNVEJpUkRFclUyeG1jVnBFWjBKeENrRk5aRE5rTmpaWUswVmpiVkppUzBNelZrTkdXRlJLWWxoWU4yVjZlbGMwTUdSdWJrRlRVSFl3YUVKaGRuWnNaRlJXT1ZkdE5XeFBjVkkyUkN0aVZFTUtSM0F6WnpscVEyZ3JkbE5yYjJwMGJXSnVhWEV5UkdkUU5tZGllVTRyU2poc1ZFZDBMMlpLWWpWT0wxVmxVamhETjFobFIxcHBZMHgyTkhVMWEzRnlXUXBDYWxadmF5dEhjbmhqVDB3d0swaGFLMlpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWTA5QksyUm1kREZxZDFKSVVraFVVVE5IYW5JM1JETjVSMDFOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDUVZaRFUyeDZkbmsyYWpaVFNuUXZSREpwZUhWemFUWjNWMk5hTldOV1RGUjRMeXQwWkZGRGJYQlJXWGR5WlZsalVncEZkMUYzYUhSd2JsVjFhSFp6T0ZOUVpXeElTVmhGVVhNNVVHTnZOVlpUUjJKRFdrcDJRbXBOVDI0eE9HOTJVelpHTm1Fd2MwcFZhVE5hVmt4QmExWndDblF3UzNWV2FuSjZjM3BaYmxkTGFYVlJPRGhvWkRGVmFISlVlV1o0WlV3NVlYRTVaekZTYWtoU05VaFFiRWsySzNSbmJGTkVaVkEwYmk5R2JuUnhTMUlLUkRRcldGSTNXR2xHTTJ0UlpFeHZkRzFVZEc5dVJ6ZHVWQzk2THpWdGNHdGpPSEp0YVRObE5YZHhaamhhVTI1MWFpOW9WVXhqYmpJcmFFUnRNM3BhYlFwa01WbFJNbTlsYTBkNFZtdHdXRlJsYm5sV2ExTmpSRU4yTlZrd1dGSkpkMlV5VDI0d2RWTnVaRE4wUTNwb2EwUTFibEJSZGt0eE5uRnJhVUZIVVhCVkNtcEZhVkowYmpoYWEyODJkbmRRYTBWSlJIaEtTSEJVV21wRlJ6QjFaVlpTVTNSQ1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jYjdlZjE1NC1mY2IxLTRhZWItOWNmOC1mNWUxNGUyZmFjYzQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPc3R5aGVlQkhtempYckdLS1poWGpxY1JNdGFVY2xNdzlIemFwUllKWmd5ajdtbnVLOTFHWmFkdA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSSmVFNUdiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFbDRUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRVdExDbFpRVUVNeWNrZHlhbEpWTDNVeWMzQTRPRWsxTW5sWUwyVXphazlxUzFNclkzSm5MM1ZRTm1WamVFd3pLMmxXYXpGblFXTnFURmxVVFVaaFpsUjNRbG9LVGpSb1FXZFRVRTVqT0U5T05VYzNaUzlQT1hSVVVXNXBNRTlCZDBGT2J6UjRUM1ZHY0hKR1VrNVBUWHBXZUdOSlMxQlRNV1Z6VFUwMWEyOURaMGdyVEFwd2VESkxTM1EyUkRSMGFuZzNhSE56WWpGUU4wTm9hWGh5WTBaTVNtRmlkR2RIV1N0RldqUjViMk5oZEVGNGF6WjFORzlvTUZwc04wbHdUVmR1Y3poNUNsbERTVU5SZFc5bFpETnZlall4WXpWaFR6UnRXa3BYVjI1Qk9VTktOMlZZVUZCdEwwNXdRbWQ2WTNjeU1tUXdVVlY0YlZkTFJtdEpRbVp0U1V0S2RGVUtZaXN6VVU5dlp6VlVVbVJJY21SVmJHeDZOMGRKUlRkdE1qQmpkbWRhU2xkdGNGRjNZVGhUTmtGQ01XdGhLMVZSVDBWc01XMHJhMk5YZDFKVFEzTXdiQXBtTmxOMVRIUmFhMnhCYTFwUGMzQTFOMXBqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPUlU1V1J5ODJkRzFsY1ZnM1pHeG1XV1pWTVZsRFRYbzRjV2ROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYUM5MVNGSnVlbUp4VERSNVFVRm1SMGxqYzI1UEwwUXhXalpGYW1Fd2RYbDRLMFUxY0VORFZrTkNZV2hNYXpaWE5RbzNVVTQxV0dwSWFua3lNREprV0haS1pVVkVPVmRYTVU1RGQyOXdVV0Z3UTI4eFpEbEpZMmR0UzI5clZtRlFWVzgxWjJjNWN5dHFRaXRFYlRFMlREQlVDa3RCTWxweFdFRklWMDFSTW1NNWRXUXlUSGc0U1RWT1IyWktVRW93VlV0U1NrbHRPRkJpWlhOcmVVUjZXRWxMUTFkNlQxazRZVXB3YkdzNGFHZzNSbE1LYlRCbk9GY3lUa0ZHV1VSTmIwaHRjMFJSZG10RkszRnZjU3N6ZFdGR1JUSTBRelJNV0RKMVZFMXJTWEpHSzFVd0syNU9SMlJuTkdoVWJXYzRlSFpKYndwaVlXOHlWSGx3SzNsd04xQlFNbTR2TkVGa1RXRkNjbEJvVnpCU1l6TmhUVzlSYjFScVRsaFRXVWxvVDFoMVFUSkVUbVJHZDNCWVNsVmFWRmxrTURkcUNubzBaWE5EU1RGR1FsRkRVWE5wTUdaRVRtNXhPRUpYTld3eVpFZHJiemxMVTAxR1V3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lY2QwZDI3OC05NWQwLTQ1ZGMtOGY2Yi03MmJkYjcyODQ1YzguYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYRGg0RGl4SkxpRUxJMmhsUEpSMjM1VHY2eVlBODZZQjdVTlF0WTN3OVR5dmM2NjlyWHoyeGRmSA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -2872,7 +2509,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:04 GMT
+      - Mon, 13 Nov 2023 13:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2882,7 +2519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b04ade2-4997-4c4b-b145-8e7d700ea526
+      - 9e1754d6-0fee-4a0c-8312-3f3be1fa5cad
     status: 200 OK
     code: 200
     duration: ""
@@ -2893,10 +2530,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:27:58.030471Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:56:23.938752Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "613"
@@ -2905,7 +2542,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:04 GMT
+      - Mon, 13 Nov 2023 13:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2915,7 +2552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcfa560b-64b5-476a-ae4a-ce8776ec7f1b
+      - 6a8e45a6-4210-46b9-9375-699fe68ceadb
     status: 200 OK
     code: 200
     duration: ""
@@ -2926,19 +2563,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4/nodes?order_by=created_at_asc&page=1&pool_id=4a9eca00-563a-4ef1-8820-97f4e075a2c6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8/nodes?order_by=created_at_asc&page=1&pool_id=d62babd0-e846-403f-8db6-2d0b8337aba1&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:42.238344Z","error_message":null,"id":"dae1027a-49f4-4a66-969b-35e273b8473e","name":"scw-test-pool-size-pool-dae1027a49f44a66969b35","pool_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","provider_id":"scaleway://instance/fr-par-1/85284d71-2af4-4fa7-a9d6-9272328aef36","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:27:58.008278Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:29.924465Z","error_message":null,"id":"003b12c7-ec07-4494-9bd7-3321fae087ad","name":"scw-test-pool-size-pool-003b12c7ec0744949bd733","pool_id":"d62babd0-e846-403f-8db6-2d0b8337aba1","provider_id":"scaleway://instance/fr-par-1/70ea6cea-258f-4050-bb83-0853c72a6bb1","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:23.924018Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:04 GMT
+      - Mon, 13 Nov 2023 13:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2948,7 +2585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9245992a-ea66-4dab-9103-21c3d2631b2d
+      - d0d85847-4d41-479d-97d9-0935dbc52a8c
     status: 200 OK
     code: 200
     duration: ""
@@ -2959,10 +2596,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306804825Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:28.370790104Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "619"
@@ -2971,7 +2608,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:05 GMT
+      - Mon, 13 Nov 2023 13:56:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2981,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf21d2be-3634-4737-90da-5eeb6880289c
+      - a94cbf31-4deb-40c6-978b-f175d04b5a80
     status: 200 OK
     code: 200
     duration: ""
@@ -2992,10 +2629,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306805Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:28.370790Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3004,7 +2641,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:05 GMT
+      - Mon, 13 Nov 2023 13:56:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3014,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7c4f46d-2f5c-48ed-8c40-6ffca93b084c
+      - 4137695f-2b1e-43fd-955a-bcafd383dc50
     status: 200 OK
     code: 200
     duration: ""
@@ -3025,10 +2662,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306805Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:28.370790Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3037,7 +2674,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:10 GMT
+      - Mon, 13 Nov 2023 13:56:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3047,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93268860-a4c5-4c17-afd5-ec297a80ea17
+      - 7e7428e2-3732-4d38-ab5c-b5b2fc7f5f29
     status: 200 OK
     code: 200
     duration: ""
@@ -3058,10 +2695,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306805Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:28.370790Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3070,7 +2707,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:15 GMT
+      - Mon, 13 Nov 2023 13:56:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3080,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7191789c-19df-41d3-b53f-1071803d0999
+      - 967f0ddc-96c2-4aba-a61f-80e6463f9d96
     status: 200 OK
     code: 200
     duration: ""
@@ -3091,10 +2728,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","container_runtime":"containerd","created_at":"2023-11-10T13:23:03.307342Z","id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:28:05.306805Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","container_runtime":"containerd","created_at":"2023-11-13T13:52:18.910144Z","id":"d62babd0-e846-403f-8db6-2d0b8337aba1","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T13:56:28.370790Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "616"
@@ -3103,7 +2740,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:20 GMT
+      - Mon, 13 Nov 2023 13:56:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3113,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bccec5a-d2b9-43eb-aaf5-aeaa9fb18685
+      - 000b275f-62d8-4305-b005-7f63ca77d250
     status: 200 OK
     code: 200
     duration: ""
@@ -3124,10 +2761,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"d62babd0-e846-403f-8db6-2d0b8337aba1","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3136,7 +2773,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:25 GMT
+      - Mon, 13 Nov 2023 13:56:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3146,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a756e88-3a16-49f0-8c42-41f9993fdc98
+      - 4a040b08-67cf-41d6-9244-d67199091691
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3157,10 +2794,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:28:25.596922515Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:56:48.666189856Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1452"
@@ -3169,7 +2806,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:25 GMT
+      - Mon, 13 Nov 2023 13:56:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3179,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49205ce0-4a51-4a88-b9e3-5c3deb75f5f9
+      - 651bd400-c5d0-45ed-aba4-7ea8026de6e5
     status: 200 OK
     code: 200
     duration: ""
@@ -3190,10 +2827,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:28:25.596923Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:56:48.666190Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1449"
@@ -3202,7 +2839,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:25 GMT
+      - Mon, 13 Nov 2023 13:56:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3212,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89fe456e-2ef6-49c0-93cc-4e77a8673523
+      - 17833ac0-3a1d-4442-bd49-72aa0b184a4e
     status: 200 OK
     code: 200
     duration: ""
@@ -3223,10 +2860,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:22:57.814138Z","created_at":"2023-11-10T13:22:57.814138Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-10T13:28:25.596923Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ecd0d278-95d0-45dc-8f6b-72bdb72845c8.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:52:13.442240Z","created_at":"2023-11-13T13:52:13.442240Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ecd0d278-95d0-45dc-8f6b-72bdb72845c8.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b0f61662-2be0-45f7-9348-462f77e21e73","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-13T13:56:48.666190Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1449"
@@ -3235,7 +2872,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:30 GMT
+      - Mon, 13 Nov 2023 13:56:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3245,7 +2882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4e40864-1835-4a09-9964-209b5088b49c
+      - 85cdde1e-1387-42ac-9b8d-772a4761f641
     status: 200 OK
     code: 200
     duration: ""
@@ -3256,10 +2893,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3268,7 +2905,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05523c08-bd48-49dc-b274-ef3c51dcd34e
+      - b51d7b08-fc16-4599-aed8-ea3f4ad29138
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3289,10 +2926,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b0f61662-2be0-45f7-9348-462f77e21e73
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"b0f61662-2be0-45f7-9348-462f77e21e73","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3301,7 +2938,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3311,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 693411d9-a670-475d-99f8-baafb0f34714
+      - 78dbbbb2-36de-4e2e-846a-baf8c65c59e9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3322,76 +2959,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e2fa71d7-1493-4023-97f6-f657baa1ba18
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d62babd0-e846-403f-8db6-2d0b8337aba1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"e2fa71d7-1493-4023-97f6-f657baa1ba18","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ba0a2709-bc81-4fac-b058-710ecff2c50b
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cb7ef154-fcb1-4aeb-9cf8-f5e14e2facc4","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c4edc1e-9e0b-4404-a2c9-1cf3298d097f
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4a9eca00-563a-4ef1-8820-97f4e075a2c6
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"4a9eca00-563a-4ef1-8820-97f4e075a2c6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"d62babd0-e846-403f-8db6-2d0b8337aba1","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3400,7 +2971,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:35 GMT
+      - Mon, 13 Nov 2023 13:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3410,7 +2981,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8435b040-0fc5-4389-a2a1-f7f1cb8bf170
+      - cfa8debb-66c6-450c-a8b8-e00bc171d467
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ecd0d278-95d0-45dc-8f6b-72bdb72845c8
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ecd0d278-95d0-45dc-8f6b-72bdb72845c8","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1396d21d-066c-4482-94f4-c40bf69fd4e9
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b0f61662-2be0-45f7-9348-462f77e21e73
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"b0f61662-2be0-45f7-9348-462f77e21e73","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 227fe239-7a5c-4965-bc35-f1eb542afb8a
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-upgrade-policy.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-upgrade-policy.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbdf1d02-71c2-47b9-a586-60a0febda82d
+      - 5a39816a-1d85-4606-a81d-039f82ef60f1
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.822758Z","dhcp_enabled":true,"id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.822758Z","id":"fc9c7227-841e-4c91-8ca6-b767e00b16eb","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:51:13.822758Z"},{"created_at":"2023-11-13T13:51:13.822758Z","id":"4c0505d2-09bc-44d3-8f24-6606c2d86d60","subnet":"fd63:256c:45f7:7b5c::/64","updated_at":"2023-11-13T13:51:13.822758Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.822758Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "725"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:29 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6db34709-1b13-4318-9675-edb6187bc512
+      - 0822dcaa-bd78-483b-8249-f525a74f9d34
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dbed4a58-32da-4870-8376-0629a3a5f6b7
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.822758Z","dhcp_enabled":true,"id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.822758Z","id":"fc9c7227-841e-4c91-8ca6-b767e00b16eb","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:51:13.822758Z"},{"created_at":"2023-11-13T13:51:13.822758Z","id":"4c0505d2-09bc-44d3-8f24-6606c2d86d60","subnet":"fd63:256c:45f7:7b5c::/64","updated_at":"2023-11-13T13:51:13.822758Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.822758Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "725"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:29 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b51bc51b-4af5-48b3-8a32-1b533faab785
+      - fd56a0c3-4cae-4eec-9d0e-ce70f1749073
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-upgrade-policy","description":"","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-upgrade-policy","description":"","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035431Z","created_at":"2023-11-10T13:23:29.665035431Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:29.676686733Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684205Z","created_at":"2023-11-13T13:51:18.577684205Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.589193730Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:29 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53de69a8-6e92-4ddd-9941-a710e118d35b
+      - 7a73b249-cca3-4cd2-91c9-20351f25ac01
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:29.676687Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.589194Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1514"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:29 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7c72781-4dd5-48ab-8a42-84939592fbba
+      - 0369ec54-bff0-426c-a4f4-625c0359a527
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:33.188612Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.440779Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1519"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:34 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14d74732-5b4e-4da3-89f8-30a7b65733f4
+      - 4e8cb8b6-8299-4f9d-97c0-25526b97269d
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:33.188612Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.440779Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1519"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:34 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a86ab2c-eda9-4c10-af27-3228a908b68c
+      - 9a3bdc94-8bc5-46bb-8793-e03c89dae57c
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcE5lazFXYjFoRVZFMTZUVlJGZDA5VVJYcE5hazE2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVWQyQ2tkblREaFVWMVJzWlVzeFNqSkpXbmR0V25aR1pFMW9RMFpwTlVFM09VOXFTbXhKT1RoU1NXbDVhVlUwZUZFckwyUTFaRXhOT1djNWVFUjZaQ3RZU25vS1RVZEZRM015ZVhrdmIwZEpjVU15VmtwWVpITnNTRkp3U2xKNVEwVldVV3N6TWpRMmVHcHBSVVFyY1VGa1FWQmpibmhNTml0TGR6RnZZWEFyUlVWaFpBb3lhMjB4V2pCck0xRktPREpxZGtOTFFtaExURlZJYzBwNGIzWm1SeXRDTUhCdGQwVmpRbUY2SzBsS1MzbHJPVzFPWlRkMFZrZE5jRFI1YmxkNGQzWXhDamxyVERWWWNucDFlbTQyYlVsc1pEQk5OREpuT1hWT1dpdGpiRzgzUWs5WE1VOHpVSE01WVd4TVJIUlRSVGw0U1c5cVNVRkliU3QyU1ZCMFpXcERUR0lLTlZSMFNUSkZiQ3RKTVRKbmFsVjFlRXgyUkd4cGNEUk1NRk5ZV25sV01YYzJjVTVYWTBaRFVDOWhZVk14ZG1zck9XZFpVbU5uVHk5QlEzcGlRMWx5T1FweVlqRklWRWt2YjJGcWNtazRWU3REVnl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFZpdGxLMlJaUlhsRVEzWkVPRzB5Y1VGcWNYaHhVV1puZVhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5HRlJRMHhQWkZoTk1WaEROR3BIWTJkUVR6bHVTRVYwSzBwd2JtNVJSR2RhTlRoUFFqZDJSakpqTTFSUFdGSjJjQXBrVkdreU5GVlplWGgyT0RoNGFWRlVNSHBuTXlzNVpYSXJlVUUxUVhORVQyUm1WRkI1TVZKQlNrdzNXRFpoY1hWV04yNHlRWGR3V2t3elRHbE5RVzB4Q2k5WlRHcFVhbkJsWjFWRWRHTndNbmRXY21kME5ISkxXV2xMVUVKQk5tWjFUbHByVFUxeVZUazVSSEZQTjNGWlF6ZDVabVpEV0cxV1MxVkhla2h2TjNVS04wcEdXRE5MY25nNVkwVnFjRVJ5UzBOaE5WTXpPRU5UTWpJMVJDdDVNSFJwU2toblRIcHVOVmx4VEVSU1RGVkhNbWx6VEc0d1IzSkpVek13WmtkMlVRcEpXUzl6WkhGSWJ6Qk5ZMmhKYWtzMWFGUTNhalI0WlhSVE5UZEVZMjU1Vkd4NFN6TlVkamN2UTJoYVVHTjBNRTE1WVd4UFptTnFOMlJhU0ZWalp5dHZDbXM1TTNNd01rWTVWeTh2VW1SWVpVUlhLMnc0ZUd0dlQzVkNjVFJXZDIxWk9HRk1lQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMjJhMGIzYWItMzAxNC00ZmIxLTljNmYtZmJmNGQ3M2U0ZmMyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5N0FtM3VBSzN3M2xQQ21FS0JTTHFqVmFkREhDRnFST3VMMW04VGh2RnpQYnhxNjBYMEFpUnhvcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFHYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV1p3Q2tSaldUUTRLMWRHYzNabFpYWlhXbWMwVFZvelNFdzNTRVZVYmk5RFIzTmpSbWh0UkdGNWNYRk5VbmhaZUdaVFJYbDJPWGw2V21KME1rZEdkMUpGTTJ3S1NHdFdNSEZYTm0wNVdFTkVibXRqU0ZaRGVWUXJlVXBvYkhCNmFUVktMMlZtVEhOQlkxVlljbEZ6UkdSMGNGQlVUWEZKYjNrcllqZzNaVkZqVkVWcU53cFFRazB6UjFWRVdGbEdNbVZwYmxkVWNUWllRbnAzWkZCYWNGUlZVV0Z1UTI0eVUyNHpOM1ZoZVdsSk0wZDZZakV4V1U0elpXWkRhelJhZFdWc1RqbHJDazFNYTBSelEwTTBOSFZMVGxKaVNVb3lUSEJRVDJ4MlFXRkJabEV6Y0dkbmIxTlhaSEZVUVRVMFpsaHdSREZhUjNjMFZGQlVOMXBDY1RCT2RTdHNkMWtLVTFKaFYybGFNRVpzYUhkdU9HaENUaXMzWnpSUlVXMUJXSFZRV0RJeVZHeHZNR0Z0VTJaUlFqbFRUVVZUVEdwMmJURnhPV05FY1djd1NrdE5NMVl4Y3dvclMzazBabFpuZUdzek5WUm9TMk41YlZSalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTmNXOWFWa29yY0VwT1V6TnZNRFZGVmpSalVXaDJkVVJ3UkVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmIyRTVVVTUzY1ZoaFZsZFRSbk52V1hwSVRsUXJlbmsyY1RRNWNWQkllRXBHUTBJMWR6UnJWVTQxUkhScVdVMVVVd3BCTTBnNGNVd3hjR2QwZDA0NFdtTnNhMGQ0ZWpneWF6ZFhhamRTZUZSdU1VTjRWR3hXVmswNVFuUmFaMlo0VEdGd1pscFNWblpWWmpnM2RtMVVPQ3RXQ210SlRUbHJPSGRoYURkeVIyRjBTbWhTSzJwSU1ISldPRmxoT0U5aFVtMVFaVUk0UjNwWFpGbFFhalpRUWk5allXSm1WMFphTm1kUlpFbEZWRVUxVW5vS00wNTZZMDQ0WnpSM1UzSjVaMnhsU25nNGRFRjFNM2xUVDJRM2J5dGxielZWVm5KTGVsWlhSV2c1Y0ZWTFZGbFBNR3RVUW5sbVdERndhbVpFTUZGQkt3b3dheTlSY0VWUlNGRlZPSGd4VUU5NVNHcDFiMmhzZEhsT1VqbEljRXhIVVhOb1YyVkhWMDAyU21RNFptVkVaeTlLYUhCUlNtb3hhRll4Y0dwVk5FOHdDalJEYnpOT1NHNHhjbU5YYVVGNWNuaHBNMkpxYzFjeU1YVlVaVmhoUzBaaVltbHhTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzdkNTc5YTctYWQxOC00YjBmLTg5ZGQtNmI3ZDM4MjhmNjllLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbzlCUWJjM3BVYkN0MkpubHgxakU1aDBBTkxEQ0h1MTZnbXVsTm4wNFJmek9QVDZDMVhpS0dDdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2686"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:35 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43640997-ec4f-4910-b310-b1d1bae62e07
+      - cff27d01-7e49-4a36-8ab5-5022e79ba1f6
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:23:33.188612Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:51:20.440779Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1519"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:35 GMT
+      - Mon, 13 Nov 2023 13:51:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04fc41ce-349b-49af-b95d-ca74eb1569c6
+      - f7726587-34e7-43de-90ab-ab832d946504
     status: 200 OK
     code: 200
     duration: ""
@@ -315,10 +315,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613211Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009387913Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "695"
@@ -327,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:35 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a91e829c-efc6-4ed6-8caf-6ba034da31a8
+      - c21745f3-a2eb-4da4-bfb4-2372cd95ef14
     status: 200 OK
     code: 200
     duration: ""
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -360,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:35 GMT
+      - Mon, 13 Nov 2023 13:51:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7770d92-10ec-497c-a2cd-78ca0ccfab38
+      - 705491a1-be62-48c2-957f-dd56c66b5f63
     status: 200 OK
     code: 200
     duration: ""
@@ -381,10 +381,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -393,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:40 GMT
+      - Mon, 13 Nov 2023 13:51:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb6bbdab-8c54-4319-8b3b-0bc91bc762a4
+      - 3fac154c-2c90-4e1c-b50a-60b32f3c1610
     status: 200 OK
     code: 200
     duration: ""
@@ -414,10 +414,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -426,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 13:51:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bbe3833-2e90-4c49-8f74-3a12497abce2
+      - 8693c4b7-0a0e-43a4-88b5-d2488841e1ef
     status: 200 OK
     code: 200
     duration: ""
@@ -447,10 +447,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -459,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:50 GMT
+      - Mon, 13 Nov 2023 13:51:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fb479b3-d2e4-484c-9e5e-44718ecd9fbe
+      - 333e021d-9f97-4562-93c9-b4701bb08232
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -492,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:55 GMT
+      - Mon, 13 Nov 2023 13:51:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f55330b6-3894-4796-920e-5aeacd7d8779
+      - f8b87237-a47d-48d1-b276-092f94f92a23
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:00 GMT
+      - Mon, 13 Nov 2023 13:51:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b9fe8b2-2a21-4187-bfea-e673e335a5b7
+      - 5416e1a5-49b5-45e2-bf3f-6ae16e06abc6
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:05 GMT
+      - Mon, 13 Nov 2023 13:51:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34fdbc9c-ef91-46ca-8fd1-3a3dd1779808
+      - 62183256-d090-4669-bfbb-adc15ab2a956
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -591,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:11 GMT
+      - Mon, 13 Nov 2023 13:52:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cb57403-7cc0-4347-a967-3af861b588b0
+      - e3782909-81d5-4a93-b796-500e0ef0f87e
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:16 GMT
+      - Mon, 13 Nov 2023 13:52:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e68d6b7-a7d3-4129-93eb-a0a2d1e2d5ca
+      - 3f509e0c-4554-4b6c-905b-c27dd43788a4
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:21 GMT
+      - Mon, 13 Nov 2023 13:52:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46464c65-c819-4dc5-97f8-1d9dcb72e1ca
+      - 4b190aa5-6d95-47b7-b101-7c947a98d4f8
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:26 GMT
+      - Mon, 13 Nov 2023 13:52:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7600d3c-49c6-4d75-8153-f44d97cd3b55
+      - 343bdd9f-ba3c-4bea-a6c5-22920df6c9c4
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:31 GMT
+      - Mon, 13 Nov 2023 13:52:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64e6db03-cea2-4398-9634-a6e2f46608ee
+      - 60b03ed1-84bb-4277-99d0-3a5d2b2a4189
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:36 GMT
+      - Mon, 13 Nov 2023 13:52:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b02e1245-888e-4f9f-ab89-18328f44ffe1
+      - 6ff51157-62ce-4d1b-bccf-1c25c9688b33
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:41 GMT
+      - Mon, 13 Nov 2023 13:52:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8749383-4bbb-4aa5-aa51-01663d0f3306
+      - 3038be13-0da1-485f-9c86-62ff873e36fb
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 13:52:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b2d7fd2-4010-44fa-a606-3b1a7304b60a
+      - 4186389e-f48d-430b-a225-31daf15c2e67
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:51 GMT
+      - Mon, 13 Nov 2023 13:52:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90880842-6525-4663-93ba-3872d3270eeb
+      - 7e46346d-d727-4634-84f8-1a5b939ba7eb
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:56 GMT
+      - Mon, 13 Nov 2023 13:52:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64401b3f-e98c-44c6-b672-87495192a13f
+      - 34b76928-f589-460a-a938-d0405796cc18
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:01 GMT
+      - Mon, 13 Nov 2023 13:52:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a366dea6-88d4-4586-8ccd-fc4361de2fb2
+      - a17a7bf4-9a00-4fb3-8ca4-b381e637f4c7
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:06 GMT
+      - Mon, 13 Nov 2023 13:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 128c8760-a3bd-4daf-bafa-f5bb5b64c5cc
+      - cebcb35b-e7b0-4261-b871-95b2e06864db
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:11 GMT
+      - Mon, 13 Nov 2023 13:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b8257c8-7d17-4034-8f41-24f5e5cdbd67
+      - 824fcc00-6af9-4b1d-8acd-2a464ae8a4b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1020,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:16 GMT
+      - Mon, 13 Nov 2023 13:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b80303a-4ddd-49a8-a0a0-9149ebe719a0
+      - 7bed3524-a64d-47ca-bce7-0395d4298930
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1053,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:21 GMT
+      - Mon, 13 Nov 2023 13:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0260acd9-d64c-470f-a5cb-ae0f61bda6f0
+      - b9c5b3f5-761c-409f-9beb-c258e5c1c89c
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1086,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:26 GMT
+      - Mon, 13 Nov 2023 13:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc692b9a-dfa1-4f69-ba13-4eaf0ef6507a
+      - 6cc3d82d-f9de-4b85-9123-befa0560f382
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1119,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:31 GMT
+      - Mon, 13 Nov 2023 13:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86d02725-4539-4987-be52-b212099c474f
+      - 0fbc6b5f-c8ae-4af1-a6ce-ad693b925122
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1152,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:36 GMT
+      - Mon, 13 Nov 2023 13:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14537edd-ca7f-455f-8d84-c61e5ca34b0b
+      - 093c6691-4174-4605-8765-628661e06555
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1185,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:41 GMT
+      - Mon, 13 Nov 2023 13:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87a05e83-8cf9-4596-a866-ddaffff55ccc
+      - 96c5c2ec-c1fc-4ed6-8451-6296b201595e
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1218,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:47 GMT
+      - Mon, 13 Nov 2023 13:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21f77785-313e-49cc-97e3-1839d15c2053
+      - f403f521-6d0a-4d48-8a4f-efbdcd5be6ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1251,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:52 GMT
+      - Mon, 13 Nov 2023 13:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a04872b-a262-4b6a-8cf8-d312de1c4577
+      - 2f70c224-f3ba-4d74-bf19-23ed732242e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:57 GMT
+      - Mon, 13 Nov 2023 13:53:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05b1ceee-e8ec-4cdb-8ca8-2599961d86fc
+      - 264e2ca9-f1a9-4b64-a670-be31acad9fab
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1317,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:02 GMT
+      - Mon, 13 Nov 2023 13:53:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94877dd3-7f0b-4c67-bd18-f275d1ab5245
+      - 846888d3-4073-45e1-b758-5d8bb922b093
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1350,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:07 GMT
+      - Mon, 13 Nov 2023 13:53:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab9c1be8-53c6-40e7-b697-c3b217ce028b
+      - fcbdb7cd-2c9c-4c66-9e1f-3da38e69a429
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1383,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:12 GMT
+      - Mon, 13 Nov 2023 13:54:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46911545-f749-439c-b90f-2d8d1af2806e
+      - 3b130e69-4115-4cac-ba42-0dc594147775
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1416,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:17 GMT
+      - Mon, 13 Nov 2023 13:54:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5437735-30d9-45d5-ae96-79543c248b9f
+      - 9cd9b064-2ccd-4fcc-8686-99917c9ee818
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1449,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:22 GMT
+      - Mon, 13 Nov 2023 13:54:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45b48a6d-20ef-487b-8261-f61e51f62d73
+      - 1fda0fae-0d9b-430c-b42b-ded982888705
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1482,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:27 GMT
+      - Mon, 13 Nov 2023 13:54:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11911818-2429-4c9c-af14-3259afe62415
+      - 2581df13-2fa7-4941-a081-d49aadd597d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1515,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:32 GMT
+      - Mon, 13 Nov 2023 13:54:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64155f17-1a0e-4999-bd0e-09cd3b55580d
+      - eb0536c0-24fd-4595-bc79-fd5dffad97d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1548,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:37 GMT
+      - Mon, 13 Nov 2023 13:54:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d72fcab-0e90-411a-ba02-43e92278e1f4
+      - 29d2efba-ea26-4968-b27e-50bb8ac21d87
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1581,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:42 GMT
+      - Mon, 13 Nov 2023 13:54:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0be9a381-c8d6-4f94-bf15-2fcf2c580d42
+      - 2eff5eac-89ef-4052-95a7-b374f3506b10
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1614,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 13:54:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd55a183-6c4c-4e99-830f-5373ea5dafb8
+      - 17c01e5f-f066-41e1-994a-dd410b4eeb74
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1647,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:52 GMT
+      - Mon, 13 Nov 2023 13:54:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b76705d-7312-4bc2-9720-0eed9283078b
+      - dda21418-1021-4962-ac54-35bcd5d852bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1680,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:57 GMT
+      - Mon, 13 Nov 2023 13:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0be6e5c3-2741-461c-9fb9-a607910ff1fd
+      - 3784b3a1-96de-4355-88cc-e67c5546d62f
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1713,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:02 GMT
+      - Mon, 13 Nov 2023 13:54:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d371fc2-d474-45a2-9ea4-5c55824489a1
+      - 065278f9-d98b-49e0-b63b-77a8c5c4b42a
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1746,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:07 GMT
+      - Mon, 13 Nov 2023 13:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39481d1c-2d3c-4e2c-817c-6d92e9b00ea3
+      - 75e3df51-3b19-49e4-b537-e25f92c3af1f
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1779,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:12 GMT
+      - Mon, 13 Nov 2023 13:55:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3e4a093-0fc1-428d-8663-93d31c672271
+      - 4934a9c3-2546-4be6-8158-6c9aa9f6fd05
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1812,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:17 GMT
+      - Mon, 13 Nov 2023 13:55:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e813c845-fd0c-460c-bc5c-6374b25b88f1
+      - c5a90da7-e7a4-4b76-a2ad-5f8dfdc001eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1845,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:22 GMT
+      - Mon, 13 Nov 2023 13:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ae129c3-b2e4-477a-8542-9604ef0fcfee
+      - b960d348-9b26-4310-8c16-f0d40bc99e7b
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1878,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:28 GMT
+      - Mon, 13 Nov 2023 13:55:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 768cd2d7-d257-45d5-9190-445176f111f9
+      - 49e28cff-5d64-4a9f-bca4-a9b77c458afa
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1911,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:33 GMT
+      - Mon, 13 Nov 2023 13:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 318ffda4-ead3-4c44-a287-6db0303a95eb
+      - 766eb983-0aea-4c3d-bc90-51a4fda7bfd9
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1944,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:38 GMT
+      - Mon, 13 Nov 2023 13:55:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 846e28ef-2e42-4206-a43e-4fd3375a126b
+      - a2eb68ae-3fe9-4d66-8d8f-cc78a6fe37d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -1977,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:43 GMT
+      - Mon, 13 Nov 2023 13:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5518d44-2d89-42f6-9f62-8fe40e8df873
+      - 89fc6013-3bcf-4296-ad41-a0fad773ac88
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -2010,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:48 GMT
+      - Mon, 13 Nov 2023 13:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccfc44a0-e1db-4d56-9f24-2a9385018c5f
+      - dfbdbe7e-d380-4176-8021-5f44a7095796
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -2043,7 +2043,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:53 GMT
+      - Mon, 13 Nov 2023 13:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4307c00-d280-4393-9eb4-372051006008
+      - edfabbed-a24f-4f0e-9ffa-555c6f3bac1b
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,10 +2064,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -2076,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:58 GMT
+      - Mon, 13 Nov 2023 13:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a98e4857-63e2-4156-9f46-e61ef1418c35
+      - 1631eab9-f800-43a5-92eb-c976b4462a32
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,10 +2097,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:23:35.159613Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "692"
@@ -2109,7 +2109,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:03 GMT
+      - Mon, 13 Nov 2023 13:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36cd2532-23f8-4523-88b6-22214affc2fa
+      - edad1a47-75c7-4150-a068-ba7d2b95dd19
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,10 +2130,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "692"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c9cf041c-00c4-406e-839a-d2e72841676c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "692"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d8457be8-bb05-42b7-ab60-3c4cd792d5c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:51:24.009388Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "692"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - edd3718f-246a-4601-9d7c-eb726ce66102
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:12.606551Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2142,7 +2241,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:08 GMT
+      - Mon, 13 Nov 2023 13:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4902ae2c-c677-47d0-817d-4d10d123ad7a
+      - 6476f22a-d954-48a2-8569-ac842833f65e
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,10 +2262,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.705058Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1511"
@@ -2175,7 +2274,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:08 GMT
+      - Mon, 13 Nov 2023 13:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3997e882-7de9-470e-95cc-e948922fb25e
+      - 18c1b38d-4580-42e4-b0a5-f759768cd4b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,10 +2295,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:12.606551Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2208,7 +2307,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:08 GMT
+      - Mon, 13 Nov 2023 13:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48724cfe-5398-493d-b287-e33c6d9c7935
+      - 8a9c9269-15d4-4c34-a84c-1fc77aa7dc11
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/nodes?order_by=created_at_asc&page=1&pool_id=7af078ed-83f7-45f2-bd37-f098116c5775&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:03.471387Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:10.581390Z","error_message":null,"id":"ec5df55c-b0c2-421c-9e24-79d167e9978d","name":"scw-test-pool-upgrade-test-pool-upgrade-ec5df5","pool_id":"7af078ed-83f7-45f2-bd37-f098116c5775","provider_id":"scaleway://instance/fr-par-1/110c3a12-14ef-47f6-850b-31eca03d54df","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:12.589619Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:08 GMT
+      - Mon, 13 Nov 2023 13:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae71416b-3005-4063-be82-acc8b9fa3120
+      - e3b40f58-bb76-4822-9829-b6ad226e0362
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,10 +2361,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.705058Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1511"
@@ -2274,7 +2373,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:08 GMT
+      - Mon, 13 Nov 2023 13:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ce3c624-dcc9-4c4e-a6e9-d3b9a723d0cc
+      - ec5bdee2-6943-4b93-9d81-878b041140d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2394,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:12.606551Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2307,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:08 GMT
+      - Mon, 13 Nov 2023 13:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d1c2fe2-79b8-42cf-9355-5815210ac650
+      - 9843b034-ae3b-4034-8872-843a69dc5994
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,10 +2427,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dbed4a58-32da-4870-8376-0629a3a5f6b7
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.822758Z","dhcp_enabled":true,"id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.822758Z","id":"fc9c7227-841e-4c91-8ca6-b767e00b16eb","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:51:13.822758Z"},{"created_at":"2023-11-13T13:51:13.822758Z","id":"4c0505d2-09bc-44d3-8f24-6606c2d86d60","subnet":"fd63:256c:45f7:7b5c::/64","updated_at":"2023-11-13T13:51:13.822758Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.822758Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "725"
@@ -2340,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:09 GMT
+      - Mon, 13 Nov 2023 13:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb605bc2-73fb-4ad1-9e30-12176d4ab8f9
+      - d35b4396-0d80-4c6a-b323-88185d3f9577
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,10 +2460,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.705058Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1511"
@@ -2373,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:09 GMT
+      - Mon, 13 Nov 2023 13:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52e8396e-2f1f-45a2-8cc6-1228be484176
+      - 7c139bc8-7b4c-47d8-9166-0e2af80dd714
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,10 +2493,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcE5lazFXYjFoRVZFMTZUVlJGZDA5VVJYcE5hazE2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVWQyQ2tkblREaFVWMVJzWlVzeFNqSkpXbmR0V25aR1pFMW9RMFpwTlVFM09VOXFTbXhKT1RoU1NXbDVhVlUwZUZFckwyUTFaRXhOT1djNWVFUjZaQ3RZU25vS1RVZEZRM015ZVhrdmIwZEpjVU15VmtwWVpITnNTRkp3U2xKNVEwVldVV3N6TWpRMmVHcHBSVVFyY1VGa1FWQmpibmhNTml0TGR6RnZZWEFyUlVWaFpBb3lhMjB4V2pCck0xRktPREpxZGtOTFFtaExURlZJYzBwNGIzWm1SeXRDTUhCdGQwVmpRbUY2SzBsS1MzbHJPVzFPWlRkMFZrZE5jRFI1YmxkNGQzWXhDamxyVERWWWNucDFlbTQyYlVsc1pEQk5OREpuT1hWT1dpdGpiRzgzUWs5WE1VOHpVSE01WVd4TVJIUlRSVGw0U1c5cVNVRkliU3QyU1ZCMFpXcERUR0lLTlZSMFNUSkZiQ3RKTVRKbmFsVjFlRXgyUkd4cGNEUk1NRk5ZV25sV01YYzJjVTVYWTBaRFVDOWhZVk14ZG1zck9XZFpVbU5uVHk5QlEzcGlRMWx5T1FweVlqRklWRWt2YjJGcWNtazRWU3REVnl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFZpdGxLMlJaUlhsRVEzWkVPRzB5Y1VGcWNYaHhVV1puZVhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5HRlJRMHhQWkZoTk1WaEROR3BIWTJkUVR6bHVTRVYwSzBwd2JtNVJSR2RhTlRoUFFqZDJSakpqTTFSUFdGSjJjQXBrVkdreU5GVlplWGgyT0RoNGFWRlVNSHBuTXlzNVpYSXJlVUUxUVhORVQyUm1WRkI1TVZKQlNrdzNXRFpoY1hWV04yNHlRWGR3V2t3elRHbE5RVzB4Q2k5WlRHcFVhbkJsWjFWRWRHTndNbmRXY21kME5ISkxXV2xMVUVKQk5tWjFUbHByVFUxeVZUazVSSEZQTjNGWlF6ZDVabVpEV0cxV1MxVkhla2h2TjNVS04wcEdXRE5MY25nNVkwVnFjRVJ5UzBOaE5WTXpPRU5UTWpJMVJDdDVNSFJwU2toblRIcHVOVmx4VEVSU1RGVkhNbWx6VEc0d1IzSkpVek13WmtkMlVRcEpXUzl6WkhGSWJ6Qk5ZMmhKYWtzMWFGUTNhalI0WlhSVE5UZEVZMjU1Vkd4NFN6TlVkamN2UTJoYVVHTjBNRTE1WVd4UFptTnFOMlJhU0ZWalp5dHZDbXM1TTNNd01rWTVWeTh2VW1SWVpVUlhLMnc0ZUd0dlQzVkNjVFJXZDIxWk9HRk1lQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMjJhMGIzYWItMzAxNC00ZmIxLTljNmYtZmJmNGQ3M2U0ZmMyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5N0FtM3VBSzN3M2xQQ21FS0JTTHFqVmFkREhDRnFST3VMMW04VGh2RnpQYnhxNjBYMEFpUnhvcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFHYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV1p3Q2tSaldUUTRLMWRHYzNabFpYWlhXbWMwVFZvelNFdzNTRVZVYmk5RFIzTmpSbWh0UkdGNWNYRk5VbmhaZUdaVFJYbDJPWGw2V21KME1rZEdkMUpGTTJ3S1NHdFdNSEZYTm0wNVdFTkVibXRqU0ZaRGVWUXJlVXBvYkhCNmFUVktMMlZtVEhOQlkxVlljbEZ6UkdSMGNGQlVUWEZKYjNrcllqZzNaVkZqVkVWcU53cFFRazB6UjFWRVdGbEdNbVZwYmxkVWNUWllRbnAzWkZCYWNGUlZVV0Z1UTI0eVUyNHpOM1ZoZVdsSk0wZDZZakV4V1U0elpXWkRhelJhZFdWc1RqbHJDazFNYTBSelEwTTBOSFZMVGxKaVNVb3lUSEJRVDJ4MlFXRkJabEV6Y0dkbmIxTlhaSEZVUVRVMFpsaHdSREZhUjNjMFZGQlVOMXBDY1RCT2RTdHNkMWtLVTFKaFYybGFNRVpzYUhkdU9HaENUaXMzWnpSUlVXMUJXSFZRV0RJeVZHeHZNR0Z0VTJaUlFqbFRUVVZUVEdwMmJURnhPV05FY1djd1NrdE5NMVl4Y3dvclMzazBabFpuZUdzek5WUm9TMk41YlZSalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTmNXOWFWa29yY0VwT1V6TnZNRFZGVmpSalVXaDJkVVJ3UkVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmIyRTVVVTUzY1ZoaFZsZFRSbk52V1hwSVRsUXJlbmsyY1RRNWNWQkllRXBHUTBJMWR6UnJWVTQxUkhScVdVMVVVd3BCTTBnNGNVd3hjR2QwZDA0NFdtTnNhMGQ0ZWpneWF6ZFhhamRTZUZSdU1VTjRWR3hXVmswNVFuUmFaMlo0VEdGd1pscFNWblpWWmpnM2RtMVVPQ3RXQ210SlRUbHJPSGRoYURkeVIyRjBTbWhTSzJwSU1ISldPRmxoT0U5aFVtMVFaVUk0UjNwWFpGbFFhalpRUWk5allXSm1WMFphTm1kUlpFbEZWRVUxVW5vS00wNTZZMDQ0WnpSM1UzSjVaMnhsU25nNGRFRjFNM2xUVDJRM2J5dGxielZWVm5KTGVsWlhSV2c1Y0ZWTFZGbFBNR3RVUW5sbVdERndhbVpFTUZGQkt3b3dheTlSY0VWUlNGRlZPSGd4VUU5NVNHcDFiMmhzZEhsT1VqbEljRXhIVVhOb1YyVkhWMDAyU21RNFptVkVaeTlLYUhCUlNtb3hhRll4Y0dwVk5FOHdDalJEYnpOT1NHNHhjbU5YYVVGNWNuaHBNMkpxYzFjeU1YVlVaVmhoUzBaaVltbHhTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzdkNTc5YTctYWQxOC00YjBmLTg5ZGQtNmI3ZDM4MjhmNjllLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbzlCUWJjM3BVYkN0MkpubHgxakU1aDBBTkxEQ0h1MTZnbXVsTm4wNFJmek9QVDZDMVhpS0dDdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2686"
@@ -2406,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:09 GMT
+      - Mon, 13 Nov 2023 13:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bc09f65-a921-42d3-96e5-40126787e667
+      - bf1ef63e-8182-46fc-b067-edff05dd87c1
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,10 +2526,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:12.606551Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2439,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:09 GMT
+      - Mon, 13 Nov 2023 13:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d73f2619-29d8-4702-9939-de7241501f86
+      - 63cce18c-a898-4bfb-b84f-47d3669a7e45
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/nodes?order_by=created_at_asc&page=1&pool_id=7af078ed-83f7-45f2-bd37-f098116c5775&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:03.471387Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:10.581390Z","error_message":null,"id":"ec5df55c-b0c2-421c-9e24-79d167e9978d","name":"scw-test-pool-upgrade-test-pool-upgrade-ec5df5","pool_id":"7af078ed-83f7-45f2-bd37-f098116c5775","provider_id":"scaleway://instance/fr-par-1/110c3a12-14ef-47f6-850b-31eca03d54df","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:12.589619Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:09 GMT
+      - Mon, 13 Nov 2023 13:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea3efb4c-e65c-4943-8daa-6a60ae922303
+      - 3df66439-cb39-455e-9fc8-b575ae9961eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,10 +2592,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dbed4a58-32da-4870-8376-0629a3a5f6b7
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.822758Z","dhcp_enabled":true,"id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.822758Z","id":"fc9c7227-841e-4c91-8ca6-b767e00b16eb","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:51:13.822758Z"},{"created_at":"2023-11-13T13:51:13.822758Z","id":"4c0505d2-09bc-44d3-8f24-6606c2d86d60","subnet":"fd63:256c:45f7:7b5c::/64","updated_at":"2023-11-13T13:51:13.822758Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.822758Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "725"
@@ -2505,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:09 GMT
+      - Mon, 13 Nov 2023 13:56:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 667f3a38-6dcd-4259-8c48-bfe891a4bcbc
+      - 80d173fe-6f0b-4195-bee6-76e7957755e9
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,10 +2625,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.705058Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1511"
@@ -2538,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:10 GMT
+      - Mon, 13 Nov 2023 13:56:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a72dec04-c5e1-4e2b-9f1c-3f9b69b90a15
+      - edc9c820-d0dc-41c4-86fe-b0c2e18987fd
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,10 +2658,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcE5lazFXYjFoRVZFMTZUVlJGZDA5VVJYcE5hazE2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVWQyQ2tkblREaFVWMVJzWlVzeFNqSkpXbmR0V25aR1pFMW9RMFpwTlVFM09VOXFTbXhKT1RoU1NXbDVhVlUwZUZFckwyUTFaRXhOT1djNWVFUjZaQ3RZU25vS1RVZEZRM015ZVhrdmIwZEpjVU15VmtwWVpITnNTRkp3U2xKNVEwVldVV3N6TWpRMmVHcHBSVVFyY1VGa1FWQmpibmhNTml0TGR6RnZZWEFyUlVWaFpBb3lhMjB4V2pCck0xRktPREpxZGtOTFFtaExURlZJYzBwNGIzWm1SeXRDTUhCdGQwVmpRbUY2SzBsS1MzbHJPVzFPWlRkMFZrZE5jRFI1YmxkNGQzWXhDamxyVERWWWNucDFlbTQyYlVsc1pEQk5OREpuT1hWT1dpdGpiRzgzUWs5WE1VOHpVSE01WVd4TVJIUlRSVGw0U1c5cVNVRkliU3QyU1ZCMFpXcERUR0lLTlZSMFNUSkZiQ3RKTVRKbmFsVjFlRXgyUkd4cGNEUk1NRk5ZV25sV01YYzJjVTVYWTBaRFVDOWhZVk14ZG1zck9XZFpVbU5uVHk5QlEzcGlRMWx5T1FweVlqRklWRWt2YjJGcWNtazRWU3REVnl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFZpdGxLMlJaUlhsRVEzWkVPRzB5Y1VGcWNYaHhVV1puZVhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5HRlJRMHhQWkZoTk1WaEROR3BIWTJkUVR6bHVTRVYwSzBwd2JtNVJSR2RhTlRoUFFqZDJSakpqTTFSUFdGSjJjQXBrVkdreU5GVlplWGgyT0RoNGFWRlVNSHBuTXlzNVpYSXJlVUUxUVhORVQyUm1WRkI1TVZKQlNrdzNXRFpoY1hWV04yNHlRWGR3V2t3elRHbE5RVzB4Q2k5WlRHcFVhbkJsWjFWRWRHTndNbmRXY21kME5ISkxXV2xMVUVKQk5tWjFUbHByVFUxeVZUazVSSEZQTjNGWlF6ZDVabVpEV0cxV1MxVkhla2h2TjNVS04wcEdXRE5MY25nNVkwVnFjRVJ5UzBOaE5WTXpPRU5UTWpJMVJDdDVNSFJwU2toblRIcHVOVmx4VEVSU1RGVkhNbWx6VEc0d1IzSkpVek13WmtkMlVRcEpXUzl6WkhGSWJ6Qk5ZMmhKYWtzMWFGUTNhalI0WlhSVE5UZEVZMjU1Vkd4NFN6TlVkamN2UTJoYVVHTjBNRTE1WVd4UFptTnFOMlJhU0ZWalp5dHZDbXM1TTNNd01rWTVWeTh2VW1SWVpVUlhLMnc0ZUd0dlQzVkNjVFJXZDIxWk9HRk1lQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMjJhMGIzYWItMzAxNC00ZmIxLTljNmYtZmJmNGQ3M2U0ZmMyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5N0FtM3VBSzN3M2xQQ21FS0JTTHFqVmFkREhDRnFST3VMMW04VGh2RnpQYnhxNjBYMEFpUnhvcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFHYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV1p3Q2tSaldUUTRLMWRHYzNabFpYWlhXbWMwVFZvelNFdzNTRVZVYmk5RFIzTmpSbWh0UkdGNWNYRk5VbmhaZUdaVFJYbDJPWGw2V21KME1rZEdkMUpGTTJ3S1NHdFdNSEZYTm0wNVdFTkVibXRqU0ZaRGVWUXJlVXBvYkhCNmFUVktMMlZtVEhOQlkxVlljbEZ6UkdSMGNGQlVUWEZKYjNrcllqZzNaVkZqVkVWcU53cFFRazB6UjFWRVdGbEdNbVZwYmxkVWNUWllRbnAzWkZCYWNGUlZVV0Z1UTI0eVUyNHpOM1ZoZVdsSk0wZDZZakV4V1U0elpXWkRhelJhZFdWc1RqbHJDazFNYTBSelEwTTBOSFZMVGxKaVNVb3lUSEJRVDJ4MlFXRkJabEV6Y0dkbmIxTlhaSEZVUVRVMFpsaHdSREZhUjNjMFZGQlVOMXBDY1RCT2RTdHNkMWtLVTFKaFYybGFNRVpzYUhkdU9HaENUaXMzWnpSUlVXMUJXSFZRV0RJeVZHeHZNR0Z0VTJaUlFqbFRUVVZUVEdwMmJURnhPV05FY1djd1NrdE5NMVl4Y3dvclMzazBabFpuZUdzek5WUm9TMk41YlZSalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTmNXOWFWa29yY0VwT1V6TnZNRFZGVmpSalVXaDJkVVJ3UkVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmIyRTVVVTUzY1ZoaFZsZFRSbk52V1hwSVRsUXJlbmsyY1RRNWNWQkllRXBHUTBJMWR6UnJWVTQxUkhScVdVMVVVd3BCTTBnNGNVd3hjR2QwZDA0NFdtTnNhMGQ0ZWpneWF6ZFhhamRTZUZSdU1VTjRWR3hXVmswNVFuUmFaMlo0VEdGd1pscFNWblpWWmpnM2RtMVVPQ3RXQ210SlRUbHJPSGRoYURkeVIyRjBTbWhTSzJwSU1ISldPRmxoT0U5aFVtMVFaVUk0UjNwWFpGbFFhalpRUWk5allXSm1WMFphTm1kUlpFbEZWRVUxVW5vS00wNTZZMDQ0WnpSM1UzSjVaMnhsU25nNGRFRjFNM2xUVDJRM2J5dGxielZWVm5KTGVsWlhSV2c1Y0ZWTFZGbFBNR3RVUW5sbVdERndhbVpFTUZGQkt3b3dheTlSY0VWUlNGRlZPSGd4VUU5NVNHcDFiMmhzZEhsT1VqbEljRXhIVVhOb1YyVkhWMDAyU21RNFptVkVaeTlLYUhCUlNtb3hhRll4Y0dwVk5FOHdDalJEYnpOT1NHNHhjbU5YYVVGNWNuaHBNMkpxYzFjeU1YVlVaVmhoUzBaaVltbHhTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzdkNTc5YTctYWQxOC00YjBmLTg5ZGQtNmI3ZDM4MjhmNjllLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbzlCUWJjM3BVYkN0MkpubHgxakU1aDBBTkxEQ0h1MTZnbXVsTm4wNFJmek9QVDZDMVhpS0dDdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2686"
@@ -2571,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:10 GMT
+      - Mon, 13 Nov 2023 13:56:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 343da2da-7eed-4b33-a04f-4b2c5b78c80e
+      - 1c505fcd-0ec7-4ff1-a92b-f761ead591e2
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,10 +2691,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:03.485726Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:12.606551Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2604,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:10 GMT
+      - Mon, 13 Nov 2023 13:56:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a97b254-f958-482e-96ca-3ea157cb75e1
+      - 1293821d-98ce-4764-91e7-baf2dea97ec2
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,19 +2724,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/nodes?order_by=created_at_asc&page=1&pool_id=7af078ed-83f7-45f2-bd37-f098116c5775&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:03.471387Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:10.581390Z","error_message":null,"id":"ec5df55c-b0c2-421c-9e24-79d167e9978d","name":"scw-test-pool-upgrade-test-pool-upgrade-ec5df5","pool_id":"7af078ed-83f7-45f2-bd37-f098116c5775","provider_id":"scaleway://instance/fr-par-1/110c3a12-14ef-47f6-850b-31eca03d54df","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:12.589619Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:10 GMT
+      - Mon, 13 Nov 2023 13:56:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc0831a9-57c6-48a0-8b39-54b7622a1c32
+      - 86cc7a6e-b833-4a55-9adc-5ad4d9191638
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,10 +2759,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: PATCH
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785756541Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:19.146085135Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "693"
@@ -2672,7 +2771,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2682,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d7c6ab8-bba1-4346-b81e-8c3b37006c4f
+      - 99d7e26f-31b5-424f-8aea-6a3542ae382d
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,10 +2792,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785757Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:19.146085Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2705,7 +2804,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2715,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e50f87cf-6a7a-40b0-ba13-04a391e4cb7e
+      - c9508ed4-445f-4e30-879f-5d612b777617
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,10 +2825,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785757Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:19.146085Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2738,7 +2837,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b06f43f-cd71-4f71-bcc5-d14837bafc09
+      - cfe46b79-8c53-4fa7-a2b1-f955ee7f55cc
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,19 +2858,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/nodes?order_by=created_at_asc&page=1&pool_id=7af078ed-83f7-45f2-bd37-f098116c5775&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:03.471387Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:10.581390Z","error_message":null,"id":"ec5df55c-b0c2-421c-9e24-79d167e9978d","name":"scw-test-pool-upgrade-test-pool-upgrade-ec5df5","pool_id":"7af078ed-83f7-45f2-bd37-f098116c5775","provider_id":"scaleway://instance/fr-par-1/110c3a12-14ef-47f6-850b-31eca03d54df","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:12.589619Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2781,7 +2880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 024bc6c8-20fe-4474-acf5-7d0b04267f61
+      - eaef58ea-c777-4d6f-94c5-cf13b1f6b901
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,10 +2891,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.705058Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1511"
@@ -2804,7 +2903,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3babd233-a5c6-4a58-9415-4fb305e50c5a
+      - 0a28b72c-1fb3-4b2f-baae-4f96b54d93c2
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,10 +2924,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785757Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:19.146085Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2837,7 +2936,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08163227-fcd0-4cbf-8f46-258cbe92fec7
+      - fb813773-3972-4b67-aade-31a3b0495be6
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,10 +2957,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dbed4a58-32da-4870-8376-0629a3a5f6b7
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:23:28.620833Z","dhcp_enabled":true,"id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:23:28.620833Z","id":"fe07d182-74ee-4f65-9f67-0d590d0f50e4","subnet":"172.16.52.0/22","updated_at":"2023-11-10T13:23:28.620833Z"},{"created_at":"2023-11-10T13:23:28.620833Z","id":"6a0ee991-e458-42c9-a9b1-cdc910cad4b8","subnet":"fd63:256c:45f7:3f5c::/64","updated_at":"2023-11-10T13:23:28.620833Z"}],"tags":[],"updated_at":"2023-11-10T13:23:28.620833Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.822758Z","dhcp_enabled":true,"id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.822758Z","id":"fc9c7227-841e-4c91-8ca6-b767e00b16eb","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:51:13.822758Z"},{"created_at":"2023-11-13T13:51:13.822758Z","id":"4c0505d2-09bc-44d3-8f24-6606c2d86d60","subnet":"fd63:256c:45f7:7b5c::/64","updated_at":"2023-11-13T13:51:13.822758Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.822758Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "725"
@@ -2870,7 +2969,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0487bfa4-a585-4775-8e30-e66b04deef95
+      - c8f99574-d38a-4abf-b62b-fcb9bb90b4a6
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,10 +2990,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:24:49.760800Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:52:43.705058Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1511"
@@ -2903,7 +3002,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70589c00-300f-4e08-a6f6-423d8d3172b4
+      - 4f36f4f9-f0b7-4dce-8a6d-bc95e210187d
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,10 +3023,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRXcE5lazFXYjFoRVZFMTZUVlJGZDA5VVJYcE5hazE2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVWQyQ2tkblREaFVWMVJzWlVzeFNqSkpXbmR0V25aR1pFMW9RMFpwTlVFM09VOXFTbXhKT1RoU1NXbDVhVlUwZUZFckwyUTFaRXhOT1djNWVFUjZaQ3RZU25vS1RVZEZRM015ZVhrdmIwZEpjVU15VmtwWVpITnNTRkp3U2xKNVEwVldVV3N6TWpRMmVHcHBSVVFyY1VGa1FWQmpibmhNTml0TGR6RnZZWEFyUlVWaFpBb3lhMjB4V2pCck0xRktPREpxZGtOTFFtaExURlZJYzBwNGIzWm1SeXRDTUhCdGQwVmpRbUY2SzBsS1MzbHJPVzFPWlRkMFZrZE5jRFI1YmxkNGQzWXhDamxyVERWWWNucDFlbTQyYlVsc1pEQk5OREpuT1hWT1dpdGpiRzgzUWs5WE1VOHpVSE01WVd4TVJIUlRSVGw0U1c5cVNVRkliU3QyU1ZCMFpXcERUR0lLTlZSMFNUSkZiQ3RKTVRKbmFsVjFlRXgyUkd4cGNEUk1NRk5ZV25sV01YYzJjVTVYWTBaRFVDOWhZVk14ZG1zck9XZFpVbU5uVHk5QlEzcGlRMWx5T1FweVlqRklWRWt2YjJGcWNtazRWU3REVnl0elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFZpdGxLMlJaUlhsRVEzWkVPRzB5Y1VGcWNYaHhVV1puZVhGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5HRlJRMHhQWkZoTk1WaEROR3BIWTJkUVR6bHVTRVYwSzBwd2JtNVJSR2RhTlRoUFFqZDJSakpqTTFSUFdGSjJjQXBrVkdreU5GVlplWGgyT0RoNGFWRlVNSHBuTXlzNVpYSXJlVUUxUVhORVQyUm1WRkI1TVZKQlNrdzNXRFpoY1hWV04yNHlRWGR3V2t3elRHbE5RVzB4Q2k5WlRHcFVhbkJsWjFWRWRHTndNbmRXY21kME5ISkxXV2xMVUVKQk5tWjFUbHByVFUxeVZUazVSSEZQTjNGWlF6ZDVabVpEV0cxV1MxVkhla2h2TjNVS04wcEdXRE5MY25nNVkwVnFjRVJ5UzBOaE5WTXpPRU5UTWpJMVJDdDVNSFJwU2toblRIcHVOVmx4VEVSU1RGVkhNbWx6VEc0d1IzSkpVek13WmtkMlVRcEpXUzl6WkhGSWJ6Qk5ZMmhKYWtzMWFGUTNhalI0WlhSVE5UZEVZMjU1Vkd4NFN6TlVkamN2UTJoYVVHTjBNRTE1WVd4UFptTnFOMlJhU0ZWalp5dHZDbXM1TTNNd01rWTVWeTh2VW1SWVpVUlhLMnc0ZUd0dlQzVkNjVFJXZDIxWk9HRk1lQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMjJhMGIzYWItMzAxNC00ZmIxLTljNmYtZmJmNGQ3M2U0ZmMyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5N0FtM3VBSzN3M2xQQ21FS0JTTHFqVmFkREhDRnFST3VMMW04VGh2RnpQYnhxNjBYMEFpUnhvcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUkZlVTFHYjFoRVZFMTZUVlJGZUUxcVJYcE9WRVY1VFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV1p3Q2tSaldUUTRLMWRHYzNabFpYWlhXbWMwVFZvelNFdzNTRVZVYmk5RFIzTmpSbWh0UkdGNWNYRk5VbmhaZUdaVFJYbDJPWGw2V21KME1rZEdkMUpGTTJ3S1NHdFdNSEZYTm0wNVdFTkVibXRqU0ZaRGVWUXJlVXBvYkhCNmFUVktMMlZtVEhOQlkxVlljbEZ6UkdSMGNGQlVUWEZKYjNrcllqZzNaVkZqVkVWcU53cFFRazB6UjFWRVdGbEdNbVZwYmxkVWNUWllRbnAzWkZCYWNGUlZVV0Z1UTI0eVUyNHpOM1ZoZVdsSk0wZDZZakV4V1U0elpXWkRhelJhZFdWc1RqbHJDazFNYTBSelEwTTBOSFZMVGxKaVNVb3lUSEJRVDJ4MlFXRkJabEV6Y0dkbmIxTlhaSEZVUVRVMFpsaHdSREZhUjNjMFZGQlVOMXBDY1RCT2RTdHNkMWtLVTFKaFYybGFNRVpzYUhkdU9HaENUaXMzWnpSUlVXMUJXSFZRV0RJeVZHeHZNR0Z0VTJaUlFqbFRUVVZUVEdwMmJURnhPV05FY1djd1NrdE5NMVl4Y3dvclMzazBabFpuZUdzek5WUm9TMk41YlZSalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTmNXOWFWa29yY0VwT1V6TnZNRFZGVmpSalVXaDJkVVJ3UkVwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmIyRTVVVTUzY1ZoaFZsZFRSbk52V1hwSVRsUXJlbmsyY1RRNWNWQkllRXBHUTBJMWR6UnJWVTQxUkhScVdVMVVVd3BCTTBnNGNVd3hjR2QwZDA0NFdtTnNhMGQ0ZWpneWF6ZFhhamRTZUZSdU1VTjRWR3hXVmswNVFuUmFaMlo0VEdGd1pscFNWblpWWmpnM2RtMVVPQ3RXQ210SlRUbHJPSGRoYURkeVIyRjBTbWhTSzJwSU1ISldPRmxoT0U5aFVtMVFaVUk0UjNwWFpGbFFhalpRUWk5allXSm1WMFphTm1kUlpFbEZWRVUxVW5vS00wNTZZMDQ0WnpSM1UzSjVaMnhsU25nNGRFRjFNM2xUVDJRM2J5dGxielZWVm5KTGVsWlhSV2c1Y0ZWTFZGbFBNR3RVUW5sbVdERndhbVpFTUZGQkt3b3dheTlSY0VWUlNGRlZPSGd4VUU5NVNHcDFiMmhzZEhsT1VqbEljRXhIVVhOb1YyVkhWMDAyU21RNFptVkVaeTlLYUhCUlNtb3hhRll4Y0dwVk5FOHdDalJEYnpOT1NHNHhjbU5YYVVGNWNuaHBNMkpxYzFjeU1YVlVaVmhoUzBaaVltbHhTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzdkNTc5YTctYWQxOC00YjBmLTg5ZGQtNmI3ZDM4MjhmNjllLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbzlCUWJjM3BVYkN0MkpubHgxakU1aDBBTkxEQ0h1MTZnbXVsTm4wNFJmek9QVDZDMVhpS0dDdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2686"
@@ -2936,7 +3035,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:11 GMT
+      - Mon, 13 Nov 2023 13:56:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84c15e68-3b42-483d-b326-f5cecbbac5f6
+      - 3e024b65-d4a4-45d0-a9e6-433450d0d045
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,10 +3056,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:10.785757Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:19.146085Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "690"
@@ -2969,7 +3068,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:12 GMT
+      - Mon, 13 Nov 2023 13:56:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b986224-0ac7-4a07-ac1c-3d24b8cf884a
+      - 937edbda-1809-47e5-962c-d1f95b54d14d
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,19 +3089,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2/nodes?order_by=created_at_asc&page=1&pool_id=1a832238-bd36-418b-9d9d-6b71d74ffd03&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e/nodes?order_by=created_at_asc&page=1&pool_id=7af078ed-83f7-45f2-bd37-f098116c5775&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:24:51.187783Z","error_message":null,"id":"bb421631-54c6-45fe-b4aa-cf1868e5de3c","name":"scw-test-pool-upgrade-test-pool-upgrade-bb4216","pool_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","provider_id":"scaleway://instance/fr-par-1/6a9a9d99-d526-4002-97c5-c3de424dbb4c","public_ip_v4":"163.172.164.36","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:28:11.485377Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:10.581390Z","error_message":null,"id":"ec5df55c-b0c2-421c-9e24-79d167e9978d","name":"scw-test-pool-upgrade-test-pool-upgrade-ec5df5","pool_id":"7af078ed-83f7-45f2-bd37-f098116c5775","provider_id":"scaleway://instance/fr-par-1/110c3a12-14ef-47f6-850b-31eca03d54df","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:56:19.887216Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "689"
+      - "688"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:12 GMT
+      - Mon, 13 Nov 2023 13:56:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a4a22bc-77ab-46e6-9554-3d58345eea28
+      - 6257b693-1d64-4808-8512-3dbf3828efa7
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,10 +3122,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950169Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:21.219691578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "696"
@@ -3035,7 +3134,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:12 GMT
+      - Mon, 13 Nov 2023 13:56:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f7a5e01-a92d-4ec5-ab70-824692622607
+      - d7a49734-03fe-4259-acf1-d05e02cd96e9
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,10 +3155,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:21.219692Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "693"
@@ -3068,7 +3167,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:12 GMT
+      - Mon, 13 Nov 2023 13:56:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48cbce76-b5b1-45ab-a92c-bda29f165922
+      - 22a36457-29bf-4c09-a8a6-a8b4886613a9
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,10 +3188,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:21.219692Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "693"
@@ -3101,7 +3200,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:17 GMT
+      - Mon, 13 Nov 2023 13:56:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea98b76d-6d75-4878-a662-ffd80ae9e050
+      - 0291f33a-7c03-4baa-b0fd-cb853168354e
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,10 +3221,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:21.219692Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "693"
@@ -3134,7 +3233,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:22 GMT
+      - Mon, 13 Nov 2023 13:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 263291ea-c062-44bd-bc42-faeb61f4f500
+      - 4335d943-45d7-4305-86ad-e2f34273c92a
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,10 +3254,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","container_runtime":"containerd","created_at":"2023-11-13T13:51:23.998909Z","id":"7af078ed-83f7-45f2-bd37-f098116c5775","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-13T13:56:21.219692Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "693"
@@ -3167,7 +3266,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:28 GMT
+      - Mon, 13 Nov 2023 13:56:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5340b07-d762-44a9-bdcd-ab3e20bfe1a5
+      - 6b55fe64-71aa-4391-a92f-65c8bfeeeec7
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,43 +3287,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","container_runtime":"containerd","created_at":"2023-11-10T13:23:35.150306Z","id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-10T13:28:12.801950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "693"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f61094e-851c-49ba-ae5f-2881ba143da7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"7af078ed-83f7-45f2-bd37-f098116c5775","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3233,7 +3299,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:38 GMT
+      - Mon, 13 Nov 2023 13:56:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3243,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66f95cfd-7cb9-4c36-b235-08132c44ae01
+      - e06c11fd-768a-46f1-af88-39f602817055
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3254,10 +3320,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:28:38.222237160Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:56:41.529496406Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1517"
@@ -3266,7 +3332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:38 GMT
+      - Mon, 13 Nov 2023 13:56:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - deb103b9-d006-4763-a4d3-c9299ef43eda
+      - 67b87351-98a3-4426-a34a-22ace1261fdf
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,10 +3353,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:28:38.222237Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:56:41.529496Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1514"
@@ -3299,7 +3365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:38 GMT
+      - Mon, 13 Nov 2023 13:56:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e43e535-04d0-43ec-8bcb-9b7bd19cf1bb
+      - 3f0b578b-4494-4728-a9fc-401f0672e5e2
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,10 +3386,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:23:29.665035Z","created_at":"2023-11-10T13:23:29.665035Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-10T13:28:38.222237Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:56:41.529496Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1514"
@@ -3332,7 +3398,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:43 GMT
+      - Mon, 13 Nov 2023 13:56:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74d1d32a-9e16-47eb-a618-7610fd875884
+      - 84a53bbb-6507-4ab1-b36a-a87fec702ad1
     status: 200 OK
     code: 200
     duration: ""
@@ -3353,10 +3419,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:51:18.577684Z","created_at":"2023-11-13T13:51:18.577684Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c7d579a7-ad18-4b0f-89dd-6b7d3828f69e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-13T13:56:41.529496Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1514"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a1cbd985-4690-4170-b56b-cc7e933c153e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3365,7 +3464,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:48 GMT
+      - Mon, 13 Nov 2023 13:56:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f314e888-0341-4ff0-9b67-7c3c415833c4
+      - 5da656cf-af39-4a54-91a8-7b23cb1943aa
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3386,10 +3485,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dbed4a58-32da-4870-8376-0629a3a5f6b7
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3398,7 +3497,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:48 GMT
+      - Mon, 13 Nov 2023 13:56:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d813436-51c0-4125-91d1-e8d25d80d26e
+      - 81a1b954-fc74-4088-b968-45f9e89c4a20
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3419,76 +3518,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/df80979d-0105-4fbf-bd94-ee982a1d2c06
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7af078ed-83f7-45f2-bd37-f098116c5775
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"df80979d-0105-4fbf-bd94-ee982a1d2c06","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 171b804d-9e86-4984-9894-d1c4131951d0
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"22a0b3ab-3014-4fb1-9c6f-fbf4d73e4fc2","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 68004be9-1b30-4a19-ab28-674d6eaf8416
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1a832238-bd36-418b-9d9d-6b71d74ffd03
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"1a832238-bd36-418b-9d9d-6b71d74ffd03","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"7af078ed-83f7-45f2-bd37-f098116c5775","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3497,7 +3530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:48 GMT
+      - Mon, 13 Nov 2023 13:56:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +3540,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e966aeeb-887b-4cfe-98c8-0a00c56039bd
+      - da29ce2c-8be7-47aa-9c17-c8f8ef73a908
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c7d579a7-ad18-4b0f-89dd-6b7d3828f69e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"c7d579a7-ad18-4b0f-89dd-6b7d3828f69e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 268abf63-502e-44f8-9fb5-1452b160f0cc
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dbed4a58-32da-4870-8376-0629a3a5f6b7
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"dbed4a58-32da-4870-8376-0629a3a5f6b7","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:56:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86da92c3-86bc-476f-8414-55d111c05ec1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-wait.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-wait.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76c36606-08f6-415e-bccc-4cb6ddd648f4
+      - ca69c956-8b76-4952-9c87-ca344a861c03
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75d99bdf-ffe4-472e-bee1-82691d642b87
+      - 677ef8e1-413a-46f4-b762-b6557f8837d5
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55560b99-1e5a-497b-9702-9b4dc0b05ed3
+      - 3544c880-9d21-4fe1-a4c5-0a8677c430b7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-wait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-wait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901389Z","created_at":"2023-11-10T13:16:58.936901389Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.991811604Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504101Z","created_at":"2023-11-13T13:51:18.420504101Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.431287047Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1506"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:59 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6be808d9-780c-40f0-8384-4ae9791810a2
+      - 9d0a024c-c48f-45bc-8997-a9d4ec21f618
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.991812Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.431287Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:59 GMT
+      - Mon, 13 Nov 2023 13:51:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9813709-0306-4138-a952-810f486eea6f
+      - c875dee8-60e4-4d1c-8979-0004b6e19b33
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.188493Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:18.431287Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1497"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:51:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 72a06fdc-996b-4d5b-a600-c03de9a400e2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:24.074736Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1502"
@@ -193,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7df967c-791e-40c5-a074-ce3b9e20ce50
+      - b9d39da7-20ac-4a51-95be-7158d5cbc685
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.188493Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:24.074736Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1502"
@@ -226,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d4f59e8-b639-4246-9e34-30647f43fe8e
+      - 588bae3e-de0e-49b7-8889-d8790fae15d6
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -259,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69b64b11-8099-4a4b-9c04-ce7288446566
+      - c99057eb-7d0b-4c9c-85f6-69bf9680014a
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +313,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:17:01.188493Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:51:24.074736Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1502"
@@ -292,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 833dbe79-afce-40af-922e-bceca20037b8
+      - e7b980c1-8781-4232-9373-63bd6b62e27b
     status: 200 OK
     code: 200
     duration: ""
@@ -315,10 +348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461657749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068144Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -327,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b50493c4-6553-4685-a46e-4ace4c692778
+      - aa42f0cd-5f99-421f-9205-1683c2235c68
     status: 200 OK
     code: 200
     duration: ""
@@ -348,10 +381,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -360,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1845e72-c976-4c0a-ae4d-419b1ea8db02
+      - e4a2530d-4861-467b-8a4f-9763baf1c98f
     status: 200 OK
     code: 200
     duration: ""
@@ -381,10 +414,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -393,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:09 GMT
+      - Mon, 13 Nov 2023 13:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9078d3bf-0598-4d70-a476-a8d724ff0954
+      - 2cf2dc3f-d5be-455c-bcb6-3b0828a09b84
     status: 200 OK
     code: 200
     duration: ""
@@ -414,10 +447,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -426,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:15 GMT
+      - Mon, 13 Nov 2023 13:51:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e03ca22-d670-4e8f-8119-43151923a6da
+      - c299c2e9-a12b-43d1-addd-f1d1b3e28c54
     status: 200 OK
     code: 200
     duration: ""
@@ -447,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -459,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:51:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8fdd274-2fb3-45c9-8f6f-7386c8ddf8c2
+      - 78eaf293-56d8-4627-ac02-549238642a37
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -492,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:25 GMT
+      - Mon, 13 Nov 2023 13:51:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6ffa5b4-a7b5-4e52-aa36-cfab7c1c5bf3
+      - ba27a816-c68a-43d5-bb68-f25669e1839d
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -525,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:30 GMT
+      - Mon, 13 Nov 2023 13:51:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d821872-4481-4e84-859d-75ab4da0d90e
+      - 9197404a-9536-442f-b6db-3b20ffaed6fd
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -558,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:35 GMT
+      - Mon, 13 Nov 2023 13:52:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80d3252c-f2c0-4b4f-834f-915ff5e90e53
+      - 47190214-2916-4f0e-9f8f-aa567d33e82a
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -591,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:40 GMT
+      - Mon, 13 Nov 2023 13:52:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d68eab84-25ba-414e-a867-950b33e446df
+      - 6660aacd-b46d-474a-9a51-d89357cb5fd0
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -624,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:46 GMT
+      - Mon, 13 Nov 2023 13:52:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23f5f7f6-9897-4106-b6fc-160e2f40fb1a
+      - ceade8a0-8a69-4e23-b87f-0871c39c8256
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -657,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:51 GMT
+      - Mon, 13 Nov 2023 13:52:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4184929f-a83f-41dd-a71d-4ef37e530deb
+      - 85a65f91-e57d-4309-913c-437d5538ddd6
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -690,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:56 GMT
+      - Mon, 13 Nov 2023 13:52:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79420198-60f8-4702-9fd2-b314d3381eca
+      - ece1c165-fa33-4796-82e8-88f850f4e1bb
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -723,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:01 GMT
+      - Mon, 13 Nov 2023 13:52:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dac2fc1-dd65-449d-821f-638f8f61f125
+      - 2129768b-1cfa-4e7a-ab79-856b8cbe6104
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -756,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:06 GMT
+      - Mon, 13 Nov 2023 13:52:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 153f105e-257d-469f-8f1f-364b5cf94a8d
+      - 07907710-5849-4096-a7fa-3a080c2a50e5
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -789,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:11 GMT
+      - Mon, 13 Nov 2023 13:52:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86057476-3e8b-4b2a-87e2-018cf678ae01
+      - 2c3657ac-09c0-4177-b0b1-ed9eeb68378e
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -822,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:16 GMT
+      - Mon, 13 Nov 2023 13:52:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2143ad48-383f-44a2-b243-1ff132516636
+      - d921562e-8c88-481b-afb9-d438d2999d37
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -855,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:21 GMT
+      - Mon, 13 Nov 2023 13:52:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f51b781-dbe5-4ffb-9a1c-a8bec5d59d72
+      - 7a41ef40-0004-4c8f-bae0-e82ce8896ed8
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -888,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:26 GMT
+      - Mon, 13 Nov 2023 13:52:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a8f27a6-3529-43fe-89e7-a2f3b0fcf296
+      - 539f35e8-cd80-43a7-aae7-03dd67532924
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -921,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:31 GMT
+      - Mon, 13 Nov 2023 13:52:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 406ff31c-4874-4263-a6c6-aea3bc0e6a9f
+      - c5b7c909-fcaf-43ad-a14e-b8c96df09659
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -954,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:36 GMT
+      - Mon, 13 Nov 2023 13:53:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0de53903-6510-41ad-95f8-0620d4f8613f
+      - 295d58d8-c11c-4f40-8f77-88f0bf0c02c4
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -987,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:41 GMT
+      - Mon, 13 Nov 2023 13:53:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 432d07f2-7dda-4460-9ac1-735797d52698
+      - 7813bca3-ed33-45cb-a608-e7050932d715
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1020,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:46 GMT
+      - Mon, 13 Nov 2023 13:53:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03ba0ecb-68d0-4ec7-bc37-3092bf6d28f3
+      - b4f8e73b-e90e-4739-950b-89255133b630
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1053,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:51 GMT
+      - Mon, 13 Nov 2023 13:53:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c461edb-eed5-41d2-abeb-4f35851ae1d7
+      - 69c4bc0f-5be5-483f-9858-efecd3805c9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1086,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:57 GMT
+      - Mon, 13 Nov 2023 13:53:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d442e039-e498-4f36-9500-2afa01e13604
+      - e7ccf67b-8571-4e44-9757-6a2cb29ef68e
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1119,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:02 GMT
+      - Mon, 13 Nov 2023 13:53:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99251777-e949-4de7-974a-706e5ca4c252
+      - 9ac030b1-f8c5-4596-969c-fe6e3bf80fcf
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1152,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:07 GMT
+      - Mon, 13 Nov 2023 13:53:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 014c4e6d-211a-425c-8b2e-361077fbba66
+      - a674456a-52b7-4214-814d-a4b78b272616
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1185,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:12 GMT
+      - Mon, 13 Nov 2023 13:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 408159b9-ab88-4fb0-ae88-c5defc018c55
+      - 8d801108-3e54-4245-be88-1b84ed106a67
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1218,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:17 GMT
+      - Mon, 13 Nov 2023 13:53:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 995fab4c-c0c0-4346-90a4-fa4acd7b6f69
+      - 9296ae98-25f9-41e0-9571-e534423777d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1251,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:22 GMT
+      - Mon, 13 Nov 2023 13:53:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50ece3a9-4d23-4da0-8ad3-ffda30360d7a
+      - b67d1449-13c4-4a4f-bd3f-58cc9359bc15
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1284,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:27 GMT
+      - Mon, 13 Nov 2023 13:53:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ee6f3c4-1d25-49df-a949-7cdc4fb9329c
+      - 1b3f27d9-6f93-4f04-b237-04af50f7e014
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1317,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:32 GMT
+      - Mon, 13 Nov 2023 13:54:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06ce63e1-d922-49b6-ae7f-751e479d4eb8
+      - 3b6bf634-2901-4b3d-b363-cf6a3d1f9517
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1350,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:37 GMT
+      - Mon, 13 Nov 2023 13:54:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 554cdb1e-67c2-4919-bab2-98383f84aa06
+      - 31b0d442-df03-4b52-89cc-938c2055d111
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1383,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:42 GMT
+      - Mon, 13 Nov 2023 13:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 763f9010-862c-4300-bfd7-9ac11b25dad5
+      - 9645498c-da13-4179-a966-06a2732eae3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1416,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:47 GMT
+      - Mon, 13 Nov 2023 13:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e336972-dd2d-478b-bddd-10488a7dfd1b
+      - 355fc2b1-0aa0-45ae-ae74-2e5695e6405e
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1449,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:52 GMT
+      - Mon, 13 Nov 2023 13:54:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93c052ef-2d2c-4dc0-956c-e562cce650ea
+      - 54889a50-84d4-48a8-94fa-ba3af3f538c7
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1482,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:57 GMT
+      - Mon, 13 Nov 2023 13:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 717e9b4d-520d-471a-a9d4-d39d9420a880
+      - 4edcaca0-c1de-4975-87b1-98e7cdaee08b
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1515,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:02 GMT
+      - Mon, 13 Nov 2023 13:54:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b77d42f-4317-4c31-b0b8-d6d4aac82f9a
+      - 79ecb849-7e66-4881-b51e-c83de5c51961
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1548,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:07 GMT
+      - Mon, 13 Nov 2023 13:54:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d15fa80d-feab-474d-9d2f-5b787a7d96cd
+      - 6c622b81-f8cf-4033-a918-b1db9f3298fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1581,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:12 GMT
+      - Mon, 13 Nov 2023 13:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cb16a8c-d150-4cec-ae60-ad2f5ab10df9
+      - 72cbd8a4-8427-4402-a0fd-09da7a48968a
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1614,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:17 GMT
+      - Mon, 13 Nov 2023 13:54:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58bf7aa8-5ba4-43f9-8e97-13a0567b8af9
+      - d4421c9d-d0d4-4127-8f4e-92f5022635a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1647,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:23 GMT
+      - Mon, 13 Nov 2023 13:54:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77bfa0ab-cbed-4ed9-95e8-80df7d610f29
+      - b356d53d-78b9-4e01-8c61-09c6984516f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1680,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:28 GMT
+      - Mon, 13 Nov 2023 13:54:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f321443e-b9af-4bae-acd3-a8b8800845c8
+      - a7d54d01-b4a1-4185-a20b-46175d12198e
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1713,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:33 GMT
+      - Mon, 13 Nov 2023 13:55:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 915b4fb5-2d48-4e43-9723-dd49df33e7ce
+      - b9873a4d-000e-4036-a5d4-8f2094982583
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1746,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:38 GMT
+      - Mon, 13 Nov 2023 13:55:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1f2745b-6df3-4d4e-9a6c-d3fba312117b
+      - 6bdea335-3a4d-45e9-a90a-42b60bddbd8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1779,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:43 GMT
+      - Mon, 13 Nov 2023 13:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f4e6eef-ee00-4dc6-93b0-7edb64383de0
+      - d59d73cb-78ba-455c-8d9d-f57c74a584eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1812,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:48 GMT
+      - Mon, 13 Nov 2023 13:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afdd5f07-c482-49d6-99d1-d0cdd85e26d1
+      - 2cd7b5db-6b0f-4e16-9f7d-586b292423d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1845,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:53 GMT
+      - Mon, 13 Nov 2023 13:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f31ef0f6-ce2e-4036-aabe-9ced46074805
+      - 3d69bff0-7173-4a62-8ca0-1f2ea8766c8e
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1878,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 13:55:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3a60a1d-38b1-419e-a370-977159d087c0
+      - f5a53e31-7ae0-459d-b205-33c472b81d9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1911,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:03 GMT
+      - Mon, 13 Nov 2023 13:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6676671e-9f96-47b5-92e2-f1aed33769da
+      - 40b8deaf-ef4a-4f47-92df-98b7613c515d
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1944,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:08 GMT
+      - Mon, 13 Nov 2023 13:55:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c137735-54da-41d5-84fc-531c0703498a
+      - 6fdba2bc-c359-4651-ade8-91c9b559ea76
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -1977,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:13 GMT
+      - Mon, 13 Nov 2023 13:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c7dd682-7d55-4e82-a1fc-a3e773cc3640
+      - 4badd2e1-f2b9-4802-b2ab-9d0a9bd26abf
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +2031,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -2010,7 +2043,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:18 GMT
+      - Mon, 13 Nov 2023 13:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 159b4efc-7640-4cd2-a81a-99f632e46812
+      - 5a0c6326-389c-4380-a1a3-69c4a01d2284
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2064,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:51:29.808068Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -2043,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:23 GMT
+      - Mon, 13 Nov 2023 13:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbe63c32-320a-476a-b8ef-58871609ae28
+      - 866f01b3-8960-44f0-89f9-18d7563f1779
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,868 +2097,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:21:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e3699913-71a7-470c-9c97-c22d4d070afc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:21:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c1e0c97-1934-45b5-acb3-237e6ee3e2de
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:21:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 547aada8-b968-40e2-9593-825a423de9ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:21:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8863d9b5-b6e9-43b1-acb3-e7baa809e8f3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:21:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08431446-2299-403c-9ed8-c51bdad513da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:21:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f704fc4f-4155-4538-b7ac-026b513eff2f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:21:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0c450a49-7f31-485d-926a-476a1ea61f6b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0dc868a5-03a0-4377-92a9-84364386ff4a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d0d1a4f2-35ad-4177-a07e-ac7b331fa79c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 56d89ce4-fc1d-446a-8b29-fe87e9e3eac2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f9b15c2-f0c0-4597-9d33-c923ef9a31e7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 550f7333-b521-4da6-8fff-99e22c7810ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0f6deb07-6b5a-42a2-8a0f-100d8f48e8d3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 817446fb-d707-45bf-84d3-c8e2e6024c28
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b2e5483-5327-4afe-add1-cf89aa235dea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7629de44-96e1-44eb-a799-208706ec7453
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b2d9e4a3-39ea-477e-8218-e25de6cbebd0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 732af5f1-affa-459f-8bc9-bd4639d23644
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 26caf299-6eb1-46de-b573-5c3651c0561c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fcdcf943-9132-473a-a656-8a75450186b0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ec644d80-9b3d-45a8-b83f-cd1329f70f09
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 99e70a9e-eaa9-4bb1-b659-95196c690627
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 59ecee0b-70fd-4891-bff5-c912b2eed21d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ac1175a3-fd34-4ff2-b165-46d49c2a296a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd5e993e-8420-4dab-90f7-259229d71a4f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:17:04.461658Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:23:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 241dccd7-34ba-4fb5-9600-929e680bed6f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -2934,7 +2109,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:40 GMT
+      - Mon, 13 Nov 2023 13:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2944,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7416a078-c7ec-4499-8c04-4347cee5d7f6
+      - a495a191-e774-482f-b8c3-f05f8a2d7b23
     status: 200 OK
     code: 200
     duration: ""
@@ -2955,10 +2130,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -2967,7 +2142,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:40 GMT
+      - Mon, 13 Nov 2023 13:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2977,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeddaa49-98e7-4797-8747-66c313efc46e
+      - ca365f49-c7c0-4096-95df-1db9939d1a36
     status: 200 OK
     code: 200
     duration: ""
@@ -2988,10 +2163,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -3000,7 +2175,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:40 GMT
+      - Mon, 13 Nov 2023 13:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3010,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa92315f-308a-487f-9999-6379d8e9314b
+      - 77551a57-5600-47cd-9ac7-864261a2465a
     status: 200 OK
     code: 200
     duration: ""
@@ -3021,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:23:35.771409Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:55:55.560650Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:40 GMT
+      - Mon, 13 Nov 2023 13:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3043,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4080f277-3fe7-451c-a353-77442e864c98
+      - 915cd893-559f-48ea-91a3-a48ff1c575f4
     status: 200 OK
     code: 200
     duration: ""
@@ -3054,10 +2229,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -3066,7 +2241,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:40 GMT
+      - Mon, 13 Nov 2023 13:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3076,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d12bd85e-4675-4867-b850-304042fe0091
+      - a488fe2d-b947-400e-bce1-828fa5a1d016
     status: 200 OK
     code: 200
     duration: ""
@@ -3087,10 +2262,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -3099,7 +2274,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:40 GMT
+      - Mon, 13 Nov 2023 13:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3109,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab90f275-5d82-4088-a18e-5494a3c8cf07
+      - 7e4777bc-d592-4b49-9599-0bc6bd8b0dbc
     status: 200 OK
     code: 200
     duration: ""
@@ -3120,10 +2295,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -3132,7 +2307,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:41 GMT
+      - Mon, 13 Nov 2023 13:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3142,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c502beb-9266-48cc-9652-c632349c146f
+      - ce93d2e9-dc31-4342-835f-d3251cd35897
     status: 200 OK
     code: 200
     duration: ""
@@ -3153,10 +2328,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -3165,7 +2340,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:41 GMT
+      - Mon, 13 Nov 2023 13:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3175,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62ff3d39-3d5d-4a43-a892-eae869e13641
+      - 976844b7-61ae-46cf-a73e-d809d5602520
     status: 200 OK
     code: 200
     duration: ""
@@ -3186,10 +2361,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -3198,7 +2373,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:41 GMT
+      - Mon, 13 Nov 2023 13:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3208,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91612639-2776-43fd-a439-d777a9aced84
+      - 4065fcb9-9533-4f0a-a8b4-4d331f876a7a
     status: 200 OK
     code: 200
     duration: ""
@@ -3219,10 +2394,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -3231,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:41 GMT
+      - Mon, 13 Nov 2023 13:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3241,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77408e26-9ad7-4eff-8584-75399a702aa7
+      - 29a580bc-d0de-492b-90d7-1fc22d9ba572
     status: 200 OK
     code: 200
     duration: ""
@@ -3252,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:23:35.771409Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:55:55.560650Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:41 GMT
+      - Mon, 13 Nov 2023 13:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3274,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d4e4f27-656b-43ca-8ded-a2e6996522f3
+      - 286fb343-135f-4170-843a-919ce49c0a2c
     status: 200 OK
     code: 200
     duration: ""
@@ -3285,10 +2460,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -3297,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:42 GMT
+      - Mon, 13 Nov 2023 13:55:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3307,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acb9223b-b407-4b9f-9ef9-5886a6dcb609
+      - f06a1583-0db0-46d2-a96e-c96bf09e001b
     status: 200 OK
     code: 200
     duration: ""
@@ -3318,10 +2493,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -3330,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:42 GMT
+      - Mon, 13 Nov 2023 13:55:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3340,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed97d978-98dc-4770-a11a-2748a6e14928
+      - 2ebd90c0-8551-42fd-9ce0-d79b70f3048f
     status: 200 OK
     code: 200
     duration: ""
@@ -3351,10 +2526,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -3363,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:42 GMT
+      - Mon, 13 Nov 2023 13:55:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3373,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9a0e3a2-8c4b-4ada-9ecf-25ee9de9d7ee
+      - 353281b4-dd37-4ff7-9cb1-cbb0fbf1799b
     status: 200 OK
     code: 200
     duration: ""
@@ -3384,10 +2559,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -3396,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:42 GMT
+      - Mon, 13 Nov 2023 13:55:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3406,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed89c2dd-17aa-4c2c-8c6f-59853718b961
+      - ce5706ba-ed0b-4adf-b53e-4d63407ba140
     status: 200 OK
     code: 200
     duration: ""
@@ -3417,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:23:35.771409Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:55:55.560650Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:42 GMT
+      - Mon, 13 Nov 2023 13:55:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3439,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b0932f0-3c2e-4ade-8606-7d082522629a
+      - be4a69b1-a65b-4d4a-a839-d8f11fc7b265
     status: 200 OK
     code: 200
     duration: ""
@@ -3450,10 +2625,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -3462,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:43 GMT
+      - Mon, 13 Nov 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3472,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cff028b5-5f8c-43c2-950e-9a87dcb73cf8
+      - 1776d216-0896-49ed-8e88-d4f0e3e53f2a
     status: 200 OK
     code: 200
     duration: ""
@@ -3485,10 +2660,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148621824Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693463Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "631"
@@ -3497,7 +2672,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:43 GMT
+      - Mon, 13 Nov 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db6be453-0d21-4595-b8f8-203c627aa3e0
+      - 139c8a73-f1d4-4c8d-96a3-ffaeb30110d0
     status: 200 OK
     code: 200
     duration: ""
@@ -3518,10 +2693,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3530,7 +2705,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:43 GMT
+      - Mon, 13 Nov 2023 13:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +2715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 792d10ce-2668-426e-89e1-14c9c37ba369
+      - c002fac4-eda0-4f15-af8b-c6ae9b986378
     status: 200 OK
     code: 200
     duration: ""
@@ -3551,10 +2726,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3563,7 +2738,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:48 GMT
+      - Mon, 13 Nov 2023 13:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3573,7 +2748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8393c341-909a-4bf0-a756-582b670dcaed
+      - 9946f687-2954-433d-8d82-6d9f26725d77
     status: 200 OK
     code: 200
     duration: ""
@@ -3584,10 +2759,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3596,7 +2771,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:53 GMT
+      - Mon, 13 Nov 2023 13:56:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3606,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 206a7ca5-085e-46dc-ada5-63f6386845b4
+      - 4256832c-e424-4bd9-ba9c-f72495afb5b6
     status: 200 OK
     code: 200
     duration: ""
@@ -3617,10 +2792,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3629,7 +2804,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:59 GMT
+      - Mon, 13 Nov 2023 13:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3639,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ca45b1c-9351-4665-9831-c971a398535d
+      - 5cdc636c-4903-4655-adac-8ef5c51bed93
     status: 200 OK
     code: 200
     duration: ""
@@ -3650,10 +2825,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3662,7 +2837,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:04 GMT
+      - Mon, 13 Nov 2023 13:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80b0ef5b-1872-4a7a-aec8-f25413b26d96
+      - e1618e7d-94f1-4691-a690-e6cff25ae778
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,10 +2858,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3695,7 +2870,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:09 GMT
+      - Mon, 13 Nov 2023 13:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +2880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1feb2a17-f775-4405-b089-eda93702f63c
+      - e0df4190-84cb-4ec3-ac77-edf89735b264
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,10 +2891,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3728,7 +2903,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:14 GMT
+      - Mon, 13 Nov 2023 13:56:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3738,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 170be4fd-38c4-4166-b27a-6a2eb8c62cb6
+      - 60233131-5e02-45a4-9e71-4d7159cd7827
     status: 200 OK
     code: 200
     duration: ""
@@ -3749,10 +2924,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3761,7 +2936,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:19 GMT
+      - Mon, 13 Nov 2023 13:56:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3771,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 870576bb-dccf-48c1-83e4-ee0c1e4613a8
+      - 99868ad9-5d31-4289-a1ab-8c1729c80d62
     status: 200 OK
     code: 200
     duration: ""
@@ -3782,10 +2957,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3794,7 +2969,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:24 GMT
+      - Mon, 13 Nov 2023 13:56:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3eaff1b1-c340-4395-8687-1473a95d928d
+      - 2b20f6cd-38c8-40cd-859b-749d7be12c80
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,10 +2990,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3827,7 +3002,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:29 GMT
+      - Mon, 13 Nov 2023 13:56:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5cfb4a5-1b31-4b4f-9c8f-7ac8fd1892a6
+      - 8b8a755d-c365-4aa2-a745-44cdd67214df
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,10 +3023,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3860,7 +3035,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:34 GMT
+      - Mon, 13 Nov 2023 13:56:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3870,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2cdbd5d-6a95-4b3e-8fcc-bf8d63766699
+      - b82af9e6-4294-4ac3-8dd8-13c6d737a6f7
     status: 200 OK
     code: 200
     duration: ""
@@ -3881,10 +3056,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3893,7 +3068,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:39 GMT
+      - Mon, 13 Nov 2023 13:56:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c55ad2b1-b824-4b64-b269-0fe304bfc6bc
+      - 359d130e-6f90-4fac-940c-cf2edd3492a1
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,10 +3089,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3926,7 +3101,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:44 GMT
+      - Mon, 13 Nov 2023 13:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba6fdcbd-1602-447b-8e37-ba95747fe51b
+      - 3d32b424-39b8-49c1-ba8a-c434e1709111
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,10 +3122,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3959,7 +3134,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:49 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79093cb8-37f4-433e-a287-9c627bf092fb
+      - 20c64f57-a512-472d-ad62-f1d1ff805de3
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,10 +3155,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -3992,7 +3167,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:54 GMT
+      - Mon, 13 Nov 2023 13:57:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e471e3a8-61bd-4634-a841-dd76672e7e32
+      - 6ea429c3-f214-4208-b1db-1c9d60d53c38
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,10 +3188,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4025,7 +3200,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:59 GMT
+      - Mon, 13 Nov 2023 13:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4035,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca62cbc3-a47a-4613-bec2-b49a7265aaa5
+      - d0ba3ca2-4dd7-446c-80f0-02cea14652ca
     status: 200 OK
     code: 200
     duration: ""
@@ -4046,10 +3221,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4058,7 +3233,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:04 GMT
+      - Mon, 13 Nov 2023 13:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4068,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68a4c981-4be3-4ee3-922f-1837fddb2a0c
+      - da31cec8-c63e-4bc5-9741-70b721c70165
     status: 200 OK
     code: 200
     duration: ""
@@ -4079,10 +3254,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4091,7 +3266,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:09 GMT
+      - Mon, 13 Nov 2023 13:57:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4101,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82a59f89-0e81-42a2-9a9a-6bd339b9d6a7
+      - b4e3905a-6608-4a5a-89fa-0ebe81104797
     status: 200 OK
     code: 200
     duration: ""
@@ -4112,10 +3287,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4124,7 +3299,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:14 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4134,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3c5036e-edc5-4cba-aa7f-6a96bf68af33
+      - 50d18e1e-0399-4df9-b4d2-acd1b57b33f5
     status: 200 OK
     code: 200
     duration: ""
@@ -4145,10 +3320,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4157,7 +3332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:19 GMT
+      - Mon, 13 Nov 2023 13:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4167,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dce1d85-49be-423e-8a62-a24c7e86b506
+      - ff8953ab-86fa-4213-8223-d947120a2072
     status: 200 OK
     code: 200
     duration: ""
@@ -4178,10 +3353,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4190,7 +3365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:24 GMT
+      - Mon, 13 Nov 2023 13:57:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4200,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 378e6133-5422-4f7c-887d-3bf021e105e7
+      - b5bf6f55-3f80-49f1-becc-20b05eb2a927
     status: 200 OK
     code: 200
     duration: ""
@@ -4211,10 +3386,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4223,7 +3398,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:30 GMT
+      - Mon, 13 Nov 2023 13:57:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60b7f5ff-1559-444d-9077-2a5b3b369c5f
+      - d02a4e2a-ad59-46ff-a808-758a5099f512
     status: 200 OK
     code: 200
     duration: ""
@@ -4244,10 +3419,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4256,7 +3431,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:35 GMT
+      - Mon, 13 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4266,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e1b6d68-8892-49e5-bc5c-9697d8cc9d71
+      - 8cd7a1d7-009b-481c-933e-a6711edc9324
     status: 200 OK
     code: 200
     duration: ""
@@ -4277,10 +3452,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4289,7 +3464,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:40 GMT
+      - Mon, 13 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4299,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 819a687d-0336-493c-a691-4cddb974cd3e
+      - 98f005f0-f9ac-4a61-8068-a677ee035a38
     status: 200 OK
     code: 200
     duration: ""
@@ -4310,10 +3485,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4322,7 +3497,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:45 GMT
+      - Mon, 13 Nov 2023 13:58:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4332,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce04ca46-b5b5-4d1e-b0ac-2e582ed09563
+      - 883a6cc8-ccf8-4d4e-b8ae-15a152d694f9
     status: 200 OK
     code: 200
     duration: ""
@@ -4343,10 +3518,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4355,7 +3530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:50 GMT
+      - Mon, 13 Nov 2023 13:58:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7f05544-b421-4b5e-982b-17d64637571f
+      - dfbebb45-c362-47f3-acd7-0d99a4bfffff
     status: 200 OK
     code: 200
     duration: ""
@@ -4376,10 +3551,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4388,7 +3563,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:55 GMT
+      - Mon, 13 Nov 2023 13:58:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c713be6-149b-4b09-a21f-3fab2615c22d
+      - c0ae68c3-1657-4322-9c21-0f95744e4f39
     status: 200 OK
     code: 200
     duration: ""
@@ -4409,10 +3584,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:55:59.388693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -4421,7 +3596,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:00 GMT
+      - Mon, 13 Nov 2023 13:58:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cde5a05-3cfd-4338-9fc4-f142c1a6892a
+      - 430b4a92-f684-4289-9a03-a05134bad964
     status: 200 OK
     code: 200
     duration: ""
@@ -4442,274 +3617,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 02fbf6d5-af33-4b9d-bf5d-25f944a89df2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3d2e9e05-42b4-4d1c-9f55-b64d507f3cb8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a29e835b-a7ba-49e0-9589-54ef9e98b1b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 92faf42d-9cf2-4674-9089-eb74657f47ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fc690929-07a6-435b-ab30-9978c4661a0f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ec09d018-3897-4848-a132-f32b658e70bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 729106c9-6669-4afb-b1a2-ca04e3977466
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:23:43.148622Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:26:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ac833d34-b778-4f0d-afed-23549d63dc47
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:58:16.827478Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -4718,7 +3629,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:45 GMT
+      - Mon, 13 Nov 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4728,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24514c0c-56ed-428b-8812-4ae8f1927942
+      - b5322e3a-cb34-4b5d-8d48-6aa5dfa80f0f
     status: 200 OK
     code: 200
     duration: ""
@@ -4739,10 +3650,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:58:16.827478Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -4751,7 +3662,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:45 GMT
+      - Mon, 13 Nov 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4761,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bae320b-b0c7-4df8-b560-da3dfd29c8d3
+      - a7011f3f-d497-4c12-ae02-900a2f45cec1
     status: 200 OK
     code: 200
     duration: ""
@@ -4772,19 +3683,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.079438Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:58:16.814828Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:45 GMT
+      - Mon, 13 Nov 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4794,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4470b199-6759-45ab-9245-d7fb5cdeee6d
+      - 7f3f134e-b666-4502-b104-a8fff74c493e
     status: 200 OK
     code: 200
     duration: ""
@@ -4805,10 +3716,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -4817,7 +3728,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:45 GMT
+      - Mon, 13 Nov 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4827,7 +3738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b74a274-57f9-47ee-be2c-39c2f6ab1f85
+      - 620210a7-1623-4e13-8adf-d8535364807f
     status: 200 OK
     code: 200
     duration: ""
@@ -4838,10 +3749,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:58:16.827478Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -4850,7 +3761,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4860,7 +3771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b0e4423-c937-4db0-9f71-75f00e20a3ac
+      - d844b014-a5a1-4bdd-a768-a03d27e8e2a9
     status: 200 OK
     code: 200
     duration: ""
@@ -4871,10 +3782,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -4883,7 +3794,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4893,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27492c08-5eea-4285-ae69-dd7e99c734aa
+      - 9b3003f6-4823-46e8-997f-da423dba7865
     status: 200 OK
     code: 200
     duration: ""
@@ -4904,10 +3815,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -4916,7 +3827,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4926,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f72a4c3d-e293-4f31-acf2-ef10311607e8
+      - 92a6bac5-fd81-4a9a-8aa4-235f571ab47b
     status: 200 OK
     code: 200
     duration: ""
@@ -4937,10 +3848,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -4949,7 +3860,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4959,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be75ac68-aca3-4826-818f-f56a4a3d5a7b
+      - 4f11781c-33a0-4efa-94cc-4c266fe30a4c
     status: 200 OK
     code: 200
     duration: ""
@@ -4970,10 +3881,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:58:16.827478Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -4982,7 +3893,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4992,7 +3903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2cb5d18-d8c9-493f-a429-800cee8d4e04
+      - 37ac2cfa-fe5f-477a-819b-46b0c575896e
     status: 200 OK
     code: 200
     duration: ""
@@ -5003,10 +3914,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -5015,7 +3926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5025,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c013fe8-b917-471f-8280-4d2c0eec854a
+      - 4efa8677-827d-4f88-aca2-1da6128dbd5d
     status: 200 OK
     code: 200
     duration: ""
@@ -5036,19 +3947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.079438Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:58:16.774794Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5058,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c17b4146-c7b6-45d8-a1ae-c2acee25cda0
+      - e1f4c6bb-8440-421b-a202-89a202b625a8
     status: 200 OK
     code: 200
     duration: ""
@@ -5069,19 +3980,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.041882Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:58:16.814828Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "690"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:46 GMT
+      - Mon, 13 Nov 2023 13:58:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5091,7 +4002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e492db75-6f5a-4056-8fe9-24c789fef2bc
+      - 20370113-4b94-4539-b89f-c9fb193c6b3c
     status: 200 OK
     code: 200
     duration: ""
@@ -5102,10 +4013,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -5114,7 +4025,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 13:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5124,7 +4035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9bdf179-f079-4cb0-9423-d4aa4068466a
+      - 3112029c-9458-4878-928d-424b12edec96
     status: 200 OK
     code: 200
     duration: ""
@@ -5135,10 +4046,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -5147,7 +4058,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 13:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5157,7 +4068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e30738c-87d0-4ae1-acdc-807827b8bc48
+      - ce762dde-82a7-496c-8b90-e00d194d4afe
     status: 200 OK
     code: 200
     duration: ""
@@ -5168,10 +4079,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -5180,7 +4091,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 13:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5190,7 +4101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d91407f-23b5-492e-9679-bf480f138f76
+      - 8526495c-01ba-4733-bdaa-5b4ee67b70b0
     status: 200 OK
     code: 200
     duration: ""
@@ -5201,10 +4112,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -5213,7 +4124,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 13:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5223,7 +4134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cedf8ae8-4422-49ff-ae13-b400c5001dfc
+      - 028d7458-fd37-4891-b757-e34eeee398f4
     status: 200 OK
     code: 200
     duration: ""
@@ -5234,10 +4145,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:26:43.094816Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:58:16.827478Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -5246,7 +4157,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 13:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5256,7 +4167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 025deb0c-ee62-4a94-851d-ff0ba2fce60e
+      - 724cd205-105a-479d-bffd-e024d6c9912e
     status: 200 OK
     code: 200
     duration: ""
@@ -5267,19 +4178,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.079438Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:58:16.774794Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "659"
+      - "689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 13:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5289,7 +4200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 234319e1-0742-454d-a583-9fde4bbc5ee4
+      - d168bed1-42b1-4632-9cc6-a4b340242ec3
     status: 200 OK
     code: 200
     duration: ""
@@ -5300,19 +4211,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:26:43.041882Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T13:58:16.814828Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "690"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 13:58:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5322,7 +4233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9917d24b-db0b-4570-91a7-88fd323ebd04
+      - 766a139e-599b-4c44-abda-ac0eabef24d8
     status: 200 OK
     code: 200
     duration: ""
@@ -5335,10 +4246,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: PATCH
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347345Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225267572Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "631"
@@ -5347,7 +4258,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:48 GMT
+      - Mon, 13 Nov 2023 13:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5357,7 +4268,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23224f3b-7f7a-4cba-a02a-032fcba536d0
+      - b135aeae-dd39-4501-ae4a-db8e22cecbf0
     status: 200 OK
     code: 200
     duration: ""
@@ -5368,10 +4279,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5380,7 +4291,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:48 GMT
+      - Mon, 13 Nov 2023 13:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5390,7 +4301,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e4d6547-cac6-4744-a4e0-3bcc5283a04b
+      - 9d46eb9f-2799-49d2-a30d-249442797d33
     status: 200 OK
     code: 200
     duration: ""
@@ -5401,10 +4312,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5413,7 +4324,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:53 GMT
+      - Mon, 13 Nov 2023 13:58:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5423,7 +4334,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71d92c0d-1207-498d-a73c-4a984457e875
+      - 3b1e419c-726d-4487-b465-525aaa043302
     status: 200 OK
     code: 200
     duration: ""
@@ -5434,10 +4345,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5446,7 +4357,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:58 GMT
+      - Mon, 13 Nov 2023 13:58:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5456,7 +4367,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20eeb269-f159-4645-8b9d-662dc946fcac
+      - e569eb08-3b2f-400b-91a5-f7a068aca08c
     status: 200 OK
     code: 200
     duration: ""
@@ -5467,10 +4378,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5479,7 +4390,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:03 GMT
+      - Mon, 13 Nov 2023 13:58:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5489,7 +4400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dcc85d9-913e-4be5-b720-f681ab84207b
+      - 3ecff6a3-8a11-4e4a-ab03-0d0f2d267760
     status: 200 OK
     code: 200
     duration: ""
@@ -5500,10 +4411,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5512,7 +4423,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:08 GMT
+      - Mon, 13 Nov 2023 13:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5522,7 +4433,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d69d860-cbca-454e-8294-8ed1e42e812a
+      - dc53c651-7fae-47a1-9d00-f2560d7c043c
     status: 200 OK
     code: 200
     duration: ""
@@ -5533,10 +4444,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5545,7 +4456,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:13 GMT
+      - Mon, 13 Nov 2023 13:58:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5555,7 +4466,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d3f4065-2f6e-4218-83f2-47833dc290f6
+      - 1ee7c40d-b76d-4bc7-80c5-9a4512a159b3
     status: 200 OK
     code: 200
     duration: ""
@@ -5566,10 +4477,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5578,7 +4489,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:18 GMT
+      - Mon, 13 Nov 2023 13:58:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5588,7 +4499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06d6cdd0-a5e9-47fb-bfd2-930257b5edc5
+      - da3a046f-3353-480f-8e25-b51c8744deea
     status: 200 OK
     code: 200
     duration: ""
@@ -5599,10 +4510,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5611,7 +4522,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:23 GMT
+      - Mon, 13 Nov 2023 13:58:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5621,7 +4532,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6ef61a3-541c-46be-afee-33ebd1cedb47
+      - 920c3ec5-aa88-4c19-bf62-a87fa166b01f
     status: 200 OK
     code: 200
     duration: ""
@@ -5632,10 +4543,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5644,7 +4555,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:28 GMT
+      - Mon, 13 Nov 2023 13:59:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5654,7 +4565,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88387d4e-f76b-4a18-a675-dba855bf16f3
+      - 7d4a8d30-2a42-46c0-929f-663042f03a79
     status: 200 OK
     code: 200
     duration: ""
@@ -5665,10 +4576,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5677,7 +4588,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:33 GMT
+      - Mon, 13 Nov 2023 13:59:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5687,7 +4598,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73c08e45-37c9-44ba-bd6d-1985e84fbe77
+      - 8dff89fd-d868-457c-a5d3-e56fca6b3eb8
     status: 200 OK
     code: 200
     duration: ""
@@ -5698,10 +4609,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5710,7 +4621,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:38 GMT
+      - Mon, 13 Nov 2023 13:59:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5720,7 +4631,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dfdeb02-5026-41f4-b191-e2166fcf1a78
+      - 68cb20f0-df3e-4100-bd27-dbb8201e41bb
     status: 200 OK
     code: 200
     duration: ""
@@ -5731,10 +4642,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5743,7 +4654,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:43 GMT
+      - Mon, 13 Nov 2023 13:59:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5753,7 +4664,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c4ef231-f580-4839-ab4d-81751651d11c
+      - e0af2fd8-3105-42ee-990f-5ba6b1f9c29d
     status: 200 OK
     code: 200
     duration: ""
@@ -5764,10 +4675,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5776,7 +4687,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:48 GMT
+      - Mon, 13 Nov 2023 13:59:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5786,7 +4697,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 652eb8fe-8118-44d3-840b-4469782e0b4a
+      - 46e7c02c-5441-4732-8f36-371f5ceb8c5d
     status: 200 OK
     code: 200
     duration: ""
@@ -5797,10 +4708,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5809,7 +4720,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:54 GMT
+      - Mon, 13 Nov 2023 13:59:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5819,7 +4730,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a35b8742-9859-46a3-84de-7c928348a236
+      - 1b2cee8f-112c-4bf1-b440-b126b99d996d
     status: 200 OK
     code: 200
     duration: ""
@@ -5830,10 +4741,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5842,7 +4753,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:59 GMT
+      - Mon, 13 Nov 2023 13:59:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5852,7 +4763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7858d410-e83f-41fe-9c65-988815cba700
+      - 8f9db2e6-e696-425b-8d04-a4b2ea698965
     status: 200 OK
     code: 200
     duration: ""
@@ -5863,10 +4774,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5875,7 +4786,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:04 GMT
+      - Mon, 13 Nov 2023 13:59:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5885,7 +4796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0821ffab-a518-4ce2-bca7-2a40a0480b70
+      - 1ea9cc82-c3f4-4a13-a5f1-ed534ec88c59
     status: 200 OK
     code: 200
     duration: ""
@@ -5896,10 +4807,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5908,7 +4819,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:09 GMT
+      - Mon, 13 Nov 2023 13:59:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5918,7 +4829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d394e48-8783-4a13-8bd7-e5fea650a824
+      - 4c0e0a20-b00f-49f2-beda-8af487bdb304
     status: 200 OK
     code: 200
     duration: ""
@@ -5929,10 +4840,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5941,7 +4852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:14 GMT
+      - Mon, 13 Nov 2023 13:59:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5951,7 +4862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7afb6729-08bc-4c4e-a47f-0b63a662304c
+      - 85d5330f-9e3d-4dcc-abee-902a07a106e8
     status: 200 OK
     code: 200
     duration: ""
@@ -5962,10 +4873,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -5974,7 +4885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:19 GMT
+      - Mon, 13 Nov 2023 13:59:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5984,7 +4895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aba94b2c-439c-44d0-af4b-4daa4e4c0ee3
+      - 76a265a7-f486-473e-8dee-f2fb2e398c1f
     status: 200 OK
     code: 200
     duration: ""
@@ -5995,10 +4906,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6007,7 +4918,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:24 GMT
+      - Mon, 13 Nov 2023 14:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6017,7 +4928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 363083c5-8191-4224-b2c8-c19e0c617b6b
+      - edd6b158-6de6-4e70-a47b-8c6ca17833e9
     status: 200 OK
     code: 200
     duration: ""
@@ -6028,10 +4939,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6040,7 +4951,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:29 GMT
+      - Mon, 13 Nov 2023 14:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6050,7 +4961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dea8e508-124f-432c-834e-4c518297c281
+      - b3eaf4fd-1383-4faa-b301-fd642454245d
     status: 200 OK
     code: 200
     duration: ""
@@ -6061,10 +4972,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6073,7 +4984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:34 GMT
+      - Mon, 13 Nov 2023 14:00:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6083,7 +4994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5952e096-32b8-40f5-bed9-9c3f50129800
+      - 57bfff93-ff30-48fc-9493-c257b4b503d9
     status: 200 OK
     code: 200
     duration: ""
@@ -6094,10 +5005,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6106,7 +5017,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:39 GMT
+      - Mon, 13 Nov 2023 14:00:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6116,7 +5027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da8dbc1f-604a-4b6d-a40f-75ae38208983
+      - fa2eeb74-4a86-4964-a36b-2f7246a57b14
     status: 200 OK
     code: 200
     duration: ""
@@ -6127,10 +5038,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6139,7 +5050,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:44 GMT
+      - Mon, 13 Nov 2023 14:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6149,7 +5060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7683ae3-a69b-4772-97a7-cdca2cad4881
+      - 55847615-4597-41cd-98cb-967c49c47f19
     status: 200 OK
     code: 200
     duration: ""
@@ -6160,10 +5071,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-13T13:58:24.225268Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6172,7 +5083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:28:49 GMT
+      - Mon, 13 Nov 2023 14:00:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6182,7 +5093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55ead4ae-fe28-40df-bb98-83b4ada3f348
+      - c48f7617-c63a-45fe-b813-6db3a52bd2b4
     status: 200 OK
     code: 200
     duration: ""
@@ -6193,109 +5104,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19be0b8c-3bf1-444a-b3d9-f5f6d4541a95
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:28:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3bcc8e8c-08ee-4abc-bd48-e4283d593b74
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:26:48.134347Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f052d73e-9410-4edd-aee4-149726547a1d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:28.400126Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -6304,7 +5116,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:09 GMT
+      - Mon, 13 Nov 2023 14:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6314,7 +5126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 507185e9-022d-4c51-a077-c6ae73c7ab15
+      - 5c602cb6-93f6-4ab0-81ab-a71a950db75e
     status: 200 OK
     code: 200
     duration: ""
@@ -6325,10 +5137,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:28.400126Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -6337,7 +5149,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:09 GMT
+      - Mon, 13 Nov 2023 14:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6347,7 +5159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff6ae8a7-6f1f-478f-a7d8-175251a6c2a6
+      - aa8c0a7d-2145-4a3d-bcec-05942a619647
     status: 200 OK
     code: 200
     duration: ""
@@ -6358,19 +5170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.253179Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.233114Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:28.369092Z"},{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:24.751037Z","error_message":null,"id":"56e6989f-4a2e-45a1-b2e4-40e1ba600b97","name":"scw-test-pool-wait-test-pool-wait-2-56e6989f4a","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/0bf3144e-f31e-4830-a5aa-8a05a0f03ae8","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:28.387337Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1318"
+      - "1320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:09 GMT
+      - Mon, 13 Nov 2023 14:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6380,7 +5192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b614f376-e255-4526-b3b3-cdb19ccaeb42
+      - a4d0cc20-1fab-43e4-aec3-c1c7f509e417
     status: 200 OK
     code: 200
     duration: ""
@@ -6391,10 +5203,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -6403,7 +5215,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:10 GMT
+      - Mon, 13 Nov 2023 14:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6413,7 +5225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4e258bf-7552-4308-ab9c-9bd7138c0832
+      - 32204f38-631d-4026-b281-797dc911d6d4
     status: 200 OK
     code: 200
     duration: ""
@@ -6424,10 +5236,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:28.400126Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -6436,7 +5248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:10 GMT
+      - Mon, 13 Nov 2023 14:00:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6446,7 +5258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b32dd38-5dcc-4276-8256-9c81899865aa
+      - d5a4e348-64a9-4e67-a01a-dc76ae1301a1
     status: 200 OK
     code: 200
     duration: ""
@@ -6457,10 +5269,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -6469,7 +5281,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:10 GMT
+      - Mon, 13 Nov 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6479,7 +5291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be2b92d8-f262-468b-abf8-3ff5363074c7
+      - c28274a5-7504-4e38-9002-2a7c5d4b0578
     status: 200 OK
     code: 200
     duration: ""
@@ -6490,10 +5302,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -6502,7 +5314,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:10 GMT
+      - Mon, 13 Nov 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6512,7 +5324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 228450c6-0b62-40f8-bfd4-2d6f6539c8b6
+      - ad6d3f39-83c7-4124-bcd7-cb79953f8e32
     status: 200 OK
     code: 200
     duration: ""
@@ -6523,10 +5335,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -6535,7 +5347,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:10 GMT
+      - Mon, 13 Nov 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6545,7 +5357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - faabce6e-40c4-40d5-9437-4239ea06cf27
+      - e8dab5dd-33f8-4a5a-adad-07a14fa417a3
     status: 200 OK
     code: 200
     duration: ""
@@ -6556,10 +5368,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -6568,7 +5380,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:10 GMT
+      - Mon, 13 Nov 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6578,7 +5390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68f1ef5a-3b46-4a82-8f0a-dd4acc3a47b4
+      - 3d90a118-eb1f-4f5b-a6a8-b1a15538280f
     status: 200 OK
     code: 200
     duration: ""
@@ -6589,10 +5401,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:28.400126Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -6601,7 +5413,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:10 GMT
+      - Mon, 13 Nov 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6611,7 +5423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3ac5d08-ae28-4c8f-9ed2-52057c0ee63d
+      - 072b20b9-0d53-41be-a38d-d3898b342a46
     status: 200 OK
     code: 200
     duration: ""
@@ -6622,19 +5434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.191323Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:28.369092Z"},{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:24.751037Z","error_message":null,"id":"56e6989f-4a2e-45a1-b2e4-40e1ba600b97","name":"scw-test-pool-wait-test-pool-wait-2-56e6989f4a","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/0bf3144e-f31e-4830-a5aa-8a05a0f03ae8","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:28.387337Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "690"
+      - "1320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
+      - Mon, 13 Nov 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6644,7 +5456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3758b24b-28ce-4dcb-974c-e73f79429a24
+      - e54dbabe-d43e-4a7c-b7ed-0893544595b2
     status: 200 OK
     code: 200
     duration: ""
@@ -6655,19 +5467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.253179Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.233114Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:28.325930Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1318"
+      - "689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
+      - Mon, 13 Nov 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6677,7 +5489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeb9d1f4-177d-48f7-aeae-673c9481b931
+      - 436b5069-63ac-46e4-a0b4-e92a2432dfab
     status: 200 OK
     code: 200
     duration: ""
@@ -6688,10 +5500,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -6700,7 +5512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
+      - Mon, 13 Nov 2023 14:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6710,7 +5522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95e1edbb-bba6-4553-8f6d-88f536f9ea8e
+      - 77e950f5-b61c-441d-84c8-6306b39c32f1
     status: 200 OK
     code: 200
     duration: ""
@@ -6721,10 +5533,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -6733,7 +5545,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
+      - Mon, 13 Nov 2023 14:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6743,7 +5555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e902ce1-b9a3-461a-9c6c-1b019ccf875e
+      - a84c772a-b4f1-409d-a040-eba446d5b718
     status: 200 OK
     code: 200
     duration: ""
@@ -6754,10 +5566,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -6766,7 +5578,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
+      - Mon, 13 Nov 2023 14:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6776,7 +5588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31e2156d-defc-4cf8-a555-bcbbbea304d5
+      - 31e1f3d8-6d38-4000-bc39-e047c2ca13bf
     status: 200 OK
     code: 200
     duration: ""
@@ -6787,43 +5599,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:05.272048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6ced6d22-7d05-4429-9cb8-2470be671f2a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -6832,7 +5611,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
+      - Mon, 13 Nov 2023 14:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6842,7 +5621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e247554-a7fa-4a5e-a7e5-f0f30e2fd761
+      - 76bfc232-74a7-41c2-887d-687f69de0d58
     status: 200 OK
     code: 200
     duration: ""
@@ -6853,19 +5632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.191323Z"}],"total_count":1}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:28.400126Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "690"
+      - "626"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
+      - Mon, 13 Nov 2023 14:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6875,7 +5654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eac0fba5-872c-4ede-bff4-b272593c5311
+      - f98251af-7e8c-4c2b-8c2d-fbdfd03e6e15
     status: 200 OK
     code: 200
     duration: ""
@@ -6886,19 +5665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.253179Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:05.233114Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:28.325930Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1318"
+      - "689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:11 GMT
+      - Mon, 13 Nov 2023 14:00:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6908,7 +5687,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c372936-c134-4dc6-b4eb-8d48ee08b72f
+      - 504ae4a9-0c2d-41b5-9210-3c626da04d29
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:28.369092Z"},{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:24.751037Z","error_message":null,"id":"56e6989f-4a2e-45a1-b2e4-40e1ba600b97","name":"scw-test-pool-wait-test-pool-wait-2-56e6989f4a","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/0bf3144e-f31e-4830-a5aa-8a05a0f03ae8","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:28.387337Z"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1320"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:00:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8a8aa6d-5af3-4363-9dda-98ad017ce670
     status: 200 OK
     code: 200
     duration: ""
@@ -6921,10 +5733,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: PATCH
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:29:12.595085928Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:00:36.661679183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "631"
@@ -6933,7 +5745,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:12 GMT
+      - Mon, 13 Nov 2023 14:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6943,7 +5755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0c47ae6-ad43-488a-9ca4-ee66e63c70f0
+      - d4404075-dc26-48cf-9631-c95b2cdedbda
     status: 200 OK
     code: 200
     duration: ""
@@ -6954,10 +5766,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-10T13:29:12.595086Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-13T14:00:36.661679Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "628"
@@ -6966,7 +5778,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:12 GMT
+      - Mon, 13 Nov 2023 14:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6976,7 +5788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f82c676a-1001-4869-82ce-d6c29eb34440
+      - 5eb24e92-758a-48e7-b841-5a64cd5c16de
     status: 200 OK
     code: 200
     duration: ""
@@ -6987,10 +5799,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:37.890669Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -6999,7 +5811,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:17 GMT
+      - Mon, 13 Nov 2023 14:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7009,7 +5821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36b7477d-03e5-4ac1-8ee0-39a01c7301af
+      - 2fb4b83f-b456-4ad0-ac83-53fe09f3a153
     status: 200 OK
     code: 200
     duration: ""
@@ -7020,10 +5832,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:37.890669Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -7032,7 +5844,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:17 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7042,7 +5854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8073c00a-c69b-4196-a897-c7b3f6480872
+      - f00f438a-9490-4dfb-a29d-fc2808d32453
     status: 200 OK
     code: 200
     duration: ""
@@ -7053,19 +5865,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.776631Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-10T13:29:13.148745Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-13T14:00:37.187557Z"},{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:24.751037Z","error_message":null,"id":"56e6989f-4a2e-45a1-b2e4-40e1ba600b97","name":"scw-test-pool-wait-test-pool-wait-2-56e6989f4a","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/0bf3144e-f31e-4830-a5aa-8a05a0f03ae8","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:37.803353Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1321"
+      - "1323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7075,7 +5887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39792917-d3da-476b-a3cf-2b8b94e9323a
+      - ef23ee44-398b-466d-8d64-58d5356fe235
     status: 200 OK
     code: 200
     duration: ""
@@ -7086,10 +5898,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -7098,7 +5910,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7108,7 +5920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be36f029-c770-4c95-9fda-4a660b100580
+      - d09bae45-6b5d-4ace-bf04-285e1751bae8
     status: 200 OK
     code: 200
     duration: ""
@@ -7119,10 +5931,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:37.890669Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -7131,7 +5943,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7141,7 +5953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6186106-018c-4c40-b32b-626d68de9afc
+      - 3e06a393-556f-4557-bb22-3d1107ab6d19
     status: 200 OK
     code: 200
     duration: ""
@@ -7152,10 +5964,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -7164,7 +5976,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7174,7 +5986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 833b8f54-b42c-47af-a77b-372434222aa0
+      - 3d7c0522-fa34-41ee-963a-822d9a71846e
     status: 200 OK
     code: 200
     duration: ""
@@ -7185,10 +5997,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -7197,7 +6009,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7207,7 +6019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c47dfbda-94ca-4716-8151-2a7981415c00
+      - 26dedc6c-3710-465a-9f25-9d0655c2f0a0
     status: 200 OK
     code: 200
     duration: ""
@@ -7218,10 +6030,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -7230,7 +6042,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7240,7 +6052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d09a4c92-e0e9-4ac6-8a01-70e00b1364b8
+      - 41984703-55f4-422d-82e1-66e5af5369a7
     status: 200 OK
     code: 200
     duration: ""
@@ -7251,10 +6063,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:37.890669Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "626"
@@ -7263,7 +6075,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7273,7 +6085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab311b2c-4a00-4121-83f9-6e100252d849
+      - f376e1a8-0d3f-418a-9dda-f684bb832d47
     status: 200 OK
     code: 200
     duration: ""
@@ -7284,10 +6096,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -7296,7 +6108,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7306,7 +6118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf78ddfe-1589-4dc5-892c-a1f83427d809
+      - 084bfe6b-868c-4ae6-a0d7-b34c37adbbc1
     status: 200 OK
     code: 200
     duration: ""
@@ -7317,19 +6129,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.776631Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-10T13:29:13.148745Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:37.761709Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1321"
+      - "689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7339,7 +6151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 208454ef-130b-4d56-9a15-e764d4e163ce
+      - 34ad1e46-31f8-41fb-a432-b412482e2cc2
     status: 200 OK
     code: 200
     duration: ""
@@ -7350,19 +6162,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.723806Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-13T14:00:37.187557Z"},{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:24.751037Z","error_message":null,"id":"56e6989f-4a2e-45a1-b2e4-40e1ba600b97","name":"scw-test-pool-wait-test-pool-wait-2-56e6989f4a","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/0bf3144e-f31e-4830-a5aa-8a05a0f03ae8","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:37.803353Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "690"
+      - "1323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:18 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7372,7 +6184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12b0079b-bcf7-4c81-bcef-96f5c39eef2e
+      - 00e5d400-6777-40d9-981a-1e3611fec56f
     status: 200 OK
     code: 200
     duration: ""
@@ -7383,43 +6195,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:29:13.846885Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 24cdfafc-94bd-42c8-8cc7-8967137424b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -7428,7 +6207,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7438,7 +6217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14fd406b-7c10-4c5c-9ae7-a81460e305af
+      - 0ab8ef7d-4ffd-4e62-9282-f06f1f68366e
     status: 200 OK
     code: 200
     duration: ""
@@ -7449,10 +6228,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T14:00:37.890669Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "626"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:00:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 98dcebc5-fb6b-4a5b-88d4-b70b7716e934
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -7461,7 +6273,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7471,7 +6283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 432dd46b-d60e-44e6-ba17-6a2b47bc8b04
+      - 0ad6fb2d-5621-4d0b-a716-072075ab3d82
     status: 200 OK
     code: 200
     duration: ""
@@ -7482,19 +6294,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=df8f941f-0be3-4458-9318-77cde72cb43a&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:23:43.809263Z","error_message":null,"id":"652f51b0-a0a8-4720-b331-2e631285716c","name":"scw-test-pool-wait-test-pool-wait-2-652f51b0a0","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/2a14c92b-ab04-4baa-b30b-ae85550eaa61","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.776631Z"},{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:26:48.613540Z","error_message":null,"id":"4c700294-3687-4268-8594-bc542e0d3b0d","name":"scw-test-pool-wait-test-pool-wait-2-4c70029436","pool_id":"df8f941f-0be3-4458-9318-77cde72cb43a","provider_id":"scaleway://instance/fr-par-1/3f219060-dd2c-481b-a563-36391c1d0abf","public_ip_v4":"51.15.211.1","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-10T13:29:13.148745Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:55:59.957036Z","error_message":null,"id":"3437e43a-0b7f-4ecd-8006-75f08b3c85c6","name":"scw-test-pool-wait-test-pool-wait-2-3437e43a0b","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/913a51e9-7f15-477f-9bdb-a9eca3dbc6bf","public_ip_v4":"163.172.149.194","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-13T14:00:37.187557Z"},{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:58:24.751037Z","error_message":null,"id":"56e6989f-4a2e-45a1-b2e4-40e1ba600b97","name":"scw-test-pool-wait-test-pool-wait-2-56e6989f4a","pool_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","provider_id":"scaleway://instance/fr-par-1/0bf3144e-f31e-4830-a5aa-8a05a0f03ae8","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:37.803353Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1321"
+      - "1323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7504,7 +6316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3077775c-07a5-48e1-86ce-d69904edae4c
+      - dcd93154-fb57-4985-8f56-650fad11d21c
     status: 200 OK
     code: 200
     duration: ""
@@ -7515,10 +6327,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -7527,7 +6339,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7537,7 +6349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8df7051-4f76-4077-9e41-ae21bb98a47d
+      - 3ae7d463-58e1-4e9f-8b6a-45d05ec72bf8
     status: 200 OK
     code: 200
     duration: ""
@@ -7548,10 +6360,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -7560,7 +6372,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7570,7 +6382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ed9cc83-b2b1-43f3-9dc9-10b4ff7c2928
+      - 66f345a8-5da3-4c4d-91e2-665e9428fb80
     status: 200 OK
     code: 200
     duration: ""
@@ -7581,19 +6393,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:13.723806Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:37.761709Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "690"
+      - "689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:19 GMT
+      - Mon, 13 Nov 2023 14:00:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7603,7 +6415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0effe3d5-c9d8-4334-b457-b1f07a12c44b
+      - 62260a21-b944-4ae5-9c58-3a715e8f6f66
     status: 200 OK
     code: 200
     duration: ""
@@ -7614,10 +6426,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.494803335Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:00:44.474491763Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "632"
@@ -7626,7 +6438,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:20 GMT
+      - Mon, 13 Nov 2023 14:00:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7636,7 +6448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d3be96a-89fe-4ffe-a4ee-1f37172fe351
+      - 49cee507-e9ed-4479-a478-31e446670e18
     status: 200 OK
     code: 200
     duration: ""
@@ -7647,10 +6459,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.494803Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:00:44.474492Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -7659,7 +6471,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:20 GMT
+      - Mon, 13 Nov 2023 14:00:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7669,7 +6481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14009c88-c0c3-46bc-9c28-268cd1466ca6
+      - ae3a7526-0b11-41fb-a84f-6631b31bc4ab
     status: 200 OK
     code: 200
     duration: ""
@@ -7680,10 +6492,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:23:43.141153Z","id":"df8f941f-0be3-4458-9318-77cde72cb43a","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:20.494803Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:00:44.474492Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "629"
@@ -7692,7 +6504,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:25 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7702,7 +6514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aab05f39-b9d1-4589-86ca-63bdc95514f9
+      - 6f8ae367-d1c3-42f6-8d3f-090d45363b2a
     status: 200 OK
     code: 200
     duration: ""
@@ -7713,10 +6525,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/df8f941f-0be3-4458-9318-77cde72cb43a
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"df8f941f-0be3-4458-9318-77cde72cb43a","type":"not_found"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:55:59.380132Z","id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:00:44.474492Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "629"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:00:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f922c819-94ab-4bcf-b449-381d35027672
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"eb99cf2f-94f6-4f95-b7db-9c2fbc8e997e","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -7725,7 +6570,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:30 GMT
+      - Mon, 13 Nov 2023 14:00:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7735,7 +6580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02ec6f1e-c31e-409f-99cd-5e1616e89e7a
+      - 0a8930be-a95c-475f-b99d-d9b744dfc823
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7746,10 +6591,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -7758,7 +6603,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:30 GMT
+      - Mon, 13 Nov 2023 14:00:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7768,7 +6613,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b86f25c-f42d-48a7-be5e-41b4fb900dec
+      - 45636066-8a93-43fb-bb70-bf98c6bff58d
     status: 200 OK
     code: 200
     duration: ""
@@ -7779,10 +6624,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.658332Z","dhcp_enabled":true,"id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.658332Z","id":"ef5af4fc-e547-4fcf-8f46-819d83d66f28","subnet":"172.16.20.0/22","updated_at":"2023-11-10T13:16:56.658332Z"},{"created_at":"2023-11-10T13:16:56.658332Z","id":"2a3a3b51-6ba2-4680-9410-2d92d1f49927","subnet":"fd63:256c:45f7:fc5f::/64","updated_at":"2023-11-10T13:16:56.658332Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.658332Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:51:13.636213Z","dhcp_enabled":true,"id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:51:13.636213Z","id":"483907c5-df3e-4110-b580-23c7724c65d4","subnet":"172.16.32.0/22","updated_at":"2023-11-13T13:51:13.636213Z"},{"created_at":"2023-11-13T13:51:13.636213Z","id":"80ea870b-5df3-4921-b0de-0bfa900ae2b7","subnet":"fd63:256c:45f7:778e::/64","updated_at":"2023-11-13T13:51:13.636213Z"}],"tags":[],"updated_at":"2023-11-13T13:51:13.636213Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "715"
@@ -7791,7 +6636,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:31 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7801,7 +6646,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54e13dd1-d7ba-40a9-8db0-f97a3a0da9dd
+      - 01223862-4e69-4bcc-aa15-14268771f048
     status: 200 OK
     code: 200
     duration: ""
@@ -7812,10 +6657,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:18:23.287548Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T13:53:04.190593Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -7824,7 +6669,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:31 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7834,7 +6679,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4adb601f-0c22-4a84-9b79-ec4edde71223
+      - db12ba5f-cd97-4290-b8a9-fbe6ca35ca43
     status: 200 OK
     code: 200
     duration: ""
@@ -7845,10 +6690,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamQwMUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjNUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6ZG5DbmhDT1hsUlJIWktURU0zVm10V09XSTBaa3BrUWxsR1JYbExia1E0YlRoRlJVcDFZa2hXVG1FM1MxUmtiVXMyWWxGYWIxVkZhakJ6ZVdSUFdYQnVPR2tLWTNodVMzRmxSalZxYlhaV1ZFdEpRelE0ZG5Jd2VHaElUakJLUTIxTWMzZDVNbFpzS3poeWEwOHZRblpXWTFCdmNtcGpUVEJ4YzFoaFdtMXRkRWRYVmdvM1VXVXZlRUo0UlZvNU9WUkROV2t4ZG5WMGJqTkJSVVZ2ZDNSRldXNVhNbGxEWkdkNE5GZzVkalpoVXpJeE9XSkJla2d3TldJcldXNUlPRzVzY0dzMENrOVBTSE5KZFdwUGNrcFJheTh3U0d4bk5TdERWR3RxYnpoRVNVdzFOaXRDZFdreVNGazJZVzlUVkdWU1RtTm1Tak5GWlRWSlMzUTFhalpXVmxsVmNtVUtPVmg2VGxkcFRYRTBXbWhuTmxKaVVrbElUbk00WkZsNWRITkpNbU5FTDJkSmVHMWxabWN5TDBZekszVjFPRXRxVWs5blVuVnRUbkl5YVdwRVdVTkZhUXBQVG01UGNsbEdMM2t5VEZvd2NtRjBSR3d3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVDJwbFluSm9Oa0l5YVRseFYzcHpZV2cxUVZBclprY3ZSRmhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZFVVZoT01EaG9SVmxaV2toWmF6Tk9jMHhqUmpkTFRERkthWEpYUTBaUFJFSlNaa0ptUlhSYVdIcE1kemhTV2pWeFRRcFpNRVJUT1c5TFp6Um9NV0U1WVhkS2FuUjFXbTFDYVhKNU9HbFdlR1oxUlhNMFNYQlJPVWgxZVVOaVowRmpWMDVqZHpNMVZYSkVORVJLVW1Wc2JtSm5DaklyU25NNE0wSm1URXg2VTBoTVluaFJjbUZzZW1WUlpucE9lWHByU2paVGJHMHpWQ3QyYlhRNVpXRTNPV1YzTm1GTFlqQjJaamw1TURaM2RuSXhPVmtLWkhCbVMwY3hjak5PVmtwYVJVWm5ZMmQxYWpKelVURnNkV2xDYzFKUFpXWlVNamxpTDBZMWQwMU5hbmRSWWsxTlMwaHpVSFJYVEcxVFpFaHdUWHBhY2dwb2FXRTVZV3BqYkV4NFRuSjFZMVJXYkcxYVVUQlhiVk5oZW5GalduaG5lbmxIZVU5bGRWUm9jM1ZzYVVwNE5HOU5ZbWxFY1dGbGJYSkZjV1pWTlVWT0NsTkZNRkpCU2xWNVpEaFlSamhYVGpjeGQzVkdaV3hrU21wUWJUZE9NMVpYWVVkaldRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kMzUxYjQ4My0yOTczLTQyOWItYmIyYy1jNWNkYjcxODM1YTMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBCS1FlQjFBTUVqcjBZSXlCQnNjazVhdG5YNmpxTURoRXMwZXljMWR3QjF5MWd0S0t6WFVMU292TQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSRmVVMHhiMWhFVkUxNlRWUkZlRTFxUlhwT1ZFVjVUVEZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRtUmtDazluUVZJM05HczBLMWhvV21ScVQxbG9iVFZGT1VrM09HVmhNVUZOUjJ0U2N6VnBNSGh2V25GdVRFZzNibFpTYldWa1IzRXlNMnhQWVZkcFoyOXdiMGtLU2xaVGNsWlNhbWMyVG14dlNFdDJUbVkyZEN0aGRrZE9ZVEJHTm1sMlpqWkdTMG8wZFc5UGNIUmtSbTgyZUcxS1RFa3dlSFZHYVRkRU5WbE1kMlZJY3dwYWQzZDZUbTV4UWpKbFVuZHZORTlDTmt0UFpGaEVRbUkxU0dsR2VrdHlkRE5XWWt3NFUyWjRSV2M0U2xOV2FrdFdiRUZwTm1GelZrdEdNMWR6TDJSakNrOXdOVTF4TjNaQk5raExjMWRWU200M1kwaGxNbTFhZEdKWk1XdzRkbVpaT1RsRVJYVkdZME40VlcxSVkwRnNNa3BsZVhsQ1VGTkJSekkwTDJaWFIwb0tNWEIwWTIxRlZEWjZXWEU1UVdWTk4yWlJTSEZsZEVvd1ZVcEZlbWxCZUdac2Iwd3pMMjV0T1VoV1kzWlFhRFE1ZUdSNlJrbHRLM2hhZHpkSlFUVnJkZ3BEWTI1UVJESllWRE50UlZoSVVuZEVjSGROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpQVjAweWNsazRXblUwYWl0alUxbFdVbVE1YVVac1p6ZG9ZbGROUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDWTFaSFZHWkRPR2haU2tGSk5uUkNaRXhqY1d0T2JYQkpUVXhuZFVKYVowWktSMHhDUVdnM1ZtMU9RMHBHTm0xelFnbzNNRGxUUVRac2JXTlBkbE5LYzJVM1IzWkNOV1ZIWTJWTmFUWjVjMW94UzB3d09FRnRXRzlWVTFvd2RISkNPVk5UYzJobGEyUmljV3hJVW1Wc1JFVjBDbVJvYTB0UlpHVkJUWFJ1V0hWc05YY3pSelZQU214NWEwdENXRzh5ZUZsU1dqWTRZa2h0TjBWb1VEaFJlRUZIV25CaldHdEZlVk56VFhsQlNFWlBMMDhLZVVrellWUnFhR3BUVERoVGFVMWtlbGhVWjJwUlFXTkZlVzlCTlV4cU9VSlFVV28yTjJSVk0yVkdUazltU1c5U1dVOUhSM05WUm5oeWFYZEhObm96TUFvelVuUTNOamRZT1U4NVYwZzBRWEZxY2xOTWFEWlFRa2RHY0ZoMlJYZ3dlVXd6UkcxcVVUSnJOMWhZU0ROWFJuUk1Na1psWWtoRldpOVZlR3RTUVU1UkNpdERhVEI2WldKTE5XVjZSVVExZVVkeFkzUkNRM0ZvVTBjelMwcFhNRGxDYUZVek5Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xM2YxZDI1Yy0xZWJiLTRmZjgtODYzYy0wZDNlZDA4ZDNiYTQuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBMRDU1T2w5MGVNWDUydDBzRmdmc2J0eE9QOGljeWtFbXUzT2Q2ajg4SzIzaUdJa3dmNkdhYklsTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -7857,7 +6702,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:31 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7867,7 +6712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e2eb6d0-a6e9-4117-8202-34a5fdc5e7af
+      - 6f7b0495-420d-4b68-8b80-f6539c7712f7
     status: 200 OK
     code: 200
     duration: ""
@@ -7878,10 +6723,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-10T13:23:35.793690Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-13T13:55:55.573944Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "624"
@@ -7890,7 +6735,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:31 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7900,7 +6745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b2ee398-7758-4312-bd42-bfc2fd0b4a2e
+      - 8aae0841-6324-4517-bf35-6aeb0b684252
     status: 200 OK
     code: 200
     duration: ""
@@ -7911,19 +6756,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3/nodes?order_by=created_at_asc&page=1&pool_id=76471576-5453-45a5-b5fe-64739c76a783&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4/nodes?order_by=created_at_asc&page=1&pool_id=664b7147-6d6f-4aa8-9a7c-d2c5229215b9&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:55.264004Z","error_message":null,"id":"3e98118f-f620-4754-890a-3675b26e4bcc","name":"scw-test-pool-wait-test-pool-wait-3e98118ff620","pool_id":"76471576-5453-45a5-b5fe-64739c76a783","provider_id":"scaleway://instance/fr-par-1/a899b6df-8d9a-4882-a6e6-c5e770f10323","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:29:21.022380Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T13:53:26.929920Z","error_message":null,"id":"c71037bb-aca6-49a6-8251-5c3aebb7e97d","name":"scw-test-pool-wait-test-pool-wait-c71037bbaca6","pool_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","provider_id":"scaleway://instance/fr-par-1/f473dc0f-2208-41b4-928b-c99062bd1312","public_ip_v4":"163.172.160.92","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:00:45.036255Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "690"
+      - "689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:31 GMT
+      - Mon, 13 Nov 2023 14:01:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7933,7 +6778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 914d341a-deea-40ac-9402-7f37cc212016
+      - b8ffdfcf-243a-4f2d-b634-dd268446349a
     status: 200 OK
     code: 200
     duration: ""
@@ -7944,10 +6789,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863350Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:01:01.229386215Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "630"
@@ -7956,7 +6801,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:32 GMT
+      - Mon, 13 Nov 2023 14:01:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7966,7 +6811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 443a7b88-16dc-4158-9265-e30043f62bba
+      - 2f1a116b-9129-482f-930c-418a24d4248c
     status: 200 OK
     code: 200
     duration: ""
@@ -7977,10 +6822,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:01:01.229386Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -7989,7 +6834,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:32 GMT
+      - Mon, 13 Nov 2023 14:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7999,7 +6844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c6fa5cc-00b3-4b04-a351-66e28521618c
+      - bf479c74-15bc-41b3-8e55-48226955ce57
     status: 200 OK
     code: 200
     duration: ""
@@ -8010,10 +6855,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:01:01.229386Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -8022,7 +6867,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:37 GMT
+      - Mon, 13 Nov 2023 14:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8032,7 +6877,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2b2be61-4200-4da4-bf2a-c72de51d8c73
+      - 9f910bca-5240-4f22-b8a9-4f4f93583fb5
     status: 200 OK
     code: 200
     duration: ""
@@ -8043,10 +6888,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:01:01.229386Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -8055,7 +6900,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:42 GMT
+      - Mon, 13 Nov 2023 14:01:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8065,7 +6910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f03033c7-4b51-4c6a-886b-7ba4492498ae
+      - 302724b1-6e90-4620-9aac-d8913b25bdd8
     status: 200 OK
     code: 200
     duration: ""
@@ -8076,10 +6921,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:01:01.229386Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -8088,7 +6933,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:47 GMT
+      - Mon, 13 Nov 2023 14:01:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8098,7 +6943,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48c1c259-803a-40d4-94b2-7a46a935aa64
+      - 97f2b360-7c84-4c6a-8b01-7d37dca8293f
     status: 200 OK
     code: 200
     duration: ""
@@ -8109,10 +6954,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:01:01.229386Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -8121,7 +6966,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:52 GMT
+      - Mon, 13 Nov 2023 14:01:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8131,7 +6976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0fe117a-b3f8-45c0-9d73-9aa6942d1d6d
+      - 97e02984-104b-4a45-8b71-e2a88923647b
     status: 200 OK
     code: 200
     duration: ""
@@ -8142,10 +6987,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:01:01.229386Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -8154,7 +6999,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:29:57 GMT
+      - Mon, 13 Nov 2023 14:01:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8164,7 +7009,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f92ec48-4ff2-457b-8706-8a5021ceca3b
+      - fb417cf0-1be1-4a96-9fc2-fd4c974dfe66
     status: 200 OK
     code: 200
     duration: ""
@@ -8175,10 +7020,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","container_runtime":"containerd","created_at":"2023-11-10T13:17:04.450801Z","id":"76471576-5453-45a5-b5fe-64739c76a783","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-10T13:29:32.095863Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","container_runtime":"containerd","created_at":"2023-11-13T13:51:29.627043Z","id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-13T14:01:01.229386Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "627"
@@ -8187,7 +7032,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:02 GMT
+      - Mon, 13 Nov 2023 14:01:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8197,7 +7042,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a04d51fb-8054-41b9-b60a-e294340f49a3
+      - 3037141c-b284-4165-a1f5-5f629a714c36
     status: 200 OK
     code: 200
     duration: ""
@@ -8208,10 +7053,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"76471576-5453-45a5-b5fe-64739c76a783","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -8220,7 +7065,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:07 GMT
+      - Mon, 13 Nov 2023 14:01:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8230,7 +7075,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae43d4ad-5185-4ab9-85cf-e6ec8cb66dc1
+      - 16c61b3f-ca3d-4b57-94b1-455136bbc3b8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8241,10 +7086,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:30:07.544878786Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:01:37.527892874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1500"
@@ -8253,7 +7098,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:07 GMT
+      - Mon, 13 Nov 2023 14:01:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8263,7 +7108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14d5418f-d3f8-460d-80fc-80b40d3b063c
+      - 807e5014-3115-49af-b808-e19b11fe38d9
     status: 200 OK
     code: 200
     duration: ""
@@ -8274,10 +7119,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:30:07.544879Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:01:37.527893Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -8286,7 +7131,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:07 GMT
+      - Mon, 13 Nov 2023 14:01:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8296,7 +7141,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25fea5c3-eae6-4bf1-a316-dc86b274a009
+      - 56c24196-f7c7-4d6e-b2c7-b4e7ade6571c
     status: 200 OK
     code: 200
     duration: ""
@@ -8307,10 +7152,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d351b483-2973-429b-bb2c-c5cdb71835a3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.936901Z","created_at":"2023-11-10T13:16:58.936901Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d351b483-2973-429b-bb2c-c5cdb71835a3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d351b483-2973-429b-bb2c-c5cdb71835a3","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-10T13:30:07.544879Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:01:37.527893Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -8319,7 +7164,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:12 GMT
+      - Mon, 13 Nov 2023 14:01:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8329,7 +7174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e21621c4-5c68-4f0b-a08d-31af58885f64
+      - 4e7ee883-419d-4ef3-9895-3962807729f7
     status: 200 OK
     code: 200
     duration: ""
@@ -8340,10 +7185,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:51:18.420504Z","created_at":"2023-11-13T13:51:18.420504Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-13T14:01:37.527893Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1497"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c70b261-c1bc-4b77-8611-8a3efc121392
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -8352,7 +7230,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:17 GMT
+      - Mon, 13 Nov 2023 14:01:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8362,7 +7240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29421981-2630-4820-99bc-a0f14c7015d0
+      - c726826a-9567-4117-b552-2fbd2d457c97
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8373,10 +7251,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -8385,7 +7263,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:17 GMT
+      - Mon, 13 Nov 2023 14:01:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8395,7 +7273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 907b4a3d-91f2-4c1c-9f9c-6129621c69ac
+      - ada9a5fe-e408-406b-973a-a5689e4a2012
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8406,76 +7284,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/08a8405b-c181-40ea-a1b5-16616ddbb5c6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/664b7147-6d6f-4aa8-9a7c-d2c5229215b9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"08a8405b-c181-40ea-a1b5-16616ddbb5c6","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:30:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d7039c38-afad-42e7-adda-dc1dfa850625
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d351b483-2973-429b-bb2c-c5cdb71835a3
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d351b483-2973-429b-bb2c-c5cdb71835a3","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:30:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 105db63d-34e6-4db7-a683-5c01e3c11be2
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/76471576-5453-45a5-b5fe-64739c76a783
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"76471576-5453-45a5-b5fe-64739c76a783","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"664b7147-6d6f-4aa8-9a7c-d2c5229215b9","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -8484,7 +7296,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:30:17 GMT
+      - Mon, 13 Nov 2023 14:01:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8494,7 +7306,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44e0bac7-93d6-48db-af6b-2d1bd2886204
+      - a879dcb0-2f6c-48d8-a70e-5b3f64d9ec03
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"13f1d25c-1ebb-4ff8-863c-0d3ed08d3ba4","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a11a8b09-a107-4f5a-9b3d-d82ee344d6d0
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d3f19320-3bcb-4550-a629-e646f8d0ab5a
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"d3f19320-3bcb-4550-a629-e646f8d0ab5a","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b75552b-2a26-4fd2-a917-dc161e4216d1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-zone.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-zone.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98edb633-899d-4019-a0a3-4622d759ac6e
+      - 35f3e4c5-ee27-4783-90c6-c07003c6d5a1
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:17:31.407080Z","dhcp_enabled":true,"id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:31.407080Z","id":"a9482212-bf45-4721-81bc-efd85a40e99c","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:17:31.407080Z"},{"created_at":"2023-11-10T13:17:31.407080Z","id":"b02f39a3-36d6-4c40-a763-20ceac944466","subnet":"fd63:256c:45f7:37db::/64","updated_at":"2023-11-10T13:17:31.407080Z"}],"tags":[],"updated_at":"2023-11-10T13:17:31.407080Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:17.332083Z","dhcp_enabled":true,"id":"02cda651-8832-495a-9ba7-d8d97c1b8686","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:17.332083Z","id":"ca7a0189-2836-405d-a34d-240a224c4e4b","subnet":"172.16.28.0/22","updated_at":"2023-11-13T13:57:17.332083Z"},{"created_at":"2023-11-13T13:57:17.332083Z","id":"d67e6cc6-4971-4ab8-a1e7-54f70556da71","subnet":"fd63:256c:45f7:9518::/64","updated_at":"2023-11-13T13:57:17.332083Z"}],"tags":[],"updated_at":"2023-11-13T13:57:17.332083Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "714"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:32 GMT
+      - Mon, 13 Nov 2023 13:57:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3160dd4f-ee9c-47af-859c-2e0715932eb7
+      - 4c955c04-b837-4f1f-aedc-8fb0723a56c0
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a915eb65-d9fa-4dc3-bb29-d36d4aa4b642
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/02cda651-8832-495a-9ba7-d8d97c1b8686
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:31.407080Z","dhcp_enabled":true,"id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:31.407080Z","id":"a9482212-bf45-4721-81bc-efd85a40e99c","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:17:31.407080Z"},{"created_at":"2023-11-10T13:17:31.407080Z","id":"b02f39a3-36d6-4c40-a763-20ceac944466","subnet":"fd63:256c:45f7:37db::/64","updated_at":"2023-11-10T13:17:31.407080Z"}],"tags":[],"updated_at":"2023-11-10T13:17:31.407080Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:17.332083Z","dhcp_enabled":true,"id":"02cda651-8832-495a-9ba7-d8d97c1b8686","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:17.332083Z","id":"ca7a0189-2836-405d-a34d-240a224c4e4b","subnet":"172.16.28.0/22","updated_at":"2023-11-13T13:57:17.332083Z"},{"created_at":"2023-11-13T13:57:17.332083Z","id":"d67e6cc6-4971-4ab8-a1e7-54f70556da71","subnet":"fd63:256c:45f7:9518::/64","updated_at":"2023-11-13T13:57:17.332083Z"}],"tags":[],"updated_at":"2023-11-13T13:57:17.332083Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "714"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:32 GMT
+      - Mon, 13 Nov 2023 13:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78d8e059-4ac0-4bd3-920f-a79a5709d18f
+      - 90c722ad-05a5-4c73-a72d-4fb25052f94d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-zone","description":"","tags":["terraform-test","scaleway_k8s_cluster","zone"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-zone","description":"","tags":["terraform-test","scaleway_k8s_cluster","zone"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819188736Z","created_at":"2023-11-10T13:17:32.819188736Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:32.887687873Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457424Z","created_at":"2023-11-13T13:57:19.413457424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T13:57:19.435275809Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:33 GMT
+      - Mon, 13 Nov 2023 13:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 438f95ce-e346-454d-a9c0-080fd7af9355
+      - f2690617-314e-4ec1-9bb9-6eacd7fbd30c
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:32.887688Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T13:57:19.435276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:33 GMT
+      - Mon, 13 Nov 2023 13:57:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e49635e4-54ae-43bc-b4fe-6a092023c20e
+      - 4579c90d-59b0-41b9-bea1-013d73ccf694
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:35.392424Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T13:57:21.725238Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1499"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:38 GMT
+      - Mon, 13 Nov 2023 13:57:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27840d45-5729-442e-acc4-da34a1b4a929
+      - a818a376-de95-44da-a97f-c720a8e23c51
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:35.392424Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T13:57:21.725238Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1499"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:38 GMT
+      - Mon, 13 Nov 2023 13:57:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bb92e29-a3dd-473b-99bb-88eac3f22aff
+      - cdf45b0f-03ed-4d03-ae71-22b82b8ef0f8
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamVrNUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjZUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQzSm9Da1I2UzJOeUwxcHdjR00yWVVNeE9TODNNMWxDVWpCTWNFOUZVakJDV1dvd1RXVkNkMUpXWVU5VGIwcExRWGgzYWpoSk5IQm5ZV04xVkhKUVRHa3dVbVlLTUZObWMwRlhlbE5rWlU0ME5YbFJhMll4UkZjdmRTczBSa1pzT1RKWU5WRmlhV3hSUldOamVUSlpaV1Y2UlVOMVluQllMMWhzYURsUVJuaHhXR3h4U1FwSVUzUTVhMkV2TWxodldVVnNkMEpKUVd4NmF6aFFTalI1VHpnclRtUkdaemhWWW5sNVVtZGpNbXhtTXpodFZubzFURE5VTVhaVVExSm5ia0ZCSzBKdkNqWk9VbW92WVRrNWRraE1aek00YlhoT1dTOWFXalpGWWxrMGRHODNka3g2UTFCcVpuSm5SREZzVDBKM1dIWmFhVWt2YjJGbmRIVjFkeTlNU2xaelV6TUtUR1pKYmxORmF5dHZhVk5QYmlzNVVFbEphRkUzVERSQ1RrTXdkbk5aYTBkcVpXUk9iek5aV0c1ME1XZFNUR2R6VEdOcFFqUTJhV3RLWlZscVNWRkxad28xVVhnMU5EVTFhazU0T0ROUlExSjRXR2RWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCZG5VMFdqQmxUbUZXTmpKUEt6azRka1JYVVN0Mk5WUkpjalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDT0dObWJHaDBjak14U0ZFMVZVOW9NVEJoVWtSNFpETm5ORWw0TkRJeFYwRkxZMjFGWm1ST1VsaGlha0pOU0VSM1Z3cHdNR1JsYmpabmRHaDFUbTFNYVZVMU5tTnpUbUlyT1RkQ01FSnVlQzlRTlZVeU1UTlZTRVZLWVVsd05GbzJRakZ2ZHpOUlQyRm5VekpLTDBwTlFuTnNDbmxPTlRCU1FqSTJZMWR3YkRWUWNqQkxZWFJFUzNSRlYyOTRWbkEyTkZCUlMzQTNhMHR6TkdFeGJqVmhlVEF4Y0ZoTWMwSTRNM0pSUlVscmRrOXNVMWdLTVRoRFJEQk5WRU12YzBGaVozUktkRFl3UjIxbGIyUnROV0pFUlVKclJrRmhaVEV6TkhVeGRqVTJhVVpHTkhodVRqUlBNSEp5TlZsUVFqSlZlVWhtYVFwcGVFaHJiWGxZVURCTE5GZDRlVTFPYURoT1ZVYzBlVzF2WjFZNVN6bHpZMncyZFdoV0wybElWMHRvV0ZaemNEUm5kMWh2VjJkVmFWQldNMlZaYUU1SkNtaE5jMlYyT0cxck5WSm9Va0ZtVTJoTGFIQnZOV3RYVkZFNGJHeHZSa0ZOTWpRM013b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kOGI5YTE5YS1iY2VmLTRjZTAtODQ4OC0wZmU4OGI5MTkyMzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3eHlpYUpzWlNkVDllMnYxTWU5NVZ4S2pNQ2ZTWm9GdGNXS1FmU25kOHpRVVdoYWdacUM2cXpDYw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSamVVMVdiMWhFVkUxNlRWUkZlRTFxUlhwT1ZHTjVUVlp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRUVlZDa3BVUm1oRGJVcHJjMk5qZUZkSWMycG9ZMk40WW14V05ETmlWVWhCYjFCQlpWQTBTbkJ1VjJOdWVFRkdWR00xTmpjdlJqWjVORTlXVWpobVZqQTFZVU1LWTA4NU9YbHBWSGM1V2xJMGJDOU9XbE55TW5SR00wUk1WRVU1Wm5wWFNURkZhMFZuYTJNMmFWY3JUbUZLT1hVeWVXTldSbFpVTmpGSGMwSmlUbEJqV1FvNWRTdEVZMWtyYnl0YVJtdFljRGhLZVZaNWRGQllOa0o1ZVdSRlNteGlPSEpSV2pOVVFtaHpRV2RuTm0xRWNYVXhUemw2V0hGcVpXSlhiV2cxVVVsMENtWm5PRFJDY0ZKcE1GcElTVkY0VG05SVQyZGhUVTV2Tm1GNVZFUjRWRVkwTTNaalRHeEVUbmRxV0U5R1JXVlJjMGxsUzFWRFZrTmtWMWRMYUVZM1QzVUtaR1JDVjBRMVVHMURiMVYyV1dkWFkxSkdhbGh4U25SVFJUVnZVMGxITlRSTWEwb3pTV2x0UlRsNlltSldjRFJpVVVOQ1ZrSnROVlZOU2tOU1lWQnFXQW94VlhjNGFVcEhiUzl1V0ROWk15dDBOVFF3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpNZFhWSVNqUnRMMHMwSzBSd2VWUnNUbHB0YVhaUE1HaFhkVUpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCTlRob1UzZHRkblZGVVU1M2Exa3hURTFaVFV4R1NqbFlUbGxwSzNZd1JWbHVRbXh2VDJkblZHWjBRbHByZWs1elZBcFVjV1JNUzJoNFkwZENWMkZ2VW00d1VreFdkMWhYTUcxaGNscHNUbFVyVFRKWE9VcFdkRXh0YzA5M00xWXhlWFZXZGpsalJuRlROV05UY0VkNllTdEhDbk5YUjIxTmExcExLM2tyVURoWGJHaHFSME52V25CS2FYRm9NMDFzUTJKYWIweE1NRnBXT1RoT1VIRlJNVkZXY1haUVJsaE5XSGR2WlM5MU5qTndRa0lLUzB0c01YQjBVVWhsT0ROU1NsUlBkbmR6YmpFMU1UWkhkbFp2V0dReVEzQjRia0lyYmxsVWRXeHhka3BEVnpGaGQxaHdNeTl3WlhjMFpYRlBVMWg0VkFwT1dIaE9Rak5TYmtaVUx6WjFZamN4VjNwNWNtTnBiSEZWZEhaMmFpdGhjMEY2VkZKTmFDczRXVzlsWkN0dEwwdHdaMnhQWjJoUVUwcFdhR0U0ZVVVMENuRnZOVFJaVTNwTE0wMUtVVmhvZDJSUVZUVlFia2hDVUVvM1FXZDVXV3BvZUhkU1VRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly84NmQzNWVmMS1iMjZjLTQyYmYtYTJhMy0zZGFiZTYwYWNkZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFMHg5UTJQN1FqeDROa2RqOEZWcER0UXp5Z2VWT0RGY0xDU0hqd05wa3NsTzZleUpDa3JORVI0Sg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:38 GMT
+      - Mon, 13 Nov 2023 13:57:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - daee46c6-1ec5-4fd1-b492-a709dd166cd7
+      - 501543ee-36c1-4a4a-9300-9e5cedf1f5c8
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:17:35.392424Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T13:57:21.725238Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1499"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:38 GMT
+      - Mon, 13 Nov 2023 13:57:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 389bf314-f6cc-434e-9109-ed732a78a49a
+      - 991c0ecf-890f-4cff-b0ed-39cae89f96f1
     status: 200 OK
     code: 200
     duration: ""
@@ -315,10 +315,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764551973Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929048Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "675"
@@ -327,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:39 GMT
+      - Mon, 13 Nov 2023 13:57:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed2ee012-e159-4950-9d41-61b087753289
+      - 66920fb2-139b-4006-a787-3b2597cafe16
     status: 200 OK
     code: 200
     duration: ""
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -360,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:39 GMT
+      - Mon, 13 Nov 2023 13:57:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb9d8622-bc22-4349-8f98-3eef2cc85f7f
+      - 14dd0271-ae55-432e-8671-9d59958ba727
     status: 200 OK
     code: 200
     duration: ""
@@ -381,10 +381,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -393,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:44 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a90c89e-a05b-49d0-9295-5bc348564f0e
+      - 6966f375-2a2a-47b6-b12f-3a3bc7e057fb
     status: 200 OK
     code: 200
     duration: ""
@@ -414,10 +414,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -426,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:49 GMT
+      - Mon, 13 Nov 2023 13:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a05e6f83-ebf3-463b-97cb-c36dfaa3f08b
+      - 4b3c9353-d2eb-4b6e-a42a-d5ad687c1818
     status: 200 OK
     code: 200
     duration: ""
@@ -447,10 +447,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -459,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:54 GMT
+      - Mon, 13 Nov 2023 13:57:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3c0d9fc-61c9-44c1-b923-97407866b4b6
+      - 6dba6180-c698-4a1e-b23a-894ba888c6c5
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -492,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:59 GMT
+      - Mon, 13 Nov 2023 13:57:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 024c9ccf-598f-4f47-b0bd-ad29e2689926
+      - 7030af88-75be-4072-9476-9462c6980a5a
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:04 GMT
+      - Mon, 13 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98bd0092-9067-45f5-bbda-1e3e4c1052ae
+      - 69c27d47-5108-409b-aea0-25583afe29b8
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:09 GMT
+      - Mon, 13 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3691cb9f-1d74-476e-8941-8d0b00574064
+      - e26e5311-6b3b-44b4-a40f-5fe12e36ab42
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -591,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:14 GMT
+      - Mon, 13 Nov 2023 13:58:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94cb17ae-5b53-4018-839a-00f7af6fb1ac
+      - 422119f1-6aa5-4723-a4e4-78bea0eee8e6
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:19 GMT
+      - Mon, 13 Nov 2023 13:58:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94361453-fb2f-4242-bd32-556143183c34
+      - 51ef7c53-ff9d-4ad4-945a-408c714424fe
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:24 GMT
+      - Mon, 13 Nov 2023 13:58:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fee5239-348e-42d7-8b27-3fee96be468b
+      - 338da27f-d57f-4a81-a0a7-cb19efa97552
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:29 GMT
+      - Mon, 13 Nov 2023 13:58:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74a2570d-fafa-478d-a6c2-b0a4ecd79609
+      - 13ae34e5-9bc8-4299-9d89-5a815ecbac54
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:35 GMT
+      - Mon, 13 Nov 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9eaf2f13-656d-4cca-a0f4-02ca527fc989
+      - f4dc2fdf-de0b-48c7-8ac4-6229203dfdd8
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:40 GMT
+      - Mon, 13 Nov 2023 13:58:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d40c9ac-9e4d-4101-bb1d-1c1cb32edfc9
+      - a304849f-96dc-4c34-87e5-3da8bd7d886e
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:45 GMT
+      - Mon, 13 Nov 2023 13:58:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57734298-1f19-4d47-bc67-605bfedcc6e1
+      - 05aaf646-5621-4619-8b10-a815aefb6f1c
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:50 GMT
+      - Mon, 13 Nov 2023 13:58:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 524c0be6-2f51-4dbf-8593-c3da4145aaef
+      - 7b69344c-a0bf-437c-8050-0484b61d7ad3
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:55 GMT
+      - Mon, 13 Nov 2023 13:58:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4d2d80f-e7f0-495a-a263-184f001e47c7
+      - 0253d209-aa4a-43b9-8d80-8c0cc232f30c
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:00 GMT
+      - Mon, 13 Nov 2023 13:58:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e45e7f34-3922-413a-96b4-c4c97e33905c
+      - f3505562-e869-469d-8732-be3d8bc25bc6
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:05 GMT
+      - Mon, 13 Nov 2023 13:58:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81694911-aaf6-4ac3-a72b-377405868e95
+      - e90045bb-9643-48c1-898f-42798423cfd2
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:10 GMT
+      - Mon, 13 Nov 2023 13:58:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b03116b-01a8-45a5-9948-273a69c0800a
+      - 5edb7892-bf8d-4fd9-864e-7f53501ef9dd
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:15 GMT
+      - Mon, 13 Nov 2023 13:59:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe5496ad-b44c-4f58-9133-3ba188bad785
+      - 06023fe1-8386-41e0-ac01-27f7248c9f9b
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1020,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:20 GMT
+      - Mon, 13 Nov 2023 13:59:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 230d8b03-a9fb-49eb-ba97-dc5b409dce38
+      - a7f034d7-8020-480f-b137-a2f6d66c6495
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1053,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:25 GMT
+      - Mon, 13 Nov 2023 13:59:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69b1da85-4fcd-42cb-865e-ea3e778cad3d
+      - 629da79b-87fb-4650-801f-d8e229168fe0
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1086,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:30 GMT
+      - Mon, 13 Nov 2023 13:59:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c86c1fc-3e9b-488b-b05f-441b70d89a8b
+      - 5b81f78b-d7e9-4f17-914c-4f31fd2b361d
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1119,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:35 GMT
+      - Mon, 13 Nov 2023 13:59:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3653d40c-3f92-47f7-9853-4e07acfa3f3d
+      - 69cddb11-29ce-441b-b8f2-751cc996e152
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1152,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:40 GMT
+      - Mon, 13 Nov 2023 13:59:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80640b59-75ef-4c96-a4cf-19909ff30c58
+      - cf2ba496-6a78-4e5b-95c7-bc5d0474d094
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1185,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:45 GMT
+      - Mon, 13 Nov 2023 13:59:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dffc6d04-75f1-449a-90f5-db3240de4d46
+      - 82629f1b-1407-4c6c-a2bf-c0151db869d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1218,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:50 GMT
+      - Mon, 13 Nov 2023 13:59:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 026b01ae-4651-429b-bbe5-fda234dc376a
+      - a6e72aa7-77bf-4e46-9568-5c59e4b4b7a8
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1251,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:55 GMT
+      - Mon, 13 Nov 2023 13:59:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a45a9e3-e8d7-45cb-b69f-d623e11c04fc
+      - a761ec57-dd3d-46cf-94d1-26b29566eb93
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:00 GMT
+      - Mon, 13 Nov 2023 13:59:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9f2fbb9-6167-4e31-8d91-30786dddfccd
+      - dcd518fa-4ab7-44cb-9e36-b7e1ac24c855
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1317,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:05 GMT
+      - Mon, 13 Nov 2023 13:59:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0746d745-d1f6-45e7-972a-8bd77c527fe7
+      - 5ad5ead6-9337-4eee-b1a2-c1e2fa027d79
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1350,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:10 GMT
+      - Mon, 13 Nov 2023 13:59:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17a4f72-616e-49e9-bd5b-6de89bed03b2
+      - 1a39c01f-855d-45f6-b99b-faad8ddcd159
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1383,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:16 GMT
+      - Mon, 13 Nov 2023 14:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcc97bf3-38a6-45eb-93d0-fdbc429f7ffb
+      - f71d45c4-a3b2-4fd3-a136-2c6efac4f637
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1416,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:21 GMT
+      - Mon, 13 Nov 2023 14:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19ddd2ba-f7a4-40c5-8c30-cda3f7dd85f2
+      - cc584d36-7087-4ea3-ae41-73d3ce48b3c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1449,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:26 GMT
+      - Mon, 13 Nov 2023 14:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c6b6e29-b1d0-40a5-9005-32a28a2a6c9f
+      - f490419e-4db7-4e3a-8b4c-47458ac66e56
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1482,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:31 GMT
+      - Mon, 13 Nov 2023 14:00:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f606af2b-7781-45d7-a3b3-83c2269c42fd
+      - 5a3de60b-0905-4f6a-8b62-c29cd3811df8
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1515,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:36 GMT
+      - Mon, 13 Nov 2023 14:00:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11c6bb40-4020-4be3-9e18-397ad954cbca
+      - 6a0de851-da26-4baf-b297-4fd82e324bfd
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1548,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:41 GMT
+      - Mon, 13 Nov 2023 14:00:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20ea6eb9-37d5-4b96-835b-3521a6fe2fb9
+      - 6d5389d4-5ddc-48b2-99a6-04ae121b0387
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1581,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:46 GMT
+      - Mon, 13 Nov 2023 14:00:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8b5fab0-d299-46ae-8189-c2a0a6aa3533
+      - 0c70d9a1-2e4b-417f-a2f5-3af3afe05aef
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1614,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:51 GMT
+      - Mon, 13 Nov 2023 14:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a076a70-d4a8-4595-a36c-fff3d60182e2
+      - df51b9a8-af6d-42a5-98a0-46ec0223e652
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1647,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:56 GMT
+      - Mon, 13 Nov 2023 14:00:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1ade5d8-3de3-4366-9eeb-e75ffc5b0c9e
+      - 93aea667-248b-46b8-9c1e-92f564c6e2ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1680,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:01 GMT
+      - Mon, 13 Nov 2023 14:00:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9682d787-a390-4d40-818b-f9b34f0f7202
+      - 48059d18-9bd1-4f8a-8a29-551471e3df17
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1713,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:06 GMT
+      - Mon, 13 Nov 2023 14:00:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dcb0032-ce6b-4c86-ad2a-051b09ee5467
+      - 193ce6af-3373-4b69-9ea8-ff37db102aee
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1746,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:11 GMT
+      - Mon, 13 Nov 2023 14:00:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 350c697a-c4a4-4fcd-808b-61baffcbf85d
+      - 4095d404-009b-48cd-9ab5-896f96f60433
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1779,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:16 GMT
+      - Mon, 13 Nov 2023 14:01:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dde0fea1-89bc-46d2-afa7-f34133928b8c
+      - eeebf5b4-e9bf-4053-8648-06285ecf8e12
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1812,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:21 GMT
+      - Mon, 13 Nov 2023 14:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a14cba84-5a7e-4273-bc84-90d81071b047
+      - b410a912-9f1b-44c1-9116-d7fe4f6a7bbb
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1845,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:26 GMT
+      - Mon, 13 Nov 2023 14:01:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0912a3c9-6b0a-4a4f-aeda-961aab1f67cc
+      - 1ce29f50-a42a-4b94-821e-47d4b965050d
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1878,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:31 GMT
+      - Mon, 13 Nov 2023 14:01:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b3e78f1-a5fe-4b51-b601-2c04a5a2d23a
+      - 22027a22-60c2-494f-86a4-6b761224ed25
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1911,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:36 GMT
+      - Mon, 13 Nov 2023 14:01:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a180d4c-f6c1-4ee3-8487-2612a5704b91
+      - 00c0d4f9-f1e1-4ab5-bc3b-71a86c56e427
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1944,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:41 GMT
+      - Mon, 13 Nov 2023 14:01:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 165d0eab-2ff7-474b-a668-f9de1296ea6b
+      - 5b383ec8-128f-430a-8a76-1c406324e0b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -1977,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:46 GMT
+      - Mon, 13 Nov 2023 14:01:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f2f4067-834a-4102-a652-62508f80d438
+      - 6cf40df1-4b17-4dd3-bf23-3a7a96e4e18d
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -2010,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:52 GMT
+      - Mon, 13 Nov 2023 14:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59cbfd31-9d38-454d-a281-524472c6d7c8
+      - 8cdd5c24-c0f6-49de-9f76-28996180e56a
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -2043,7 +2043,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:57 GMT
+      - Mon, 13 Nov 2023 14:01:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76f4a2fe-35dd-4d33-a246-884c53cf8460
+      - c49707ea-8931-4b54-b9b7-51fc39fb3e42
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,10 +2064,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -2076,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:02 GMT
+      - Mon, 13 Nov 2023 14:01:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 427e2ef1-dd5d-4bf0-8d31-c1f1296c8719
+      - 8de58a06-2c71-437b-97c5-ca545fb7a286
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,10 +2097,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -2109,7 +2109,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:07 GMT
+      - Mon, 13 Nov 2023 14:01:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16f47843-933b-4789-b875-8c984b0e0244
+      - 199cec05-c1d2-48d4-9b2b-02d56367bbbd
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,10 +2130,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -2142,7 +2142,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:12 GMT
+      - Mon, 13 Nov 2023 14:02:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 274c3bd5-86b5-48d0-82db-fc334dfc4dd1
+      - 0d52e492-2cd4-479f-9670-53624e5d5da2
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,10 +2163,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:17:38.764552Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "672"
@@ -2175,7 +2175,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:17 GMT
+      - Mon, 13 Nov 2023 14:02:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 585f0118-11b3-4462-9806-159fffa9c015
+      - e82ad1d6-6ff3-40cd-975e-e7fbf0d8571f
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,10 +2196,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:19.133861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - efc285ad-f909-4f31-a59f-e10de631b461
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d60e35cd-30b3-458d-ae61-f2b93294717a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25477fcc-cad0-49b6-b47e-1a36decb9cd1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T13:57:24.981929Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2217e2a6-5bf9-44f7-8319-4593aa112dc4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:28.503679Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "670"
@@ -2208,7 +2340,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:02:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd1e1ab6-f178-4dc7-af44-812b514562fa
+      - 9df76d00-d2a2-47af-9205-8025487f36d0
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,10 +2361,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:19:09.597809Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T13:58:30.662098Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1491"
@@ -2241,7 +2373,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:02:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ddfdd62d-7749-4761-b3a9-b5ceb244b54e
+      - 0e0b357e-5451-48d7-987e-a267465cd5e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,10 +2394,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:19.133861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:28.503679Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "670"
@@ -2274,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:02:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9b7da72-682b-46c7-b726-f2a54ba7e8d3
+      - 4260c940-b7d4-47d8-bd13-603914148c89
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2427,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/nodes?order_by=created_at_asc&page=1&pool_id=4c139d79-c993-4ce6-822d-b4284cd0d713&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc/nodes?order_by=created_at_asc&page=1&pool_id=0be1ccbe-c0d7-402f-b531-fc4b22d828f3&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:39.408229Z","error_message":null,"id":"2a1c9d37-4f9c-47da-98a7-71b7d87da8a1","name":"scw-test-pool-zone-test-pool-zone-2a1c9d374f9c","pool_id":"4c139d79-c993-4ce6-822d-b4284cd0d713","provider_id":"scaleway://instance/fr-par-2/ecc31da0-0b67-4e03-8720-b2b3174087ea","public_ip_v4":"51.159.141.113","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:19.097246Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:00:10.185268Z","error_message":null,"id":"cfd6ae66-ad01-41c2-bb62-9d88b0e10762","name":"scw-test-pool-zone-test-pool-zone-cfd6ae66ad01","pool_id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","provider_id":"scaleway://instance/fr-par-2/395d556d-d1b6-448e-8c82-145e8c525ae4","public_ip_v4":"51.159.162.176","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:02:28.488006Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "659"
@@ -2307,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:02:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c40d7ca6-fee3-4c8b-99cd-1e4ef8d7ebe8
+      - 6c3001c7-7e04-425a-be75-c1f19a4e86a5
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,10 +2460,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:19:09.597809Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T13:58:30.662098Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1491"
@@ -2340,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:02:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65ebbff6-baeb-4b32-b4da-cf36fd1eda02
+      - efc0fa13-a23e-4d83-b0a1-80fb3508cb8c
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,10 +2493,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:19.133861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:28.503679Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "670"
@@ -2373,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:02:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8115958a-5d05-41f8-a197-eb2159d3ac7d
+      - 90f5fe66-4a4a-4263-9f1c-b3854abf84a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a915eb65-d9fa-4dc3-bb29-d36d4aa4b642
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/02cda651-8832-495a-9ba7-d8d97c1b8686
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:31.407080Z","dhcp_enabled":true,"id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:31.407080Z","id":"a9482212-bf45-4721-81bc-efd85a40e99c","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:17:31.407080Z"},{"created_at":"2023-11-10T13:17:31.407080Z","id":"b02f39a3-36d6-4c40-a763-20ceac944466","subnet":"fd63:256c:45f7:37db::/64","updated_at":"2023-11-10T13:17:31.407080Z"}],"tags":[],"updated_at":"2023-11-10T13:17:31.407080Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:17.332083Z","dhcp_enabled":true,"id":"02cda651-8832-495a-9ba7-d8d97c1b8686","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:17.332083Z","id":"ca7a0189-2836-405d-a34d-240a224c4e4b","subnet":"172.16.28.0/22","updated_at":"2023-11-13T13:57:17.332083Z"},{"created_at":"2023-11-13T13:57:17.332083Z","id":"d67e6cc6-4971-4ab8-a1e7-54f70556da71","subnet":"fd63:256c:45f7:9518::/64","updated_at":"2023-11-13T13:57:17.332083Z"}],"tags":[],"updated_at":"2023-11-13T13:57:17.332083Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "714"
+      - "715"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:23 GMT
+      - Mon, 13 Nov 2023 14:02:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87eb2bb7-9b7e-444a-815f-fc290a002558
+      - d30679d1-7875-47a1-9b85-c2ea89f63ac9
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,10 +2559,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:19:09.597809Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T13:58:30.662098Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1491"
@@ -2439,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:23 GMT
+      - Mon, 13 Nov 2023 14:02:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e78daf4-35b4-4948-98c1-2314c6273c12
+      - b1e9ede9-b000-401c-bc5f-8a24809a35e5
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,10 +2592,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZFBWRVY2VFZSamVrNUdiMWhFVkUxNlRWUkZkMDlVUlhwTlZHTjZUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQzSm9Da1I2UzJOeUwxcHdjR00yWVVNeE9TODNNMWxDVWpCTWNFOUZVakJDV1dvd1RXVkNkMUpXWVU5VGIwcExRWGgzYWpoSk5IQm5ZV04xVkhKUVRHa3dVbVlLTUZObWMwRlhlbE5rWlU0ME5YbFJhMll4UkZjdmRTczBSa1pzT1RKWU5WRmlhV3hSUldOamVUSlpaV1Y2UlVOMVluQllMMWhzYURsUVJuaHhXR3h4U1FwSVUzUTVhMkV2TWxodldVVnNkMEpKUVd4NmF6aFFTalI1VHpnclRtUkdaemhWWW5sNVVtZGpNbXhtTXpodFZubzFURE5VTVhaVVExSm5ia0ZCSzBKdkNqWk9VbW92WVRrNWRraE1aek00YlhoT1dTOWFXalpGWWxrMGRHODNka3g2UTFCcVpuSm5SREZzVDBKM1dIWmFhVWt2YjJGbmRIVjFkeTlNU2xaelV6TUtUR1pKYmxORmF5dHZhVk5QYmlzNVVFbEphRkUzVERSQ1RrTXdkbk5aYTBkcVpXUk9iek5aV0c1ME1XZFNUR2R6VEdOcFFqUTJhV3RLWlZscVNWRkxad28xVVhnMU5EVTFhazU0T0ROUlExSjRXR2RWUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCZG5VMFdqQmxUbUZXTmpKUEt6azRka1JYVVN0Mk5WUkpjalpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDT0dObWJHaDBjak14U0ZFMVZVOW9NVEJoVWtSNFpETm5ORWw0TkRJeFYwRkxZMjFGWm1ST1VsaGlha0pOU0VSM1Z3cHdNR1JsYmpabmRHaDFUbTFNYVZVMU5tTnpUbUlyT1RkQ01FSnVlQzlRTlZVeU1UTlZTRVZLWVVsd05GbzJRakZ2ZHpOUlQyRm5VekpLTDBwTlFuTnNDbmxPTlRCU1FqSTJZMWR3YkRWUWNqQkxZWFJFUzNSRlYyOTRWbkEyTkZCUlMzQTNhMHR6TkdFeGJqVmhlVEF4Y0ZoTWMwSTRNM0pSUlVscmRrOXNVMWdLTVRoRFJEQk5WRU12YzBGaVozUktkRFl3UjIxbGIyUnROV0pFUlVKclJrRmhaVEV6TkhVeGRqVTJhVVpHTkhodVRqUlBNSEp5TlZsUVFqSlZlVWhtYVFwcGVFaHJiWGxZVURCTE5GZDRlVTFPYURoT1ZVYzBlVzF2WjFZNVN6bHpZMncyZFdoV0wybElWMHRvV0ZaemNEUm5kMWh2VjJkVmFWQldNMlZaYUU1SkNtaE5jMlYyT0cxck5WSm9Va0ZtVTJoTGFIQnZOV3RYVkZFNGJHeHZSa0ZOTWpRM013b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9kOGI5YTE5YS1iY2VmLTRjZTAtODQ4OC0wZmU4OGI5MTkyMzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3eHlpYUpzWlNkVDllMnYxTWU5NVZ4S2pNQ2ZTWm9GdGNXS1FmU25kOHpRVVdoYWdacUM2cXpDYw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYaE5ha1Y2VGxSamVVMVdiMWhFVkUxNlRWUkZlRTFxUlhwT1ZHTjVUVlp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRUVlZDa3BVUm1oRGJVcHJjMk5qZUZkSWMycG9ZMk40WW14V05ETmlWVWhCYjFCQlpWQTBTbkJ1VjJOdWVFRkdWR00xTmpjdlJqWjVORTlXVWpobVZqQTFZVU1LWTA4NU9YbHBWSGM1V2xJMGJDOU9XbE55TW5SR00wUk1WRVU1Wm5wWFNURkZhMFZuYTJNMmFWY3JUbUZLT1hVeWVXTldSbFpVTmpGSGMwSmlUbEJqV1FvNWRTdEVZMWtyYnl0YVJtdFljRGhLZVZaNWRGQllOa0o1ZVdSRlNteGlPSEpSV2pOVVFtaHpRV2RuTm0xRWNYVXhUemw2V0hGcVpXSlhiV2cxVVVsMENtWm5PRFJDY0ZKcE1GcElTVkY0VG05SVQyZGhUVTV2Tm1GNVZFUjRWRVkwTTNaalRHeEVUbmRxV0U5R1JXVlJjMGxsUzFWRFZrTmtWMWRMYUVZM1QzVUtaR1JDVjBRMVVHMURiMVYyV1dkWFkxSkdhbGh4U25SVFJUVnZVMGxITlRSTWEwb3pTV2x0UlRsNlltSldjRFJpVVVOQ1ZrSnROVlZOU2tOU1lWQnFXQW94VlhjNGFVcEhiUzl1V0ROWk15dDBOVFF3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpNZFhWSVNqUnRMMHMwSzBSd2VWUnNUbHB0YVhaUE1HaFhkVUpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCTlRob1UzZHRkblZGVVU1M2Exa3hURTFaVFV4R1NqbFlUbGxwSzNZd1JWbHVRbXh2VDJkblZHWjBRbHByZWs1elZBcFVjV1JNUzJoNFkwZENWMkZ2VW00d1VreFdkMWhYTUcxaGNscHNUbFVyVFRKWE9VcFdkRXh0YzA5M00xWXhlWFZXZGpsalJuRlROV05UY0VkNllTdEhDbk5YUjIxTmExcExLM2tyVURoWGJHaHFSME52V25CS2FYRm9NMDFzUTJKYWIweE1NRnBXT1RoT1VIRlJNVkZXY1haUVJsaE5XSGR2WlM5MU5qTndRa0lLUzB0c01YQjBVVWhsT0ROU1NsUlBkbmR6YmpFMU1UWkhkbFp2V0dReVEzQjRia0lyYmxsVWRXeHhka3BEVnpGaGQxaHdNeTl3WlhjMFpYRlBVMWg0VkFwT1dIaE9Rak5TYmtaVUx6WjFZamN4VjNwNWNtTnBiSEZWZEhaMmFpdGhjMEY2VkZKTmFDczRXVzlsWkN0dEwwdHdaMnhQWjJoUVUwcFdhR0U0ZVVVMENuRnZOVFJaVTNwTE0wMUtVVmhvZDJSUVZUVlFia2hDVUVvM1FXZDVXV3BvZUhkU1VRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly84NmQzNWVmMS1iMjZjLTQyYmYtYTJhMy0zZGFiZTYwYWNkZmMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBFMHg5UTJQN1FqeDROa2RqOEZWcER0UXp5Z2VWT0RGY0xDU0hqd05wa3NsTzZleUpDa3JORVI0Sg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2606"
@@ -2472,7 +2604,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:23 GMT
+      - Mon, 13 Nov 2023 14:02:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca482b86-44db-49b7-8593-2f8457a47546
+      - 1ca7d510-a355-4286-8180-56ea6ed44c1b
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,10 +2625,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:19.133861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:28.503679Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "670"
@@ -2505,7 +2637,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:23 GMT
+      - Mon, 13 Nov 2023 14:02:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bc0968b-e979-4378-8b97-40899862ba0a
+      - 32f188f8-f58e-4af8-a8ad-87c98016ccfd
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,10 +2658,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239/nodes?order_by=created_at_asc&page=1&pool_id=4c139d79-c993-4ce6-822d-b4284cd0d713&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc/nodes?order_by=created_at_asc&page=1&pool_id=0be1ccbe-c0d7-402f-b531-fc4b22d828f3&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-10T13:19:39.408229Z","error_message":null,"id":"2a1c9d37-4f9c-47da-98a7-71b7d87da8a1","name":"scw-test-pool-zone-test-pool-zone-2a1c9d374f9c","pool_id":"4c139d79-c993-4ce6-822d-b4284cd0d713","provider_id":"scaleway://instance/fr-par-2/ecc31da0-0b67-4e03-8720-b2b3174087ea","public_ip_v4":"51.159.141.113","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-10T13:22:19.097246Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-13T14:00:10.185268Z","error_message":null,"id":"cfd6ae66-ad01-41c2-bb62-9d88b0e10762","name":"scw-test-pool-zone-test-pool-zone-cfd6ae66ad01","pool_id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","provider_id":"scaleway://instance/fr-par-2/395d556d-d1b6-448e-8c82-145e8c525ae4","public_ip_v4":"51.159.162.176","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-13T14:02:28.488006Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "659"
@@ -2538,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:23 GMT
+      - Mon, 13 Nov 2023 14:02:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d613fc7-e77e-4a08-bde3-c81504615bf4
+      - cc168849-4983-4e1a-ab9c-3aacb51f8a80
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,10 +2691,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:33.138290235Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "676"
@@ -2571,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:24 GMT
+      - Mon, 13 Nov 2023 14:02:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02b6a4e2-cbd0-4d40-a7aa-94a50935042b
+      - 6a96edf4-6d4f-4731-a904-c6bf8bd88bcd
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,10 +2724,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:33.138290Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "673"
@@ -2604,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:24 GMT
+      - Mon, 13 Nov 2023 14:02:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3f47e45-2378-4399-93dc-78447a5ad13b
+      - d5cf15cd-bbb7-44ec-8ab4-bde36b540c11
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,10 +2757,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:33.138290Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "673"
@@ -2637,7 +2769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:29 GMT
+      - Mon, 13 Nov 2023 14:02:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02cbbcbe-69b8-4fe3-bf60-3e38e72e8b4d
+      - 59481df4-1214-4006-bde6-9bba2104e097
     status: 200 OK
     code: 200
     duration: ""
@@ -2658,10 +2790,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:33.138290Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "673"
@@ -2670,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:34 GMT
+      - Mon, 13 Nov 2023 14:02:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2680,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef62daf1-c4b7-4a21-9ebc-9914c8b692ce
+      - 936d91f3-e074-4fbb-8f00-f850e83ea850
     status: 200 OK
     code: 200
     duration: ""
@@ -2691,10 +2823,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","container_runtime":"containerd","created_at":"2023-11-10T13:17:38.737790Z","id":"4c139d79-c993-4ce6-822d-b4284cd0d713","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-10T13:22:24.117858Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","container_runtime":"containerd","created_at":"2023-11-13T13:57:24.974797Z","id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-13T14:02:33.138290Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
       - "673"
@@ -2703,7 +2835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:39 GMT
+      - Mon, 13 Nov 2023 14:02:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2713,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 730ddc3d-3ab5-4e5b-a749-d422b080f7a3
+      - 32a14e41-ea58-4629-b7c8-3743dda5e7a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2724,10 +2856,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"4c139d79-c993-4ce6-822d-b4284cd0d713","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2736,7 +2868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:44 GMT
+      - Mon, 13 Nov 2023 14:02:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2746,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b487edd6-11b7-45b1-8ef4-6c1e62ae9aac
+      - 63a6c544-6c54-4733-be15-7febdc6344c8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2757,10 +2889,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:22:44.519174759Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T14:02:53.430334350Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1497"
@@ -2769,7 +2901,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:44 GMT
+      - Mon, 13 Nov 2023 14:02:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2779,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75395010-3ed3-4395-9f36-6718a9a53678
+      - ff5f84d6-28d6-4775-8d67-8f8f22826e3a
     status: 200 OK
     code: 200
     duration: ""
@@ -2790,10 +2922,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:22:44.519175Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T14:02:53.430334Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -2802,7 +2934,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:44 GMT
+      - Mon, 13 Nov 2023 14:02:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2812,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11c5f21e-62c9-4108-89e9-143e2568c24f
+      - 2f3a6b3b-a7ea-4b15-af96-e1bc33802f42
     status: 200 OK
     code: 200
     duration: ""
@@ -2823,10 +2955,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:22:44.519175Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:19.413457Z","created_at":"2023-11-13T13:57:19.413457Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.86d35ef1-b26c-42bf-a2a3-3dabe60acdfc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-13T14:02:53.430334Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1494"
@@ -2835,7 +2967,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:49 GMT
+      - Mon, 13 Nov 2023 14:02:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2845,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac0b00d7-bd2d-40f6-a358-62a43f228c15
+      - a2f32519-83c5-49aa-8d1d-7301cb92f74c
     status: 200 OK
     code: 200
     duration: ""
@@ -2856,43 +2988,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8b9a19a-bcef-4ce0-8488-0fe88b919239.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:17:32.819189Z","created_at":"2023-11-10T13:17:32.819189Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8b9a19a-bcef-4ce0-8488-0fe88b919239.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-10T13:22:44.519175Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 714643b1-ea81-46df-96e2-d25b027d76db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2901,7 +3000,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:59 GMT
+      - Mon, 13 Nov 2023 14:03:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2911,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d87f05a-77c4-4842-b8e5-3e180ab2836e
+      - 791f3b56-2063-4efb-a981-684956014873
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2922,10 +3021,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a915eb65-d9fa-4dc3-bb29-d36d4aa4b642
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/02cda651-8832-495a-9ba7-d8d97c1b8686
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2934,7 +3033,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:59 GMT
+      - Mon, 13 Nov 2023 14:03:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2944,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56785a80-c38a-498f-b26c-362764993910
+      - 44542c58-8108-4809-ae9c-55f3c32ea062
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2955,76 +3054,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a915eb65-d9fa-4dc3-bb29-d36d4aa4b642
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0be1ccbe-c0d7-402f-b531-fc4b22d828f3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"a915eb65-d9fa-4dc3-bb29-d36d4aa4b642","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d411e1fa-aa3d-41bc-abb0-1a27e09e2ad9
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8b9a19a-bcef-4ce0-8488-0fe88b919239
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d8b9a19a-bcef-4ce0-8488-0fe88b919239","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 360cb8ce-ca31-4ff1-9132-bf4c80dc7d1a
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/4c139d79-c993-4ce6-822d-b4284cd0d713
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"pool","resource_id":"4c139d79-c993-4ce6-822d-b4284cd0d713","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"0be1ccbe-c0d7-402f-b531-fc4b22d828f3","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3033,7 +3066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:59 GMT
+      - Mon, 13 Nov 2023 14:03:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3043,7 +3076,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78401aa4-0868-4499-b095-f1e1d990c853
+      - 9d43bb26-7734-4781-8a5f-992af229aaaf
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/86d35ef1-b26c-42bf-a2a3-3dabe60acdfc
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"86d35ef1-b26c-42bf-a2a3-3dabe60acdfc","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 410203bf-1c99-4c78-9b79-7b668590852e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/02cda651-8832-495a-9ba7-d8d97c1b8686
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"02cda651-8832-495a-9ba7-d8d97c1b8686","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b2eb064-16a6-41e9-825c-606bddb79de5
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 780a9655-6cb8-4920-8019-b0ca95a94a6d
+      - 176686d0-8cc8-459e-9c62-9ce47bccabda
     status: 200 OK
     code: 200
     duration: ""
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:42.388792Z","dhcp_enabled":true,"id":"722a187e-ca86-4bad-95b8-6721702d8672","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:42.388792Z","id":"476fb5a2-f625-4717-a64e-f96edbc43b1c","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:42.388792Z"},{"created_at":"2023-11-13T13:57:42.388792Z","id":"75893f04-a64f-45ea-9ce7-e91f20986997","subnet":"fd63:256c:45f7:553b::/64","updated_at":"2023-11-13T13:57:42.388792Z"}],"tags":[],"updated_at":"2023-11-13T13:57:42.388792Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "719"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81c5d770-f5dd-4bd3-9375-eec2dab663dc
+      - 6b98573f-de98-4c7f-876e-81f2dbdb87e3
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/722a187e-ca86-4bad-95b8-6721702d8672
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:42.388792Z","dhcp_enabled":true,"id":"722a187e-ca86-4bad-95b8-6721702d8672","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:42.388792Z","id":"476fb5a2-f625-4717-a64e-f96edbc43b1c","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:42.388792Z"},{"created_at":"2023-11-13T13:57:42.388792Z","id":"75893f04-a64f-45ea-9ce7-e91f20986997","subnet":"fd63:256c:45f7:553b::/64","updated_at":"2023-11-13T13:57:42.388792Z"}],"tags":[],"updated_at":"2023-11-13T13:57:42.388792Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "719"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 883fdee5-0579-4d21-a88d-dd7c809b05df
+      - 4529851a-3b95-4af5-8608-1a8fc7b307a5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529941827Z","created_at":"2023-11-10T13:16:58.529941827Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.540395017Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124884791Z","created_at":"2023-11-13T13:57:47.124884791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:47.135537721Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1527"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cce046b-1f5b-419d-a98c-6d93356081a9
+      - 55962f98-f921-4369-b39a-2996bb8229c4
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.540395Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:47.135538Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1518"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1599ea4e-0bba-4610-8746-d360387ea35f
+      - 2d37f295-0dc9-45ec-8073-54352ba32d35
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:49.298661Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b331818c-607a-42ee-a677-5ba9ccad9e58
+      - 2db4f2a0-1053-4ace-8392-b1bd4c154a6e
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:49.298661Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 596e9f88-ba1d-45f2-9c6b-c95fe61752d0
+      - 1df377f3-74fa-4b92-ab12-911bca5f0a2d
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbWxUQ201NFVtZFNaMWR6V0VwYVYxVkVabkl5V0VGQ0wzaFZOSE12Wmt4Nk0ySmplbUZKU2pWcU1GWnZORkpNWTFSUVl6bE9jSEJKTURRMVRIUm9RVEJJTkdRS1dYRjNPVkZCVVhSaGJGaHBRMmxCU2pOMlVISmFlVmRKZFVNelZFTjFNalppV1hFNFQyMDNkbkI2TDBwQ2JtWXhRa3MxTURoWWJuWXJhME0xU21SS2R3cDNlRGhCTmxWWFdrZHhTVkpKVEM5b1prUk9jRTkxUTJjMFIzZ3pUemcwTkUwck1qVndVbXhOTkhsVU1HZE5kRTUxVVc1dGRFZHRkR1JQZFZKb1kxaFhDamRHYWxGelZGQkhORU0yVmxsaEx6ZEZTMFk0U1VONU9ITlVTMEV2YzB3NEx6QkpZM05TWmxvNVVrUndZelYxYzJ4QlNEQlRkVXRHY0VoQ1pta3dNMElLUVVOV1RGYzNjMGt2YkU1c2FHcGxVbVZ5YVhRMlJVZGphbVUwTWxWWlkxVjZhbTlwU2xOUGFEUnFiVTB6YlZJNGJrMW1VeTg0Y0cxM1ZtZzJWWHBhTkFwRGNFRjJTWFZDYzJkVGRrcHpNa0pPWVhCalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmFsVlVORVJSWkZsdlltRk9NazFITkROVWMyaHViVTVzWldKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFqbDVWR2hMWmk5NVdrSlBPRzUxYW5KclFsWnliMVpIUTB0SE4xUkdlRzA1YkN0MFR6aFVXamMxT1ZBelUwMDBlQXBvUW5kS2JXc3pVME5QVEZOU1NURjFOSEZYWTBReGJXZEhia0paU1VaeE1HNUpVVTlxTW14Uk9HaFVhMk4zVGtSYWRDOVBNR1J0WTBWR2JteEhMelI2Q2tWM0sxWlhORGxhTlhwdk9HVnBWbk5wV2pWSlVHTkdkSEpMZFM5RGRVcDJlakI0Y2pGV0wwdGpNUzlTYkVabldtZEVaMDFhUWxWdk5uUmpVVkIyVkRJS1lXMDRhalkyVGxSa1oyeGhUemhQYzAxSlZWbEVNRU5pUkhwbU9WaE1TWEV6WWt4WlNWaHdURFJ6VlRCeWJqWllPRVl4ZEV4NE9XWmFaVkU1YVdzNVdncFRialpKZEcxbFdWZDFSM0UyVVhCRU56ZDZaMUZITjJSWmRrSTNPWFI2V0VSU1RXTm5UemRYVjAxMk1FcHFVSEl6YkVObGJUVmtNR3hHZDBac1RWTnpDa2hCTUZVclVHSnhkRXhtVms5R01ISlZRbGRhTHpWblRtaDJiemx0TjNWdWJGRkNOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDhkOGZjMmYtOGM2Yi00ZGYxLThlYWEtYTRiYTFlNjY3ODRlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1YThHakthbk9QUlhoOUhNamdmMm9xYUVOb0RRa252dHZzclZoYjNrRXdvTFVEdmFpbm54VUxKYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUmpNRTlHYjFoRVZFMTZUVlJGZUUxcVJYcE9WR013VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM0JIQ2xOWVYzTm1Wak5TU3pSdk5XVjBkRWhoYlhreVRtaFBUVVJ2VEhWcWNpOUVTV1pvWlRWS2NFSnVRVUZFZDBaS2FHVjBWVzlaWWtZME56UkNZV3N3WVdNS1dtMUtjbTk1ZEhSbk1raElTRzl0UlZGNFdsRnlkWGR5VFZWWlZFTlZVbGhVWlN0TVJuTldiMUpzVGt4cGNXRlRlaXRVYzFSaGJtZ3paMHRUSzBReGJncHlSMjVNTW5CYU9EaENOVkFyUzBGVVRFZElSbVpsV1VSUlNYRXJUMEZXYkdGV1pHMXNNMVp2U0cxU0wxUktjbko1VjNaemQyMTNUSFIxUmtaVlUxTjFDa3c0Vm01M2MxSnlTbTFGTldKMk9IcDFNSFJNWnpBd0sxazViMDg0VXpZMk5XcHhTMjVtVDJwdGNrVlBTMW93WWxKRmVsQnRVemx6VTBKMk5XTkZXVXNLTlZrMU5GSm1abk0xY2xaRUwxWlpWR3B3Vm1jMFZscDVjRXBxWVRFMU4yVXdMelZaY2pCMFVUVk1TRFYxWmtWcVoxVXJjMDhyYjNOSFIwZFpSRXRYYUFwR2VpdDZTelkyZGxZME1IRmtRVUZRT1hwelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaR1VGQjJlVmh5TmpOS01teHVUWEJLT1ZKR2QwWnZVSGRaVWpSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZUQmtiMGxUVnpGc01YaEVTbEZuTlV3MmNUZ3lkM0J5UkhSR1ZGQnVOVEp6ZEV4c2EySTVXVmczWW5WU2JsaEhhQW93WkV0eldVdElLMUV6Y25seU9YY3phamxRY0hCT2RXTndhR05NUmt0SWVVTjFXRU13YUcxd05tNUJkRE5RWXpoU1lWaG5VRUprVTFKRFNWVnhUekpKQ205aWMwcHlVV05NSzBrdlZ6RmtOMlJsZUVkTmRGUjZLMUV6T0hZNWRrTjJVMnBzTDJsRWVGcGtMME5WUzNSUlkyUm1Na0k1WVZOS2JYWTBNRVo1WkhZS2R6TnVTMHBMUVU1cE1VSTJRa1pQUWpCVldVNXhaRGhPSzNKcVNHeEplbFJxYkhWb1lrdFFZa3RaTDAxd2JXSmpVMlJMZVhjMk5uTkdMM1JKU21oVlRRcElaMHBqUW1kVk0zZ3libWhZYkVvM2Jsa3pXbmxXUzJSQ1Mwa3hWMGRvYkZSWUwzRnhXV05sWW1KQlFrSklUM2w1V21wcmFHdEZXRFYwWVRSNmVXMHJDblJIYTFSR2JFaDJPV2g2Wm1WS2EybElkVEJuY1V0WmNYaEdabGhzV1dSVVdGcDFNZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWZiMTRiZWQtZTIyZC00Njk2LWIyYzctN2IzOGJiZmNiYzQ5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYWnhua0FyeHVPODdsU2RCNGw4NHhEdFNsZWZhWVFLaDdPc2o1bjBiN3padFpWZ05OaERQdWNxcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e5777fd-7c52-4b92-9ddc-6a29e8e8a924
+      - 0d90e4e7-de05-481e-8e0a-ae2518085961
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:49.298661Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaf6fc58-2758-451c-9c57-8534aeec09e5
+      - 487d3a65-6c81-413d-b4a4-1922f15a03a2
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/722a187e-ca86-4bad-95b8-6721702d8672
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:42.388792Z","dhcp_enabled":true,"id":"722a187e-ca86-4bad-95b8-6721702d8672","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:42.388792Z","id":"476fb5a2-f625-4717-a64e-f96edbc43b1c","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:42.388792Z"},{"created_at":"2023-11-13T13:57:42.388792Z","id":"75893f04-a64f-45ea-9ce7-e91f20986997","subnet":"fd63:256c:45f7:553b::/64","updated_at":"2023-11-13T13:57:42.388792Z"}],"tags":[],"updated_at":"2023-11-13T13:57:42.388792Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "719"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14eff6ac-657c-4950-989f-d424fd73b2ae
+      - 6f5db680-8948-403e-b9de-f8c6bb968fdc
     status: 200 OK
     code: 200
     duration: ""
@@ -346,76 +346,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1523"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64a36b8b-03b6-41ba-b79c-f5cb4f388036
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "719"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b0c8a90c-471c-4d98-81b6-41391136db58
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:49.298661Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -424,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:57:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74eb5508-5a98-46fb-a3a5-a52f6c80a95a
+      - f358f2f2-c462-40e3-b4fe-47122903588d
     status: 200 OK
     code: 200
     duration: ""
@@ -445,10 +379,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e/kubeconfig
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/722a187e-ca86-4bad-95b8-6721702d8672
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbWxUQ201NFVtZFNaMWR6V0VwYVYxVkVabkl5V0VGQ0wzaFZOSE12Wmt4Nk0ySmplbUZKU2pWcU1GWnZORkpNWTFSUVl6bE9jSEJKTURRMVRIUm9RVEJJTkdRS1dYRjNPVkZCVVhSaGJGaHBRMmxCU2pOMlVISmFlVmRKZFVNelZFTjFNalppV1hFNFQyMDNkbkI2TDBwQ2JtWXhRa3MxTURoWWJuWXJhME0xU21SS2R3cDNlRGhCTmxWWFdrZHhTVkpKVEM5b1prUk9jRTkxUTJjMFIzZ3pUemcwTkUwck1qVndVbXhOTkhsVU1HZE5kRTUxVVc1dGRFZHRkR1JQZFZKb1kxaFhDamRHYWxGelZGQkhORU0yVmxsaEx6ZEZTMFk0U1VONU9ITlVTMEV2YzB3NEx6QkpZM05TWmxvNVVrUndZelYxYzJ4QlNEQlRkVXRHY0VoQ1pta3dNMElLUVVOV1RGYzNjMGt2YkU1c2FHcGxVbVZ5YVhRMlJVZGphbVUwTWxWWlkxVjZhbTlwU2xOUGFEUnFiVTB6YlZJNGJrMW1VeTg0Y0cxM1ZtZzJWWHBhTkFwRGNFRjJTWFZDYzJkVGRrcHpNa0pPWVhCalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmFsVlVORVJSWkZsdlltRk9NazFITkROVWMyaHViVTVzWldKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFqbDVWR2hMWmk5NVdrSlBPRzUxYW5KclFsWnliMVpIUTB0SE4xUkdlRzA1YkN0MFR6aFVXamMxT1ZBelUwMDBlQXBvUW5kS2JXc3pVME5QVEZOU1NURjFOSEZYWTBReGJXZEhia0paU1VaeE1HNUpVVTlxTW14Uk9HaFVhMk4zVGtSYWRDOVBNR1J0WTBWR2JteEhMelI2Q2tWM0sxWlhORGxhTlhwdk9HVnBWbk5wV2pWSlVHTkdkSEpMZFM5RGRVcDJlakI0Y2pGV0wwdGpNUzlTYkVabldtZEVaMDFhUWxWdk5uUmpVVkIyVkRJS1lXMDRhalkyVGxSa1oyeGhUemhQYzAxSlZWbEVNRU5pUkhwbU9WaE1TWEV6WWt4WlNWaHdURFJ6VlRCeWJqWllPRVl4ZEV4NE9XWmFaVkU1YVdzNVdncFRialpKZEcxbFdWZDFSM0UyVVhCRU56ZDZaMUZITjJSWmRrSTNPWFI2V0VSU1RXTm5UemRYVjAxMk1FcHFVSEl6YkVObGJUVmtNR3hHZDBac1RWTnpDa2hCTUZVclVHSnhkRXhtVms5R01ISlZRbGRhTHpWblRtaDJiemx0TjNWdWJGRkNOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDhkOGZjMmYtOGM2Yi00ZGYxLThlYWEtYTRiYTFlNjY3ODRlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1YThHakthbk9QUlhoOUhNamdmMm9xYUVOb0RRa252dHZzclZoYjNrRXdvTFVEdmFpbm54VUxKYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"created_at":"2023-11-13T13:57:42.388792Z","dhcp_enabled":true,"id":"722a187e-ca86-4bad-95b8-6721702d8672","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:42.388792Z","id":"476fb5a2-f625-4717-a64e-f96edbc43b1c","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:42.388792Z"},{"created_at":"2023-11-13T13:57:42.388792Z","id":"75893f04-a64f-45ea-9ce7-e91f20986997","subnet":"fd63:256c:45f7:553b::/64","updated_at":"2023-11-13T13:57:42.388792Z"}],"tags":[],"updated_at":"2023-11-13T13:57:42.388792Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "720"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6af94bba-03af-433d-9e22-b5a826c4b3b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:49.298661Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1523"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:57:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e5f0f6f2-249d-419f-861f-c2182eec9dbc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUmpNRTlHYjFoRVZFMTZUVlJGZUUxcVJYcE9WR013VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM0JIQ2xOWVYzTm1Wak5TU3pSdk5XVjBkRWhoYlhreVRtaFBUVVJ2VEhWcWNpOUVTV1pvWlRWS2NFSnVRVUZFZDBaS2FHVjBWVzlaWWtZME56UkNZV3N3WVdNS1dtMUtjbTk1ZEhSbk1raElTRzl0UlZGNFdsRnlkWGR5VFZWWlZFTlZVbGhVWlN0TVJuTldiMUpzVGt4cGNXRlRlaXRVYzFSaGJtZ3paMHRUSzBReGJncHlSMjVNTW5CYU9EaENOVkFyUzBGVVRFZElSbVpsV1VSUlNYRXJUMEZXYkdGV1pHMXNNMVp2U0cxU0wxUktjbko1VjNaemQyMTNUSFIxUmtaVlUxTjFDa3c0Vm01M2MxSnlTbTFGTldKMk9IcDFNSFJNWnpBd0sxazViMDg0VXpZMk5XcHhTMjVtVDJwdGNrVlBTMW93WWxKRmVsQnRVemx6VTBKMk5XTkZXVXNLTlZrMU5GSm1abk0xY2xaRUwxWlpWR3B3Vm1jMFZscDVjRXBxWVRFMU4yVXdMelZaY2pCMFVUVk1TRFYxWmtWcVoxVXJjMDhyYjNOSFIwZFpSRXRYYUFwR2VpdDZTelkyZGxZME1IRmtRVUZRT1hwelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaR1VGQjJlVmh5TmpOS01teHVUWEJLT1ZKR2QwWnZVSGRaVWpSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZUQmtiMGxUVnpGc01YaEVTbEZuTlV3MmNUZ3lkM0J5UkhSR1ZGQnVOVEp6ZEV4c2EySTVXVmczWW5WU2JsaEhhQW93WkV0eldVdElLMUV6Y25seU9YY3phamxRY0hCT2RXTndhR05NUmt0SWVVTjFXRU13YUcxd05tNUJkRE5RWXpoU1lWaG5VRUprVTFKRFNWVnhUekpKQ205aWMwcHlVV05NSzBrdlZ6RmtOMlJsZUVkTmRGUjZLMUV6T0hZNWRrTjJVMnBzTDJsRWVGcGtMME5WUzNSUlkyUm1Na0k1WVZOS2JYWTBNRVo1WkhZS2R6TnVTMHBMUVU1cE1VSTJRa1pQUWpCVldVNXhaRGhPSzNKcVNHeEplbFJxYkhWb1lrdFFZa3RaTDAxd2JXSmpVMlJMZVhjMk5uTkdMM1JKU21oVlRRcElaMHBqUW1kVk0zZ3libWhZYkVvM2Jsa3pXbmxXUzJSQ1Mwa3hWMGRvYkZSWUwzRnhXV05sWW1KQlFrSklUM2w1V21wcmFHdEZXRFYwWVRSNmVXMHJDblJIYTFSR2JFaDJPV2g2Wm1WS2EybElkVEJuY1V0WmNYaEdabGhzV1dSVVdGcDFNZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWZiMTRiZWQtZTIyZC00Njk2LWIyYzctN2IzOGJiZmNiYzQ5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYWnhua0FyeHVPODdsU2RCNGw4NHhEdFNsZWZhWVFLaDdPc2o1bjBiN3padFpWZ05OaERQdWNxcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -457,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5f8d0eb-e5cf-475d-a241-199aa443700f
+      - 69576e98-bce1-476c-b9c0-4ec89d9a8a81
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/722a187e-ca86-4bad-95b8-6721702d8672
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:42.388792Z","dhcp_enabled":true,"id":"722a187e-ca86-4bad-95b8-6721702d8672","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:42.388792Z","id":"476fb5a2-f625-4717-a64e-f96edbc43b1c","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:42.388792Z"},{"created_at":"2023-11-13T13:57:42.388792Z","id":"75893f04-a64f-45ea-9ce7-e91f20986997","subnet":"fd63:256c:45f7:553b::/64","updated_at":"2023-11-13T13:57:42.388792Z"}],"tags":[],"updated_at":"2023-11-13T13:57:42.388792Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "719"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de8771bb-b480-4f20-b100-59c0ebcbfbaa
+      - f663a8fe-bec2-4b50-9ac7-0bd0b2626fc8
     status: 200 OK
     code: 200
     duration: ""
@@ -511,10 +511,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.336673Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:49.298661Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -523,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:57:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -533,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1455d96-8331-44c5-8b3f-ec6f5fe74689
+      - d6897531-0d69-48dc-9b30-462446e08ae9
     status: 200 OK
     code: 200
     duration: ""
@@ -544,10 +544,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUlpNVTlXYjFoRVZFMTZUVlJGZDA5VVJYcE5WRmt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbWxUQ201NFVtZFNaMWR6V0VwYVYxVkVabkl5V0VGQ0wzaFZOSE12Wmt4Nk0ySmplbUZKU2pWcU1GWnZORkpNWTFSUVl6bE9jSEJKTURRMVRIUm9RVEJJTkdRS1dYRjNPVkZCVVhSaGJGaHBRMmxCU2pOMlVISmFlVmRKZFVNelZFTjFNalppV1hFNFQyMDNkbkI2TDBwQ2JtWXhRa3MxTURoWWJuWXJhME0xU21SS2R3cDNlRGhCTmxWWFdrZHhTVkpKVEM5b1prUk9jRTkxUTJjMFIzZ3pUemcwTkUwck1qVndVbXhOTkhsVU1HZE5kRTUxVVc1dGRFZHRkR1JQZFZKb1kxaFhDamRHYWxGelZGQkhORU0yVmxsaEx6ZEZTMFk0U1VONU9ITlVTMEV2YzB3NEx6QkpZM05TWmxvNVVrUndZelYxYzJ4QlNEQlRkVXRHY0VoQ1pta3dNMElLUVVOV1RGYzNjMGt2YkU1c2FHcGxVbVZ5YVhRMlJVZGphbVUwTWxWWlkxVjZhbTlwU2xOUGFEUnFiVTB6YlZJNGJrMW1VeTg0Y0cxM1ZtZzJWWHBhTkFwRGNFRjJTWFZDYzJkVGRrcHpNa0pPWVhCalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmFsVlVORVJSWkZsdlltRk9NazFITkROVWMyaHViVTVzWldKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFqbDVWR2hMWmk5NVdrSlBPRzUxYW5KclFsWnliMVpIUTB0SE4xUkdlRzA1YkN0MFR6aFVXamMxT1ZBelUwMDBlQXBvUW5kS2JXc3pVME5QVEZOU1NURjFOSEZYWTBReGJXZEhia0paU1VaeE1HNUpVVTlxTW14Uk9HaFVhMk4zVGtSYWRDOVBNR1J0WTBWR2JteEhMelI2Q2tWM0sxWlhORGxhTlhwdk9HVnBWbk5wV2pWSlVHTkdkSEpMZFM5RGRVcDJlakI0Y2pGV0wwdGpNUzlTYkVabldtZEVaMDFhUWxWdk5uUmpVVkIyVkRJS1lXMDRhalkyVGxSa1oyeGhUemhQYzAxSlZWbEVNRU5pUkhwbU9WaE1TWEV6WWt4WlNWaHdURFJ6VlRCeWJqWllPRVl4ZEV4NE9XWmFaVkU1YVdzNVdncFRialpKZEcxbFdWZDFSM0UyVVhCRU56ZDZaMUZITjJSWmRrSTNPWFI2V0VSU1RXTm5UemRYVjAxMk1FcHFVSEl6YkVObGJUVmtNR3hHZDBac1RWTnpDa2hCTUZVclVHSnhkRXhtVms5R01ISlZRbGRhTHpWblRtaDJiemx0TjNWdWJGRkNOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDhkOGZjMmYtOGM2Yi00ZGYxLThlYWEtYTRiYTFlNjY3ODRlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1YThHakthbk9QUlhoOUhNamdmMm9xYUVOb0RRa252dHZzclZoYjNrRXdvTFVEdmFpbm54VUxKYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUmpNRTlHYjFoRVZFMTZUVlJGZUUxcVJYcE9WR013VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM0JIQ2xOWVYzTm1Wak5TU3pSdk5XVjBkRWhoYlhreVRtaFBUVVJ2VEhWcWNpOUVTV1pvWlRWS2NFSnVRVUZFZDBaS2FHVjBWVzlaWWtZME56UkNZV3N3WVdNS1dtMUtjbTk1ZEhSbk1raElTRzl0UlZGNFdsRnlkWGR5VFZWWlZFTlZVbGhVWlN0TVJuTldiMUpzVGt4cGNXRlRlaXRVYzFSaGJtZ3paMHRUSzBReGJncHlSMjVNTW5CYU9EaENOVkFyUzBGVVRFZElSbVpsV1VSUlNYRXJUMEZXYkdGV1pHMXNNMVp2U0cxU0wxUktjbko1VjNaemQyMTNUSFIxUmtaVlUxTjFDa3c0Vm01M2MxSnlTbTFGTldKMk9IcDFNSFJNWnpBd0sxazViMDg0VXpZMk5XcHhTMjVtVDJwdGNrVlBTMW93WWxKRmVsQnRVemx6VTBKMk5XTkZXVXNLTlZrMU5GSm1abk0xY2xaRUwxWlpWR3B3Vm1jMFZscDVjRXBxWVRFMU4yVXdMelZaY2pCMFVUVk1TRFYxWmtWcVoxVXJjMDhyYjNOSFIwZFpSRXRYYUFwR2VpdDZTelkyZGxZME1IRmtRVUZRT1hwelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaR1VGQjJlVmh5TmpOS01teHVUWEJLT1ZKR2QwWnZVSGRaVWpSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFZUQmtiMGxUVnpGc01YaEVTbEZuTlV3MmNUZ3lkM0J5UkhSR1ZGQnVOVEp6ZEV4c2EySTVXVmczWW5WU2JsaEhhQW93WkV0eldVdElLMUV6Y25seU9YY3phamxRY0hCT2RXTndhR05NUmt0SWVVTjFXRU13YUcxd05tNUJkRE5RWXpoU1lWaG5VRUprVTFKRFNWVnhUekpKQ205aWMwcHlVV05NSzBrdlZ6RmtOMlJsZUVkTmRGUjZLMUV6T0hZNWRrTjJVMnBzTDJsRWVGcGtMME5WUzNSUlkyUm1Na0k1WVZOS2JYWTBNRVo1WkhZS2R6TnVTMHBMUVU1cE1VSTJRa1pQUWpCVldVNXhaRGhPSzNKcVNHeEplbFJxYkhWb1lrdFFZa3RaTDAxd2JXSmpVMlJMZVhjMk5uTkdMM1JKU21oVlRRcElaMHBqUW1kVk0zZ3libWhZYkVvM2Jsa3pXbmxXUzJSQ1Mwa3hWMGRvYkZSWUwzRnhXV05sWW1KQlFrSklUM2w1V21wcmFHdEZXRFYwWVRSNmVXMHJDblJIYTFSR2JFaDJPV2g2Wm1WS2EybElkVEJuY1V0WmNYaEdabGhzV1dSVVdGcDFNZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWZiMTRiZWQtZTIyZC00Njk2LWIyYzctN2IzOGJiZmNiYzQ5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBYWnhua0FyeHVPODdsU2RCNGw4NHhEdFNsZWZhWVFLaDdPc2o1bjBiN3padFpWZ05OaERQdWNxcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -556,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:57:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -566,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fc5b8fa-c80c-493f-bb11-023c75cca2ab
+      - ff9a576c-6259-401c-98f2-8ba491842fe6
     status: 200 OK
     code: 200
     duration: ""
@@ -577,10 +577,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.178237886Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:58.941572571Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -589,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:57:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -599,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 334eb357-caf7-4325-9513-8c4bacc86539
+      - a7155e33-4ddb-43c3-8f5f-9b08d683a011
     status: 200 OK
     code: 200
     duration: ""
@@ -610,10 +610,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:16:58.529942Z","created_at":"2023-11-10T13:16:58.529942Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:06.178238Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://efb14bed-e22d-4696-b2c7-7b38bbfcbc49.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:57:47.124885Z","created_at":"2023-11-13T13:57:47.124885Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.efb14bed-e22d-4696-b2c7-7b38bbfcbc49.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"722a187e-ca86-4bad-95b8-6721702d8672","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:57:58.941573Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1518"
@@ -622,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:57:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -632,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb0c69b4-e125-446e-b860-5e762e83f061
+      - 0091257f-4f50-4264-a6f2-c8f53c43be2e
     status: 200 OK
     code: 200
     duration: ""
@@ -643,10 +643,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/efb14bed-e22d-4696-b2c7-7b38bbfcbc49
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d8d8fc2f-8c6b-4df1-8eaa-a4ba1e66784e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"efb14bed-e22d-4696-b2c7-7b38bbfcbc49","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -655,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:58:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -665,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94cb9e1b-9e33-4206-beda-22692384a083
+      - 9edf0573-644d-4d64-bd24-7c7649447293
     status: 404 Not Found
     code: 404
     duration: ""
@@ -681,7 +681,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:17:11.355771Z","dhcp_enabled":true,"id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:11.355771Z","id":"39ca8674-4e5d-4182-94f6-fec62de626f4","subnet":"172.16.56.0/22","updated_at":"2023-11-10T13:17:11.355771Z"},{"created_at":"2023-11-10T13:17:11.355771Z","id":"e1ecaf7a-05bc-44f2-a4f3-68bdc104d77f","subnet":"fd63:256c:45f7:2b8e::/64","updated_at":"2023-11-10T13:17:11.355771Z"}],"tags":[],"updated_at":"2023-11-10T13:17:11.355771Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:58:04.478063Z","dhcp_enabled":true,"id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:58:04.478063Z","id":"cd178612-c9d7-4e8e-a510-e11abe61d591","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:58:04.478063Z"},{"created_at":"2023-11-13T13:58:04.478063Z","id":"a3d07c6e-a0ca-4dab-b21c-5477941bbf38","subnet":"fd63:256c:45f7:dfd5::/64","updated_at":"2023-11-13T13:58:04.478063Z"}],"tags":[],"updated_at":"2023-11-13T13:58:04.478063Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:13 GMT
+      - Mon, 13 Nov 2023 13:58:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4fc6c4a-daa1-42a7-80c0-d555f9853de5
+      - a05be7b9-49a0-457e-9c1d-252305f80539
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c45f90a-c5a8-47e5-8856-e18c85bb870d
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:11.355771Z","dhcp_enabled":true,"id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:11.355771Z","id":"39ca8674-4e5d-4182-94f6-fec62de626f4","subnet":"172.16.56.0/22","updated_at":"2023-11-10T13:17:11.355771Z"},{"created_at":"2023-11-10T13:17:11.355771Z","id":"e1ecaf7a-05bc-44f2-a4f3-68bdc104d77f","subnet":"fd63:256c:45f7:2b8e::/64","updated_at":"2023-11-10T13:17:11.355771Z"}],"tags":[],"updated_at":"2023-11-10T13:17:11.355771Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:58:04.478063Z","dhcp_enabled":true,"id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:58:04.478063Z","id":"cd178612-c9d7-4e8e-a510-e11abe61d591","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:58:04.478063Z"},{"created_at":"2023-11-13T13:58:04.478063Z","id":"a3d07c6e-a0ca-4dab-b21c-5477941bbf38","subnet":"fd63:256c:45f7:dfd5::/64","updated_at":"2023-11-13T13:58:04.478063Z"}],"tags":[],"updated_at":"2023-11-13T13:58:04.478063Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:13 GMT
+      - Mon, 13 Nov 2023 13:58:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,12 +733,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aa0bf4d-a088-4f47-908c-f4bd8c0fb886
+      - 41388831-2bda-4c3d-ae48-b58155638598
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d"}'
     form: {}
     headers:
       Content-Type:
@@ -749,7 +749,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302129Z","created_at":"2023-11-10T13:17:13.891302129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.092792908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823947874Z","created_at":"2023-11-13T13:58:09.823947874Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:09.834238736Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1527"
@@ -758,7 +758,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:14 GMT
+      - Mon, 13 Nov 2023 13:58:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebf08ca9-e1f6-4b61-b064-50472d65b00b
+      - 3c296ab8-5c75-4fb8-aeaf-a4524434a8fd
     status: 200 OK
     code: 200
     duration: ""
@@ -779,10 +779,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:14.092793Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:09.834239Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1518"
@@ -791,7 +791,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:14 GMT
+      - Mon, 13 Nov 2023 13:58:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,7 +801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d27e271-b273-417d-a092-3d1a09e05b04
+      - b65dfbdd-9b39-4bfe-a218-3bad6ebd8c12
     status: 200 OK
     code: 200
     duration: ""
@@ -812,10 +812,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:12.405943Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -824,7 +824,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -834,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c13b3f72-976e-4bde-89f3-153a39af9277
+      - 0a5d3080-d39f-4ce0-a9c9-037479a9cefc
     status: 200 OK
     code: 200
     duration: ""
@@ -845,10 +845,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:12.405943Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -857,7 +857,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 573f4013-1d61-4ce9-b20b-5ead93672764
+      - 687f22f0-dc0d-4f15-b5b9-91bbbd229df0
     status: 200 OK
     code: 200
     duration: ""
@@ -878,10 +878,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmplRTR4YjFoRVZFMTZUVlJGZDA5VVJYcE5WR040VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWEkxQ2preGJVUldiSE5TUjFkQkwwOUhkemwxT0ZaTVptcERhekpTV1ZBNFNVOWFObWx1YUhRMVFUZGhaWEpsWm10VlZTdDNjbnBTUTBsNk1VUlRjRFI1V0VrS1ptVkZNbFV3TURadmJHMUlOVzV0U0V0TVYyaE1OWGRsVUZGSFZIZG9jWHB3VFRneFZuTlZNbUp2VEZoaGNHcFBSR0pCTkd4MllWcHNPQzk1TW1SNGR3cFFPWEJ5ZGxaWGJFNWlOM0pHVmpCck1YRlZaWEl3T1N0RWNtdGpOWE5hWm1WUU1tdEdSbWRUYzJaTllsaHRTVTVTTldWcWExZElPWGw2VkRRellqTlhDbVpIVjJ4a1JVWllNMWRUYVUxaWNWa3dVekU1WTJaUlJFVkRMM0ZHWmxscVYwZEthbmwxVFdObU5XWmFNMmQwWmtka2FGbEJkVWhsVVZseVF6ZzBXbkFLWWsxaU5UbDNRVXRHZWxGeVZEbE5NbVJyUVRGYWFtOW1SRU5WWTJSc2VGbDJkekF5TDNCWVkxVTRWRWxwUjBWeldYQkRlbFp4SzBsa1Z6bDZPVGRpV2dweGFERktTRzVOT0dRdlIwRllTMWx4UkRVNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNqVjNWMEUwU0hWM1dEZGpWVXRQWVhabWFXMTJWMGR5TTA1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFXcFVORFJ3ZWxwdU5WcExOVlZ0YkRONlptdHBkR0ZuVkhseldFbHJXVEZpZVU5b1lYcGFNRWh0WjNGa04yUnpaUXAzVm1FclUwdEVWbnB3Ym1sTWNHRmhVM0pUYnpaeGVUazRXVEppYkVWTGN6WkRSWEpJYzJRME1XNHZRbVE1Y1RaSmRrMWhZbWhhYm1SMVEwWXdjREJQQ2t4NlIwSndRWFUzTldKckswZG9RVWhvTWpNdmRrOUJaa1VyTldoNVFqbDBZMlJ5VTJOS2RFTkJURmh2VW1VM2EyWTRZVzB5ZURGbVFXTTFMMmd4U204S2RsaE5jMVpQTmtGdVUyZEpVRGRSY25kU2FHMUlhVkYwWW1KdFJYbDZSMlZsZFVSWldYaEVSMU5RWkRaME9HOWlORzFrZFd0YVVXdEhNbEJhY0ZsT053cEdWRXBGUWpOTmNVcEZkR3BLV2poWVNVWkxibUUxVW5nMlFWWnBUV0ZLZVdoeFVqTktVblpCSzB3eGFXZ3hiM0l2UkRaUk9GTjNWRzlyZDI0MFUwWXhDbmxuYVVsUmNrRnBVV1J3YmtKRFZsUTVTWFYzUlZOb2VYSm1VelZqVEdGd1VWTjJOUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjllZDk3YzMtZjM3MS00NmM0LTk3YjUtZjkxNjQ2ZDNkZjhkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPeWRjaDdoNzFweExGTERuZnl0V2pLU2hDOW1hVWZabHhjSEJJOWRVMFFaY1ZkQ0RyajJzRk9zcw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUm5lRTFzYjFoRVZFMTZUVlJGZUUxcVJYcE9WR2Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV1EzQ21kR1N6SXdiMWRoVDFreFZIbDFPVTgxTHl0R1QwZHBSbHAxY1RWVU1VcExibWhuTjNJek4xVkxSMkZST1dGUWMwTnZXVkZvUVRCaFFWSm5RVVp0VXpVS2QyWmFXa3A2YkZRNVNDdDNXbFJUWnpGV1kyNWllSFZRZVZJMlFXdFBZamt2YkhSek1FeGFSRVozTlZvd2RWcEZNMVY1UmtWbGVWQkhWazh5T1dJMFN3cDBLMmhXTDNnM2RWaEhhMmh3Tlc5NFFsVktVRVJ4TjNOYU0yUm1iRkF5S3paVVptRk5TWFpuU21SVGNHMXZhMlpQYjBGbFdHUTJkR0pPSzFKNlpUVnlDazR5UjNJelNraFpjVTF6VjBzMWJVSlBiMUI0Y0VkTVEzbHJkamxZVkVsbGQzRldaVzlQV2xVNVdrVnVUMUZ4UXpKU01qTmxjVVJKVW5oa1YxWnNTMmdLWjI0emNWTmtSV3huYWtSR1JuaDZZMFJHTTNNMVExWnNWMnRNVDFGaVVtb3lTMGsxTUhWa1RpdFFTWFZwV205RVYzQkRWVzlCVkVzd1NURkRZVlpWTWdwb05pOXVlbEl3ZGpSclRsUk1jR2hUZWpSalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1VtdEtPRnBoY0hKU2VIcGFjVGxPVkRjM1JtNHlhbk5oY0dsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1UyTnFLekZhTVUxVlVIQlJaSEJ4VlZKQlRFRlhOVlozV21ObVJIcFlhMU5zTVROeGFYVjJRbXc0T1RsNlUwOTZNQXBEWjBjclFtcHVabXAxZVVaa2RFdDVjRFEzWVhwRldqRnFSRlp1VWtZdk9GRkxRbFl5VFZka2NraFFTMUZyZGtGd01uTlpORTR3U0dRNWVsRlZaMVJuQ210NlRHNVFZVVJwZEV0Qk5WVktTMFJNVjBnMk5HOUljM2xRWnpscE4waHdTbWxRTUUxcldVNDNWVzFpWVZOTU9YQlNOa2M1ZVhwRVNGTlJiR3hJSzNJS1JqTnRhbFJQU1dWRVdsQjVZeXRHYzNaV2JrRkNUR05pVm10cmEwUkJiSHB1YzFCd1dEQjBWVE5PVm5WTFQzcGFNbE5KTDBGalFraHhNbmd6TW1ONEt3cENTVVJSVVZGNVZXOUNOMDEzUTJocVEwWmtUazFPWkhGc2FIUlFSVEVyUWl0TVowOUhSMWxXYTFWSFdFb3pkM1JEYTNwb2NVcFVUVEZTTlhOSFRGbFZDa05XUmxOclFuZHFhVEZ6Vm1vek56Wk9aMUpzU0cxTWJsbDFPRkZvYkRrelkwWjBTZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDNhNGVlYWUtYmZkZC00NjNkLWE3YWUtZDE2MjY5NTA5NjVlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5bmNUVndzVjJKZDE3b3Z5OUZxNlowTnlITGhDckFlNUZLbUhkVng2dzc2Q00yWTBqSlR5bGd0WA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -890,7 +890,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -900,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d8b1770-fa7f-41cf-9711-0716fcfb86b7
+      - 9052d983-62cc-400a-a93c-367ecedd2812
     status: 200 OK
     code: 200
     duration: ""
@@ -911,10 +911,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:12.405943Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -923,7 +923,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88b0ab49-f4f2-4d4d-b53c-df90776ba9a5
+      - e3542439-090f-446b-a5bb-d0b5160c3f6d
     status: 200 OK
     code: 200
     duration: ""
@@ -944,19 +944,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/722a187e-ca86-4bad-95b8-6721702d8672
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:42.388792Z","dhcp_enabled":true,"id":"722a187e-ca86-4bad-95b8-6721702d8672","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:42.388792Z","id":"476fb5a2-f625-4717-a64e-f96edbc43b1c","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:42.388792Z"},{"created_at":"2023-11-13T13:57:42.388792Z","id":"75893f04-a64f-45ea-9ce7-e91f20986997","subnet":"fd63:256c:45f7:553b::/64","updated_at":"2023-11-13T13:57:42.388792Z"}],"tags":[],"updated_at":"2023-11-13T13:57:42.388792Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "719"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -966,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e56220d-2d35-436e-a245-52bd31b50988
+      - 82e3f441-876a-4bff-bc6e-97b85a14bb55
     status: 200 OK
     code: 200
     duration: ""
@@ -977,10 +977,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c45f90a-c5a8-47e5-8856-e18c85bb870d
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:11.355771Z","dhcp_enabled":true,"id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:11.355771Z","id":"39ca8674-4e5d-4182-94f6-fec62de626f4","subnet":"172.16.56.0/22","updated_at":"2023-11-10T13:17:11.355771Z"},{"created_at":"2023-11-10T13:17:11.355771Z","id":"e1ecaf7a-05bc-44f2-a4f3-68bdc104d77f","subnet":"fd63:256c:45f7:2b8e::/64","updated_at":"2023-11-10T13:17:11.355771Z"}],"tags":[],"updated_at":"2023-11-10T13:17:11.355771Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:58:04.478063Z","dhcp_enabled":true,"id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:58:04.478063Z","id":"cd178612-c9d7-4e8e-a510-e11abe61d591","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:58:04.478063Z"},{"created_at":"2023-11-13T13:58:04.478063Z","id":"a3d07c6e-a0ca-4dab-b21c-5477941bbf38","subnet":"fd63:256c:45f7:dfd5::/64","updated_at":"2023-11-13T13:58:04.478063Z"}],"tags":[],"updated_at":"2023-11-13T13:58:04.478063Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -989,7 +989,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -999,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab467d2d-7680-426a-a5ca-5f50b6a2b0d9
+      - 8f2d0ec2-99bd-495d-a78f-c62cb65ef7ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1010,10 +1010,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:12.405943Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -1022,7 +1022,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:20 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1032,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18cab11e-9416-4038-8ef2-b79f1097dbe0
+      - 3f788bc7-0c8b-406c-99a4-ebe3107eafd0
     status: 200 OK
     code: 200
     duration: ""
@@ -1043,10 +1043,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/722a187e-ca86-4bad-95b8-6721702d8672
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:17:11.355771Z","dhcp_enabled":true,"id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:17:11.355771Z","id":"39ca8674-4e5d-4182-94f6-fec62de626f4","subnet":"172.16.56.0/22","updated_at":"2023-11-10T13:17:11.355771Z"},{"created_at":"2023-11-10T13:17:11.355771Z","id":"e1ecaf7a-05bc-44f2-a4f3-68bdc104d77f","subnet":"fd63:256c:45f7:2b8e::/64","updated_at":"2023-11-10T13:17:11.355771Z"}],"tags":[],"updated_at":"2023-11-10T13:17:11.355771Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:57:42.388792Z","dhcp_enabled":true,"id":"722a187e-ca86-4bad-95b8-6721702d8672","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:57:42.388792Z","id":"476fb5a2-f625-4717-a64e-f96edbc43b1c","subnet":"172.16.36.0/22","updated_at":"2023-11-13T13:57:42.388792Z"},{"created_at":"2023-11-13T13:57:42.388792Z","id":"75893f04-a64f-45ea-9ce7-e91f20986997","subnet":"fd63:256c:45f7:553b::/64","updated_at":"2023-11-13T13:57:42.388792Z"}],"tags":[],"updated_at":"2023-11-13T13:57:42.388792Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "720"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a0057ed5-fbc5-4837-a385-242323c12721
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c45f90a-c5a8-47e5-8856-e18c85bb870d
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-13T13:58:04.478063Z","dhcp_enabled":true,"id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:58:04.478063Z","id":"cd178612-c9d7-4e8e-a510-e11abe61d591","subnet":"172.16.52.0/22","updated_at":"2023-11-13T13:58:04.478063Z"},{"created_at":"2023-11-13T13:58:04.478063Z","id":"a3d07c6e-a0ca-4dab-b21c-5477941bbf38","subnet":"fd63:256c:45f7:dfd5::/64","updated_at":"2023-11-13T13:58:04.478063Z"}],"tags":[],"updated_at":"2023-11-13T13:58:04.478063Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "722"
@@ -1055,7 +1088,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:21 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1065,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50d38e18-0d91-4769-be52-03c31d89cdea
+      - b04fe2c0-0ccd-4067-8049-1ea91dc216c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,43 +1109,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.438288Z","dhcp_enabled":true,"id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.438288Z","id":"455fc52a-21dc-463e-8dbf-cb3f670a86a1","subnet":"172.16.0.0/22","updated_at":"2023-11-10T13:16:56.438288Z"},{"created_at":"2023-11-10T13:16:56.438288Z","id":"33bd4722-40c8-4853-9994-a020bd6e670b","subnet":"fd63:256c:45f7:13e6::/64","updated_at":"2023-11-10T13:16:56.438288Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.438288Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "719"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6316d49-82f2-4e72-9d0e-3b0f695b1c11
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:18.532499Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:12.405943Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1523"
@@ -1121,7 +1121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:21 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 869f2850-83c9-4567-9dc9-ed113305d299
+      - 089adcf2-762d-4632-96f3-c2b54fa075cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,10 +1142,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRQVkVWNlRWUmplRTR4YjFoRVZFMTZUVlJGZDA5VVJYcE5WR040VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWEkxQ2preGJVUldiSE5TUjFkQkwwOUhkemwxT0ZaTVptcERhekpTV1ZBNFNVOWFObWx1YUhRMVFUZGhaWEpsWm10VlZTdDNjbnBTUTBsNk1VUlRjRFI1V0VrS1ptVkZNbFV3TURadmJHMUlOVzV0U0V0TVYyaE1OWGRsVUZGSFZIZG9jWHB3VFRneFZuTlZNbUp2VEZoaGNHcFBSR0pCTkd4MllWcHNPQzk1TW1SNGR3cFFPWEJ5ZGxaWGJFNWlOM0pHVmpCck1YRlZaWEl3T1N0RWNtdGpOWE5hWm1WUU1tdEdSbWRUYzJaTllsaHRTVTVTTldWcWExZElPWGw2VkRRellqTlhDbVpIVjJ4a1JVWllNMWRUYVUxaWNWa3dVekU1WTJaUlJFVkRMM0ZHWmxscVYwZEthbmwxVFdObU5XWmFNMmQwWmtka2FGbEJkVWhsVVZseVF6ZzBXbkFLWWsxaU5UbDNRVXRHZWxGeVZEbE5NbVJyUVRGYWFtOW1SRU5WWTJSc2VGbDJkekF5TDNCWVkxVTRWRWxwUjBWeldYQkRlbFp4SzBsa1Z6bDZPVGRpV2dweGFERktTRzVOT0dRdlIwRllTMWx4UkRVNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNqVjNWMEUwU0hWM1dEZGpWVXRQWVhabWFXMTJWMGR5TTA1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFFXcFVORFJ3ZWxwdU5WcExOVlZ0YkRONlptdHBkR0ZuVkhseldFbHJXVEZpZVU5b1lYcGFNRWh0WjNGa04yUnpaUXAzVm1FclUwdEVWbnB3Ym1sTWNHRmhVM0pUYnpaeGVUazRXVEppYkVWTGN6WkRSWEpJYzJRME1XNHZRbVE1Y1RaSmRrMWhZbWhhYm1SMVEwWXdjREJQQ2t4NlIwSndRWFUzTldKckswZG9RVWhvTWpNdmRrOUJaa1VyTldoNVFqbDBZMlJ5VTJOS2RFTkJURmh2VW1VM2EyWTRZVzB5ZURGbVFXTTFMMmd4U204S2RsaE5jMVpQTmtGdVUyZEpVRGRSY25kU2FHMUlhVkYwWW1KdFJYbDZSMlZsZFVSWldYaEVSMU5RWkRaME9HOWlORzFrZFd0YVVXdEhNbEJhY0ZsT053cEdWRXBGUWpOTmNVcEZkR3BLV2poWVNVWkxibUUxVW5nMlFWWnBUV0ZLZVdoeFVqTktVblpCSzB3eGFXZ3hiM0l2UkRaUk9GTjNWRzlyZDI0MFUwWXhDbmxuYVVsUmNrRnBVV1J3YmtKRFZsUTVTWFYzUlZOb2VYSm1VelZqVEdGd1VWTjJOUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjllZDk3YzMtZjM3MS00NmM0LTk3YjUtZjkxNjQ2ZDNkZjhkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPeWRjaDdoNzFweExGTERuZnl0V2pLU2hDOW1hVWZabHhjSEJJOWRVMFFaY1ZkQ0RyajJzRk9zcw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGhOYWtWNlRsUm5lRTFzYjFoRVZFMTZUVlJGZUUxcVJYcE9WR2Q0VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV1EzQ21kR1N6SXdiMWRoVDFreFZIbDFPVTgxTHl0R1QwZHBSbHAxY1RWVU1VcExibWhuTjNJek4xVkxSMkZST1dGUWMwTnZXVkZvUVRCaFFWSm5RVVp0VXpVS2QyWmFXa3A2YkZRNVNDdDNXbFJUWnpGV1kyNWllSFZRZVZJMlFXdFBZamt2YkhSek1FeGFSRVozTlZvd2RWcEZNMVY1UmtWbGVWQkhWazh5T1dJMFN3cDBLMmhXTDNnM2RWaEhhMmh3Tlc5NFFsVktVRVJ4TjNOYU0yUm1iRkF5S3paVVptRk5TWFpuU21SVGNHMXZhMlpQYjBGbFdHUTJkR0pPSzFKNlpUVnlDazR5UjNJelNraFpjVTF6VjBzMWJVSlBiMUI0Y0VkTVEzbHJkamxZVkVsbGQzRldaVzlQV2xVNVdrVnVUMUZ4UXpKU01qTmxjVVJKVW5oa1YxWnNTMmdLWjI0emNWTmtSV3huYWtSR1JuaDZZMFJHTTNNMVExWnNWMnRNVDFGaVVtb3lTMGsxTUhWa1RpdFFTWFZwV205RVYzQkRWVzlCVkVzd1NURkRZVlpWTWdwb05pOXVlbEl3ZGpSclRsUk1jR2hUZWpSalEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1VtdEtPRnBoY0hKU2VIcGFjVGxPVkRjM1JtNHlhbk5oY0dsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1UyTnFLekZhTVUxVlVIQlJaSEJ4VlZKQlRFRlhOVlozV21ObVJIcFlhMU5zTVROeGFYVjJRbXc0T1RsNlUwOTZNQXBEWjBjclFtcHVabXAxZVVaa2RFdDVjRFEzWVhwRldqRnFSRlp1VWtZdk9GRkxRbFl5VFZka2NraFFTMUZyZGtGd01uTlpORTR3U0dRNWVsRlZaMVJuQ210NlRHNVFZVVJwZEV0Qk5WVktTMFJNVjBnMk5HOUljM2xRWnpscE4waHdTbWxRTUUxcldVNDNWVzFpWVZOTU9YQlNOa2M1ZVhwRVNGTlJiR3hJSzNJS1JqTnRhbFJQU1dWRVdsQjVZeXRHYzNaV2JrRkNUR05pVm10cmEwUkJiSHB1YzFCd1dEQjBWVE5PVm5WTFQzcGFNbE5KTDBGalFraHhNbmd6TW1ONEt3cENTVVJSVVZGNVZXOUNOMDEzUTJocVEwWmtUazFPWkhGc2FIUlFSVEVyUWl0TVowOUhSMWxXYTFWSFdFb3pkM1JEYTNwb2NVcFVUVEZTTlhOSFRGbFZDa05XUmxOclFuZHFhVEZ6Vm1vek56Wk9aMUpzU0cxTWJsbDFPRkZvYkRrelkwWjBTZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDNhNGVlYWUtYmZkZC00NjNkLWE3YWUtZDE2MjY5NTA5NjVlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5bmNUVndzVjJKZDE3b3Z5OUZxNlowTnlITGhDckFlNUZLbUhkVng2dzc2Q00yWTBqSlR5bGd0WA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2710"
@@ -1154,7 +1154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:21 GMT
+      - Mon, 13 Nov 2023 13:58:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1164,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f5fed1e-5e35-4426-a21d-afda3921b5d2
+      - f4ba60c3-482a-4608-a8bc-e74f03c70277
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,41 +1175,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e?with_additional_resources=false
     method: DELETE
   response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 325a04eb-a769-4519-95b1-3218ecd95388
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d?with_additional_resources=false
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.546408703Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:16.618325530Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -1218,7 +1187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:23 GMT
+      - Mon, 13 Nov 2023 13:58:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b73b5e17-ff5f-478c-a449-0f97d5c17862
+      - 753dec3d-aa9c-40cd-ae70-1177c0154277
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1208,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.546409Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:16.618326Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1518"
@@ -1251,7 +1220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:23 GMT
+      - Mon, 13 Nov 2023 13:58:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e1330d2-aa4b-4b78-abed-b78b7dd991e0
+      - a64fefd5-cafd-480e-8ea6-cb0f2132ecae
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,106 +1241,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.546409Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1518"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 52dd470b-a482-4e64-a0a4-5700911df06a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b9ed97c3-f371-46c4-97b5-f91646d3df8d.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-10T13:17:13.891302Z","created_at":"2023-11-10T13:17:13.891302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b9ed97c3-f371-46c4-97b5-f91646d3df8d.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-10T13:17:22.546409Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1518"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 062e36a3-aa97-4f30-88a0-71d0ca895d03
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e7239539-807b-4242-b45c-ae1c94965e30
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/722a187e-ca86-4bad-95b8-6721702d8672
     method: DELETE
   response:
     body: ""
@@ -1381,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:39 GMT
+      - Mon, 13 Nov 2023 13:58:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb3c5523-bf39-4014-870b-464093dbf9a4
+      - 3c48ba78-557e-475f-86a8-9d580a382555
     status: 204 No Content
     code: 204
     duration: ""
@@ -1402,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd1f7908-377e-437c-8ed1-f5d7ef4781f7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"cd1f7908-377e-437c-8ed1-f5d7ef4781f7","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://43a4eeae-bfdd-463d-a7ae-d1626950965e.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-13T13:58:09.823948Z","created_at":"2023-11-13T13:58:09.823948Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.43a4eeae-bfdd-463d-a7ae-d1626950965e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-13T13:58:16.618326Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "136"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:39 GMT
+      - Mon, 13 Nov 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,9 +1294,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 296d0482-3832-4bf3-b416-2ab9511b2a4b
-    status: 404 Not Found
-    code: 404
+      - 8279e3b3-0fef-49d2-b347-adf2c9319cb8
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -1435,43 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/518e6ebb-ba2c-4ee4-bac5-0725d8c39999
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"518e6ebb-ba2c-4ee4-bac5-0725d8c39999","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "136"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - adf64237-d1f9-4b1e-87b1-cc6b9d13a152
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b9ed97c3-f371-46c4-97b5-f91646d3df8d
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b9ed97c3-f371-46c4-97b5-f91646d3df8d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1480,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:40 GMT
+      - Mon, 13 Nov 2023 13:58:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1490,7 +1327,137 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cbcac9c-7ed5-4e03-b8e4-98f52398b867
+      - 1b580038-bbf7-467a-ac4e-d884c52bbad0
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c45f90a-c5a8-47e5-8856-e18c85bb870d
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 930ea90a-cde4-443e-8db6-f495b02c0154
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/43a4eeae-bfdd-463d-a7ae-d1626950965e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"43a4eeae-bfdd-463d-a7ae-d1626950965e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e915dc8f-4a7b-424a-9a49-cd12543625e3
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/722a187e-ca86-4bad-95b8-6721702d8672
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"722a187e-ca86-4bad-95b8-6721702d8672","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f7638529-b7a0-4727-9e54-d476d8673b96
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c45f90a-c5a8-47e5-8856-e18c85bb870d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"7c45f90a-c5a8-47e5-8856-e18c85bb870d","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:27 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ef60f784-07fc-46f4-87a4-e3f47a65f2e1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-type-change.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-type-change.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:53 GMT
+      - Mon, 13 Nov 2023 13:51:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 706d0df8-4d41-4314-a760-319029875e83
+      - 9441cb1f-7e29-4311-847a-e0dafac98987
     status: 200 OK
     code: 200
     duration: ""
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26214f22-0980-48ce-b97a-e4df1b555cd8
+      - 3a9a9061-ac7d-4e9a-8d9d-d4d7d229f90b
     status: 200 OK
     code: 200
     duration: ""
@@ -80,10 +80,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 912c7faa-9b7d-4754-b99a-4b22ccc11334
+      - 4de87161-1114-4627-955e-a49b6ea072b1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486464737Z","created_at":"2023-11-10T13:16:58.486464737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.499426405Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:00.723791496Z","created_at":"2023-11-13T13:57:00.723791496Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-13T13:57:00.735257903Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 877766cf-14ea-43ed-8435-7bf6cbe81dcd
+      - 4d90c28d-fec6-408d-aa55-9507439615a0
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:16:58.499426Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:00.723791Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-13T13:57:00.735258Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1503"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:16:58 GMT
+      - Mon, 13 Nov 2023 13:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b9991bd-4582-42ae-b72c-63504be486da
+      - e27129c8-628c-4cec-874b-b4ea6c7eab17
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:00.723791Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-13T13:57:02.515366Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fcefd0f-d682-4a14-9171-956d418e9372
+      - 205cdaf7-5b5e-4abe-8204-d4a1bb7f262c
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:00.723791Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-13T13:57:02.515366Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 539d0e40-4e0e-46b6-b7f7-47ba17071b48
+      - dbfb35c4-9dfc-47e0-aec9-19baa1c51242
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 575ba852-29bf-43f9-a227-59881fc1968f
+      - efcfa99d-b87d-44f8-b6d2-7d5647f15a27
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:00.723791Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-13T13:57:02.515366Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:03 GMT
+      - Mon, 13 Nov 2023 13:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24ecb0ed-b369-44bd-a1f3-45f728b43753
+      - f985b26b-11f3-45b6-9bf0-ad9dcccad3e8
     status: 200 OK
     code: 200
     duration: ""
@@ -313,10 +313,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -325,7 +325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f9752d5-e2de-4ca0-a228-120af7185b9f
+      - 994ab808-2894-47d8-ac9d-6c3f6ae22c44
     status: 200 OK
     code: 200
     duration: ""
@@ -346,10 +346,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:00.723791Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-13T13:57:02.515366Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -358,7 +358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5040722-fab8-4605-9a08-90a9fb20b21b
+      - 1f53601d-2e83-4668-8d65-56e31f337ca0
     status: 200 OK
     code: 200
     duration: ""
@@ -379,10 +379,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -391,7 +391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d7ae551-4f30-44c4-82dc-1708f8b0aa19
+      - b6a8b482-79dd-4c11-a1c0-6051bac05252
     status: 200 OK
     code: 200
     duration: ""
@@ -412,10 +412,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -424,7 +424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:04 GMT
+      - Mon, 13 Nov 2023 13:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dab7299c-c2aa-4a24-ad62-5e4ec55c7f40
+      - d7f15bca-6c09-4714-8e30-9ef33a69ffca
     status: 200 OK
     code: 200
     duration: ""
@@ -445,10 +445,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:00.723791Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-13T13:57:02.515366Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -457,7 +457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 735afd6f-4d81-4715-9232-f1e416208ad2
+      - 6abd102e-9c13-468a-900c-b449bbc2c5b5
     status: 200 OK
     code: 200
     duration: ""
@@ -478,10 +478,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -490,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80f57acf-8682-40f5-a56f-b24e177ca51c
+      - 6bdf4436-24e8-4be5-bc29-8e52cdc34bcf
     status: 200 OK
     code: 200
     duration: ""
@@ -511,7 +511,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
@@ -523,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:57:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -533,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be123893-75cd-46f4-8abb-e7b108a84771
+      - 59274724-879a-4c85-bc9b-e4babf10dc94
     status: 200 OK
     code: 200
     duration: ""
@@ -544,7 +544,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
@@ -556,7 +556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:05 GMT
+      - Mon, 13 Nov 2023 13:57:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -566,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eef07048-512c-4cff-9c4a-0bf766b52b75
+      - a5058b0b-9fe8-4ead-90bd-f131b5cf9b10
     status: 200 OK
     code: 200
     duration: ""
@@ -577,7 +577,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
@@ -589,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:57:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -599,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c219f084-c50e-4177-8829-b980e0df7b53
+      - 6ca566c1-4f4b-4c07-a67e-f82065fa7075
     status: 200 OK
     code: 200
     duration: ""
@@ -610,10 +610,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-10T13:16:58.486465Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-10T13:17:00.097036Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-13T13:57:00.723791Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-13T13:57:02.515366Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1508"
@@ -622,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:57:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -632,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 887df2b4-748d-4d45-8285-5e99e3ff87e2
+      - bc184019-a3b5-40e6-8fdf-87c7f7ef2868
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263957800Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892452Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604173Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535369Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1521"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:57:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71baec61-2f45-453f-b915-169a242f4a97
+      - 215ca2c1-1ee0-4397-8938-bb2293cca153
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:06 GMT
+      - Mon, 13 Nov 2023 13:57:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e515db7-588c-416c-8399-fe4a49d593d6
+      - 3aaa1902-24f3-494a-b966-7af6718a5255
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:11 GMT
+      - Mon, 13 Nov 2023 13:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d358ee9a-beaa-46fa-be0c-80880bedf4d9
+      - 3df3a4b3-1ee5-458b-8e7a-1fc3ffa31125
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:16 GMT
+      - Mon, 13 Nov 2023 13:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99a4ac89-67cd-4693-82a7-1b3a40c21c81
+      - 720f6a7c-5cc2-40e7-98f4-8ba590131096
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:21 GMT
+      - Mon, 13 Nov 2023 13:57:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73b4ea96-3adb-491e-bd07-cc9b9d82ab4e
+      - d0737cad-6935-4f38-80cd-9f4a3c5e9221
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:26 GMT
+      - Mon, 13 Nov 2023 13:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68af9d99-4aa3-49d9-9748-da8483e455f2
+      - cfc5cffc-6764-4b41-88a0-c5aa965ec05f
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:32 GMT
+      - Mon, 13 Nov 2023 13:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1321cd3a-f65d-4aa7-bf9b-96d27b671d8d
+      - e8f548c7-eb31-4e76-af52-cdaf813679a8
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:37 GMT
+      - Mon, 13 Nov 2023 13:57:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89911edb-dbfd-4a79-bf16-fd826cf7f466
+      - be3b4a64-2936-4a3c-981d-8b6929058502
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:42 GMT
+      - Mon, 13 Nov 2023 13:57:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da164e64-034c-45be-b4a0-8c322c919455
+      - c43b3075-a57d-4bac-a2cc-ebc7b3a799a4
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:47 GMT
+      - Mon, 13 Nov 2023 13:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f299ed08-00bc-4138-980b-36210ac53052
+      - cb6e38c1-0884-41cf-a152-41bfa21a78a6
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:57:09.968535Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:17:52 GMT
+      - Mon, 13 Nov 2023 13:57:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae5fe2f7-5d7f-4867-9826-a77079ed5ffa
+      - af490dee-5c06-46e1-9745-2f5151239acf
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,241 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:17:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9580e5e1-9a44-46a6-ab39-cebb56ac1e0d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:18:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8e71e87a-22ec-4171-8398-73e0808dc146
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:18:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 613b4cf6-516a-4896-8a46-e490615b9513
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:18:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ba1b9a2f-76ab-4acc-bc4a-ea0f1347417d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:18:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - afc03345-6496-4025-9a62-f27ba9a71da6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:18:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4fc7403a-5bdb-4d97-9ada-b7a546811558
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:17:06.319892Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:18:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f61c38b-2d3b-4a08-9739-42509a003af9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:30.290815Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.087479Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -1251,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:32 GMT
+      - Mon, 13 Nov 2023 13:58:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a961cf63-f6e3-4d02-bf88-629acbdb806f
+      - 8452cf22-620a-4e00-9e6b-ad6c21df0f7f
     status: 200 OK
     code: 200
     duration: ""
@@ -1274,10 +1043,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250118Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060257Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1518"
@@ -1286,7 +1055,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:33 GMT
+      - Mon, 13 Nov 2023 13:58:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1296,7 +1065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9addc38f-6f7d-467c-a591-80042994adb7
+      - d2743db6-1c19-49a0-af3d-601ee977637f
     status: 200 OK
     code: 200
     duration: ""
@@ -1307,10 +1076,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -1319,7 +1088,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:33 GMT
+      - Mon, 13 Nov 2023 13:58:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1329,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3653cc9-5e6d-412e-ab04-2ff7873c61b0
+      - 5a87bf6d-8ec1-4982-89ef-09632e6910a8
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,10 +1109,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -1352,7 +1121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:38 GMT
+      - Mon, 13 Nov 2023 13:58:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1362,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b26358d3-bb17-4686-b87a-4057d6f4cb76
+      - e7e660b7-8312-4408-84e9-f2f0585882d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1373,10 +1142,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -1385,7 +1154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:43 GMT
+      - Mon, 13 Nov 2023 13:58:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1395,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 938f3b5a-0502-430a-a653-871748940053
+      - ab59808a-043a-49ca-9d59-64ba117da7e9
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,10 +1175,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -1418,7 +1187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:48 GMT
+      - Mon, 13 Nov 2023 13:58:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1428,7 +1197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c17cc78-2fde-4c2c-a747-4dadaeacfe4c
+      - 0f7ebe89-ab59-42c2-a900-1383404d6678
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,10 +1208,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -1451,7 +1220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:53 GMT
+      - Mon, 13 Nov 2023 13:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1461,7 +1230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 234bcce1-6153-4400-817a-fcf2c2d7c64d
+      - c76e8d55-c9c7-4e0d-9521-ed0c78f8f39d
     status: 200 OK
     code: 200
     duration: ""
@@ -1472,10 +1241,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:18:33.028250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -1484,7 +1253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:18:58 GMT
+      - Mon, 13 Nov 2023 13:58:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1494,7 +1263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b2956af-f6f5-48a4-97e8-32d6bec56bb6
+      - a851d6e8-c08e-49eb-80d3-4d8fc765a752
     status: 200 OK
     code: 200
     duration: ""
@@ -1505,10 +1274,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3351f5b1-8d48-4157-b274-c9966d580fc7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:01.533060Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 13:58:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9967aed8-9bdd-4f12-b1db-0c64b228e3f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:38.631745Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -1517,7 +1352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:03 GMT
+      - Mon, 13 Nov 2023 13:58:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1527,7 +1362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7d73fbe-0fdc-44bd-b545-a6b0d192ed6e
+      - 0cbe716a-ceda-4eb9-943e-c89f404a49c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1538,10 +1373,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:38.631745Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -1550,7 +1385,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:03 GMT
+      - Mon, 13 Nov 2023 13:58:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1560,7 +1395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 929eadcc-c5d3-4a67-92cc-d02ef6d56ffb
+      - 1736e848-28f2-448d-9a18-ef53dcccf396
     status: 200 OK
     code: 200
     duration: ""
@@ -1571,10 +1406,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -1583,7 +1418,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:03 GMT
+      - Mon, 13 Nov 2023 13:58:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1593,7 +1428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e4f13a0-532b-4c87-900c-9f209aa54980
+      - 2a3b29b6-d6bc-4ca3-8225-86dbf91d4641
     status: 200 OK
     code: 200
     duration: ""
@@ -1604,10 +1439,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:38.631745Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -1616,7 +1451,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:03 GMT
+      - Mon, 13 Nov 2023 13:58:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1626,7 +1461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85fa7d1e-366b-458e-8398-f8bd170b92a9
+      - 570b5ebd-c9f7-41fd-8402-a29b8abfb8b6
     status: 200 OK
     code: 200
     duration: ""
@@ -1637,10 +1472,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -1649,7 +1484,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:03 GMT
+      - Mon, 13 Nov 2023 13:58:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1659,7 +1494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8099edde-d219-4db8-8e6b-33bafca5acbe
+      - 32732d40-e5c5-4cad-a98d-c1c215962855
     status: 200 OK
     code: 200
     duration: ""
@@ -1670,10 +1505,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:38.631745Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -1682,7 +1517,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:03 GMT
+      - Mon, 13 Nov 2023 13:58:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1692,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac157ccf-8901-4fec-949e-6bcb6641462f
+      - 67ace241-7707-4df0-aaba-d6a19a005b8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1703,10 +1538,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -1715,7 +1550,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:04 GMT
+      - Mon, 13 Nov 2023 13:58:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1725,7 +1560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ed33e2-d6fd-4a69-957c-e307d312b7c2
+      - eea61e92-62d2-495e-a133-b1471a85690a
     status: 200 OK
     code: 200
     duration: ""
@@ -1736,10 +1571,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -1748,7 +1583,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:04 GMT
+      - Mon, 13 Nov 2023 13:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1758,7 +1593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e31c37c9-f5e4-44e8-935b-689146ab7f1d
+      - 3ee42e63-9856-440c-9a38-0cad73cc88e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1769,10 +1604,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:38.631745Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -1781,7 +1616,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:04 GMT
+      - Mon, 13 Nov 2023 13:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1791,7 +1626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8f639b9-562b-4fb4-a845-1c16ac288d29
+      - bf04ef1e-1e04-4eae-982a-0e57ba213911
     status: 200 OK
     code: 200
     duration: ""
@@ -1802,10 +1637,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -1814,7 +1649,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:04 GMT
+      - Mon, 13 Nov 2023 13:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1824,7 +1659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4aabb25a-8f59-4087-adf1-0ec7adfe2885
+      - 30414500-8eff-4ce3-865b-27d73919fa1e
     status: 200 OK
     code: 200
     duration: ""
@@ -1835,7 +1670,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
@@ -1847,7 +1682,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:04 GMT
+      - Mon, 13 Nov 2023 13:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1857,7 +1692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5854b479-98e9-4bb1-9ebf-6eca8c985a28
+      - ff57fc2e-d7a8-4e4d-82e3-7b8c89f99770
     status: 200 OK
     code: 200
     duration: ""
@@ -1868,7 +1703,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
@@ -1880,7 +1715,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:05 GMT
+      - Mon, 13 Nov 2023 13:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1890,7 +1725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7075ceb0-b2b0-4487-8977-b5af710406f3
+      - 284ee501-0728-4e6a-b6d3-2327cd222b9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1901,7 +1736,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
@@ -1913,7 +1748,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:05 GMT
+      - Mon, 13 Nov 2023 13:58:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1923,7 +1758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd72aaa3-53d0-401e-8d7e-93ed204e3e66
+      - ea7f2235-4f18-4b9b-b632-788a438e8d87
     status: 200 OK
     code: 200
     duration: ""
@@ -1934,10 +1769,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:17:06.263958Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-10T13:19:02.945215Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:57:09.895604Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-13T13:58:38.631745Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -1946,7 +1781,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:05 GMT
+      - Mon, 13 Nov 2023 13:58:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1956,7 +1791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 117560b5-a047-409c-b856-7b260175e8b9
+      - b4eae11b-3967-45f2-a487-2f45dd6284f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,10 +1804,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503659860Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586977848Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260382548Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062361Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1522"
@@ -1981,7 +1816,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:05 GMT
+      - Mon, 13 Nov 2023 13:58:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1991,7 +1826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d64f356f-4ed0-4357-95d8-aa9ad275b627
+      - 1ac6ed58-4d18-4aeb-a2c1-f033c2d25b8d
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,10 +1837,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2014,7 +1849,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:05 GMT
+      - Mon, 13 Nov 2023 13:58:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2024,7 +1859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f1d2e47-860e-4f4a-8408-ad779390b992
+      - fb53c017-2bda-41fb-a3d4-96b2c47006f3
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,10 +1870,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2047,7 +1882,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:10 GMT
+      - Mon, 13 Nov 2023 13:58:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2057,7 +1892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f5b71ee-c180-4fce-8d30-6d04696efd61
+      - 647591e1-099f-4b56-a88f-e257d4408d87
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,10 +1903,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2080,7 +1915,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:15 GMT
+      - Mon, 13 Nov 2023 13:58:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2090,7 +1925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b57be703-1fb0-4c2c-a0cc-5a4468fc57de
+      - 9d24acd6-4e66-4996-aa66-b00a815798b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,10 +1936,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2113,7 +1948,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:20 GMT
+      - Mon, 13 Nov 2023 13:59:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2123,7 +1958,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e84571a0-5dc6-4c2a-98c2-d9f325f81794
+      - 71816044-456f-4651-8816-bda227b713ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,10 +1969,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2146,7 +1981,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:25 GMT
+      - Mon, 13 Nov 2023 13:59:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2156,7 +1991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c259b5a-86dd-4cbd-aeb2-bf26977e614e
+      - b9666696-069d-47c2-8783-dbc4b56be4f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,10 +2002,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2179,7 +2014,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:31 GMT
+      - Mon, 13 Nov 2023 13:59:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2189,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 080abb38-2aa3-4b51-b853-c11be055f161
+      - 08571dad-e0e5-48f7-9419-18e1a571c686
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,10 +2035,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2212,7 +2047,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:36 GMT
+      - Mon, 13 Nov 2023 13:59:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2222,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2e74cce-48b6-401f-a407-1d3e3b8fc39b
+      - b18f6bd8-7186-489b-b2ff-e0bdbdd42517
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,10 +2068,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2245,7 +2080,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:41 GMT
+      - Mon, 13 Nov 2023 13:59:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7136c438-967c-4cc5-a7cd-6d46f59ff045
+      - 4b0ef6be-6472-4612-8064-85972ae0a3e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2266,10 +2101,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2278,7 +2113,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:46 GMT
+      - Mon, 13 Nov 2023 13:59:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2288,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b4f20a5-bf9a-4173-921f-c2ac5604ee01
+      - fa3afe7c-0739-4ac8-9a54-478e9e03148d
     status: 200 OK
     code: 200
     duration: ""
@@ -2299,10 +2134,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2311,7 +2146,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:51 GMT
+      - Mon, 13 Nov 2023 13:59:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2321,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b5fb1bc-8973-4187-99e1-ef11b6c4e02d
+      - e6f06f18-096e-4099-b7bf-b796de361f1e
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,10 +2167,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2344,7 +2179,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:19:56 GMT
+      - Mon, 13 Nov 2023 13:59:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2354,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8cc033b-06ce-4522-8728-5599bdebc14e
+      - 26ded4f5-bbca-4272-bdca-44497681703d
     status: 200 OK
     code: 200
     duration: ""
@@ -2365,10 +2200,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2377,7 +2212,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:01 GMT
+      - Mon, 13 Nov 2023 13:59:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2387,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70ab7ac7-c93c-428d-a2ed-4971f1cd640b
+      - 98066cd5-406f-426e-b218-b0c512b33419
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,10 +2233,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:58:45.331062Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2410,7 +2245,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:06 GMT
+      - Mon, 13 Nov 2023 13:59:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2420,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 742c2033-2036-4474-a533-c4fa22e84b3d
+      - dedeffcf-967d-480b-9e7d-8802036bf66a
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,43 +2266,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:19:05.586978Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1516"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:20:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9e602929-3d99-4f30-9647-bb57d1df6030
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:15.367031Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:50.295244Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2476,7 +2278,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:16 GMT
+      - Mon, 13 Nov 2023 13:59:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 803655a0-9cac-400a-87cc-bb6b922e36f5
+      - 602cd85f-3ab4-4492-a2c3-ef5e4716e554
     status: 200 OK
     code: 200
     duration: ""
@@ -2499,10 +2301,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854065Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893654988Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1519"
@@ -2511,7 +2313,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:16 GMT
+      - Mon, 13 Nov 2023 13:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2521,7 +2323,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d68e8330-55d0-4232-99f6-1233fddbc09b
+      - b18930f3-85f0-45f3-9426-580d603de8e9
     status: 200 OK
     code: 200
     duration: ""
@@ -2532,10 +2334,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2544,7 +2346,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:16 GMT
+      - Mon, 13 Nov 2023 13:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2554,7 +2356,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8475ca12-ecf6-401c-97a1-bcdb8a8945f5
+      - 40606e30-a65b-4ccb-b8f9-396011554cf0
     status: 200 OK
     code: 200
     duration: ""
@@ -2565,10 +2367,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2577,7 +2379,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:21 GMT
+      - Mon, 13 Nov 2023 13:59:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2587,7 +2389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef99598f-bc2f-49c0-9f0e-058103404456
+      - 76e09ef9-3722-420a-8ad0-7f91256b4ae2
     status: 200 OK
     code: 200
     duration: ""
@@ -2598,10 +2400,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2610,7 +2412,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:26 GMT
+      - Mon, 13 Nov 2023 14:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2620,7 +2422,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea2ec300-7bd9-422d-b1bc-2dcd3b6a2e70
+      - b9ee7c57-afda-4638-a754-63cff434f938
     status: 200 OK
     code: 200
     duration: ""
@@ -2631,10 +2433,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2643,7 +2445,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:31 GMT
+      - Mon, 13 Nov 2023 14:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2653,7 +2455,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c76d764-dd13-49a2-a801-2f2b7a29f78d
+      - 860af148-4587-4981-b3fc-2f3018ca82e9
     status: 200 OK
     code: 200
     duration: ""
@@ -2664,10 +2466,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2676,7 +2478,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:36 GMT
+      - Mon, 13 Nov 2023 14:00:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2686,7 +2488,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d16d8e2-0c78-478b-b6a3-06a2847bcf99
+      - 07862474-8f43-408d-8f91-94e0cb1a862e
     status: 200 OK
     code: 200
     duration: ""
@@ -2697,10 +2499,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2709,7 +2511,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:41 GMT
+      - Mon, 13 Nov 2023 14:00:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2719,7 +2521,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ecfd435-fd5f-4580-9953-828820924009
+      - 5829fadd-c33d-4868-a843-bc43465f5264
     status: 200 OK
     code: 200
     duration: ""
@@ -2730,10 +2532,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2742,7 +2544,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:46 GMT
+      - Mon, 13 Nov 2023 14:00:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2752,7 +2554,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac2e36c4-cbf9-4668-9b08-e1f3d332a1e4
+      - 3dd55580-c8fa-47f5-a384-3d0525ab4186
     status: 200 OK
     code: 200
     duration: ""
@@ -2763,10 +2565,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:16.455854Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -2775,7 +2577,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:51 GMT
+      - Mon, 13 Nov 2023 14:00:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2785,7 +2587,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdcef856-ef16-429e-99e5-63d41ae959b7
+      - 8f566f7f-6b69-4226-85e2-14cf90463369
     status: 200 OK
     code: 200
     duration: ""
@@ -2796,10 +2598,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T13:59:51.893655Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1516"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:00:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfea0de7-6ce3-4fba-abaa-940e5816b135
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T14:00:35.703145Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2808,7 +2643,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:56 GMT
+      - Mon, 13 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2818,7 +2653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77ba5668-6e75-4199-b725-2d3a2acc3a75
+      - 763a0e2c-3baf-40b0-94dc-6966f9b27fb1
     status: 200 OK
     code: 200
     duration: ""
@@ -2829,10 +2664,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T14:00:35.703145Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2841,7 +2676,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:56 GMT
+      - Mon, 13 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2851,7 +2686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcac7646-bd39-40c2-b060-c17f7587ecd5
+      - db39636d-bb82-405b-b51d-e04225928245
     status: 200 OK
     code: 200
     duration: ""
@@ -2862,10 +2697,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -2874,7 +2709,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:57 GMT
+      - Mon, 13 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2884,7 +2719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aa97384-1103-485e-bb3e-c2d38aabfaa7
+      - e1b55bc8-50fe-494d-8e0b-866c3b1c7a61
     status: 200 OK
     code: 200
     duration: ""
@@ -2895,10 +2730,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T14:00:35.703145Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2907,7 +2742,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:57 GMT
+      - Mon, 13 Nov 2023 14:00:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2917,7 +2752,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ed01cfc-897b-45ef-977a-2c99f5def52b
+      - 151dad46-e156-4e73-b2f2-c12b9c097b7e
     status: 200 OK
     code: 200
     duration: ""
@@ -2928,10 +2763,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -2940,7 +2775,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:57 GMT
+      - Mon, 13 Nov 2023 14:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2950,7 +2785,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae043af7-9a98-4294-97c1-32eac8275408
+      - 68310f14-6953-4134-9e50-685ba4f3e1a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2961,10 +2796,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T14:00:35.703145Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -2973,7 +2808,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:57 GMT
+      - Mon, 13 Nov 2023 14:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2983,7 +2818,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5c376d2-714e-41fc-bca4-478f1f90dbba
+      - 92f71e1a-b87e-4795-acc3-933e4e18f0f5
     status: 200 OK
     code: 200
     duration: ""
@@ -2994,10 +2829,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -3006,7 +2841,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:57 GMT
+      - Mon, 13 Nov 2023 14:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3016,7 +2851,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45130f25-209c-45e6-8b7c-db0b73bb429a
+      - 518424de-c917-428c-a020-ffecbeea2aad
     status: 200 OK
     code: 200
     duration: ""
@@ -3027,10 +2862,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -3039,7 +2874,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:57 GMT
+      - Mon, 13 Nov 2023 14:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3049,7 +2884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a692ef05-5fcb-4f12-b54d-29e9d4441a5b
+      - 4b5fb40c-d7db-47da-bab8-885bef8f68ca
     status: 200 OK
     code: 200
     duration: ""
@@ -3060,10 +2895,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:56.100941Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T14:00:35.703145Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1513"
@@ -3072,7 +2907,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 14:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3082,7 +2917,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 715fe79d-cad0-4955-9a39-8aa75299a306
+      - 9b120c36-d50c-4e7f-81e0-becc7390b0f7
     status: 200 OK
     code: 200
     duration: ""
@@ -3093,10 +2928,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUVlJaTVU5V2IxaEVWRTE2VFZSRmQwOVVSWHBOVkZreFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNCR0NqRm9TbnBKWjJwQlpsWnhUMEZXYTNrclZuSk9abFpRYVVGWVlpdFpNMVZSVFcxR1RuTjBLMHgwZDJZdlNVdHVibkpzUTFob1ZEUlhWa3N3TW5SNldsUUtaSEprWldSdFV6UkxNMWhaTDFWa05XbFBja2RwWVZKdmMxZGtObWxWYWpOU2JEUlBaRmt5T0RsclVUaFROa2RLUWpCU1ozaHJURGhIYjJGd1MybEVlQXBMWjBkbmRYQXJZMlpLYUZRM1VXSjFSRzV4VUhsYVZuSTBjV00zVG1oNVNtcExWMkpzT0RCNWVrVkhhMWRYV25ZMFltTkNXa3RuY0dkMlFXa3laMnhCQ21GaU0ydDRhMGhRY210QmRFUkNVVWhNWlZOVmRqTlRhV2RVYmxVMVpFZG1iR2RKYXpWdlZHOUZkM280TTBWMVptWnViRzVqWTFoNWFrVnFTa1Y0ZWxrS1QxUlNjU3RQUWpkcU4yODFLM0JVT1dsWE1YZEJUbHBDVEVaRU1tcEhOMHh4Y21kUmRXNVVhbTV0ZGt0V1YzVTNXRU5YU1hsSldYZG1XVVJKYURKQ013cG5jVlpVUTI5NFprOTJSamQ1Vm1GU01DOU5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkNXbWN2T0VabGRpOVVRMDVYVTJ3NFRXUjJaamM0UkZGbllWTk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWbXcxWW14QmEzTnNSRk5tZEd0V1FUTmpWamRtZERkaVEzbzRXVzVCU210NFFTOXJla1V6TjNBMFNVbzVhMGhVUXdwRVptOVBWR2xuTjFOTk1tODJkMWhxYzJwTVVIVXlZVXR1Y0U5TlZrbFdkVU5YUlVsRlJqSXJTMFZyV0ZKQ2VrMXFjMVJsTUVGdVMwUlJNRFU1ZDJONkNrOUZORXBtT1RKelQycFZkbE5rYlNzMGVrc3lWMDh6WTJKQmRGb3ZVelJWWWxWVk1WTnJLMU1yWjFJck5tMVdOVzlOY0ZoQlZWUk1UMjVWY25OV1Iyb0tjVVJKYnpkVlZGZHpjbEJWZVdrMWQxUjNhWGxGVkVKNVpIQXJSMkkzYVdnMU1IRTJZVXRWVG5JMFYxUlVaM2g1ZERFMU4yZHRRelJHWTNoaWNGRnVjd3BIU25aaVRrUnNkVkIwZUZBNWRFUXJSRzlyTDJkUVlYQnlUbWxOTTJSbVRGbHNhWE5aUm5GTFFVSXZSRUp2ZWtVdlJXeFNkeTgxYmpBMGVYWnRPRVF6Q2tGU05VRkxLM0U0ZUROd2JrczJialYzUW5aS1FuTklNV0pOU1ZoUU0wTkZjRm8zVndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzFlYTJiZGZiLTU4ZmMtNDRjNC05MGE5LTE5MTc5MDhlYjk2MS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBmdDFzbjB4V1p6TU9vV0lzOVlJWDZRZVRQR0tsVGFqVm4zNzFMSXh2WkNVUDRJZFF2d2JjT1RPdQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVjZUbFJqZDAxc2IxaEVWRTE2VFZSRmVFMXFSWHBPVkdOM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUc0M0NuQnlOV2huYm5odVVFRjRWVnBIU2t0UlRFWTNhMk5ZTXpOMFNuWjBkVFUyY21nM1pYVXpVVkZCVDB4c05GWndla0pOY0VReWIyVm5TRTlyZEd3MkwxSUtUMEZEV1M5U2IzcE9PVGgzTTFSM05TODVaa3hYZUZaV1V6Wk1SR3gyY2l0U2VUZFVZamxwYzFwRldIZHJNa2w2ZFV4WmEzVnFjMjFXZDBselFYcDRTQXB3V0dGa1UxQmhWa2N6TUZaNlFYSTFWbGh5ZURob0syUXpjRmR2T0VaMGJ6VlZRbmxHTkN0eGNrZDNjMHhEZW5saGNEWmljazVRU1U5cVVWQklZblpMQ25KNGVVSktiVWxIY0dwUVpqWkxZVmN4VDIxSFIxRTBWMDVOVjFKVFZsRTBkMW94ZEhaaFNVSnNMMW93Y0RKR1JsZ3hhamd6VVZONldURlJZbGx6WTBvS1ZtNWlabTFUYVV4UmMwMWhZMmx2UXpSRVZYWnphME5tZEVRNGRuQkZOemxLWTBKS1ZXZFNkelJNU0ZsRlNtSm1RM2hxUTFCRk9WaEJZMHBqUWtGb1J3cFZVWE51ZEhGRlIyWTFOMFYxWmxsME5rZFZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhiV3RLVHpONWJWbDNVSFpuTHk5aVoyeEdhak5pWlZWeVZHZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaRE00YTBSb1ZtSTVja2RVV1RSYWVteEhSRGRwWlhoMGVtdEZiMDhyZFhGdVJGSmtiazA1VlZkbGFFeDBMelZhVmdwMGVVUnROMlpEYlhkNksya3ZURU55V2tVMU1TczJja0Z5YTI1b05HMXhNVXRWYjBKbVpscFFWM2hXV21OcGVETjNjemhsVlZoTmN6ZzJTSGRvUjFkcUNqRm1OMnd3YjBRd01UQlpWRzR4VjBvNWFFOXJRV05ITTJwSE4xUmlla3BsZUVsSWRHbG1PRWxFUjJsSmIwbDNUVFJsTjJFeUwzaDJhRzFtV25WNGJqZ0tNM2RHUmxCRU1HTk5TblpQTDFaWldFUnBOeTlNZFRRNWNtZDFXazEzVkRrMlpWRjVlREkwUjA4M1QxRTJiak40YmxrM01VSlViWEJ5TTBOR1kxVklNUXB6Uld4V2MwRXZNRmczYmpsNVprOHlhVlJIZEZBMWFWSlBXbEZ4UVM5elIwUmFWRVUzVUdkR1RHRkhTRmcxTTNSSlkwSlVkRVYwUkVoUmVEazVTR2xDQ2tOUU1sVm1SM1JRWW5SYVpXbG5LMjVoUWtKVFJrNXpVVGN4Ynl0cmNubE5iekJ6UndvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzJhODc1M2YyLTg4MDctNGQwMS1iZDYwLTk4NjNlZWMyNDNmMS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB2dEpoeGVKT2E1cVdHenlTaTBucWNOUjlnQzdIdFhhaTlCcHNUelhXWlZWS2VFMFYxT3pSaG53Vg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -3105,7 +2940,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 14:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3115,7 +2950,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ca29c12-962d-424d-9269-2d19ea6c7fbe
+      - 568d1686-15fc-4c03-8289-8885a168137c
     status: 200 OK
     code: 200
     duration: ""
@@ -3126,7 +2961,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/available-types
     method: GET
   response:
     body: '{"cluster_types":[],"total_count":0}'
@@ -3138,7 +2973,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3148,7 +2983,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 008b9254-b212-44f7-a444-b5e75049d460
+      - f6f9c035-5a53-4fdd-bd77-a15816b93a81
     status: 200 OK
     code: 200
     duration: ""
@@ -3159,7 +2994,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1/available-types
     method: GET
   response:
     body: '{"cluster_types":[],"total_count":0}'
@@ -3171,7 +3006,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 14:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3181,7 +3016,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22d97707-53ae-417e-8358-9f0e17bd5836
+      - 62e2ef81-7e42-4ccb-9a78-3decd0d4296f
     status: 200 OK
     code: 200
     duration: ""
@@ -3192,10 +3027,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:58.804934640Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T14:00:41.832962531Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1519"
@@ -3204,7 +3039,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 14:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3214,7 +3049,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9434834-fa57-4a3c-9ee9-7770b756d991
+      - 563efb33-7fc1-4498-adbc-2b5dedf08a69
     status: 200 OK
     code: 200
     duration: ""
@@ -3225,10 +3060,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:58.804935Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T14:00:41.832963Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -3237,7 +3072,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:20:58 GMT
+      - Mon, 13 Nov 2023 14:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3247,7 +3082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8551bea-81ff-4ac5-a214-762492fad9b0
+      - d5094787-25fc-45fa-8ab3-9039aec1aa90
     status: 200 OK
     code: 200
     duration: ""
@@ -3258,10 +3093,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1ea2bdfb-58fc-44c4-90a9-1917908eb961.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:19:05.503660Z","created_at":"2023-11-10T13:16:58.486465Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1ea2bdfb-58fc-44c4-90a9-1917908eb961.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-10T13:20:58.804935Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://2a8753f2-8807-4d01-bd60-9863eec243f1.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T13:58:45.260383Z","created_at":"2023-11-13T13:57:00.723791Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.2a8753f2-8807-4d01-bd60-9863eec243f1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"2a8753f2-8807-4d01-bd60-9863eec243f1","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-13T14:00:41.832963Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1516"
@@ -3270,7 +3105,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:03 GMT
+      - Mon, 13 Nov 2023 14:00:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3280,7 +3115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aab22d8-f8a1-4924-8acb-44930a6de7d7
+      - 4ec833bd-0468-416f-b690-539e23252b6c
     status: 200 OK
     code: 200
     duration: ""
@@ -3291,10 +3126,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1ea2bdfb-58fc-44c4-90a9-1917908eb961
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/2a8753f2-8807-4d01-bd60-9863eec243f1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1ea2bdfb-58fc-44c4-90a9-1917908eb961","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"2a8753f2-8807-4d01-bd60-9863eec243f1","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3303,7 +3138,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:08 GMT
+      - Mon, 13 Nov 2023 14:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3313,12 +3148,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db6fc4bc-d83b-41f6-8dda-6bd56a5f2fea
+      - ca1404df-49b7-4a58-8566-42b1a402879e
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule-dedicated-8","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule-dedicated-8","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd"}'
     form: {}
     headers:
       Content-Type:
@@ -3329,7 +3164,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070371Z","created_at":"2023-11-10T13:21:09.134070371Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250399Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586043Z","created_at":"2023-11-13T14:00:52.342586043Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906441Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1524"
@@ -3338,7 +3173,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:09 GMT
+      - Mon, 13 Nov 2023 14:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3348,7 +3183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97afb1c4-6f0b-446a-85b2-8cbc59ca6c72
+      - 86071fd6-0f9c-4b86-a2c1-5062b5e5cf22
     status: 200 OK
     code: 200
     duration: ""
@@ -3359,10 +3194,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3371,7 +3206,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:09 GMT
+      - Mon, 13 Nov 2023 14:00:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3381,7 +3216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d7c765c-d289-44e4-96f9-07d78f3d9bac
+      - 1972f000-7c2b-4bf8-bc81-d648e0916e38
     status: 200 OK
     code: 200
     duration: ""
@@ -3392,10 +3227,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3404,7 +3239,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:14 GMT
+      - Mon, 13 Nov 2023 14:00:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3414,7 +3249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a04db758-f426-4cbd-ad28-f66283b12a37
+      - 86c94443-cec9-412a-b0d1-e821e1e5a5d9
     status: 200 OK
     code: 200
     duration: ""
@@ -3425,10 +3260,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3437,7 +3272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:19 GMT
+      - Mon, 13 Nov 2023 14:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3447,7 +3282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdf5ca20-76bc-41be-8cb0-90a09e937057
+      - f2387073-a6ca-48b0-b1a3-f51a6576467f
     status: 200 OK
     code: 200
     duration: ""
@@ -3458,10 +3293,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3470,7 +3305,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:24 GMT
+      - Mon, 13 Nov 2023 14:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3480,7 +3315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35c98251-d266-4a26-8f9e-abaf5ae98467
+      - fe02c1e7-42e7-4057-a5e6-d2fc44cafab1
     status: 200 OK
     code: 200
     duration: ""
@@ -3491,10 +3326,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3503,7 +3338,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:29 GMT
+      - Mon, 13 Nov 2023 14:01:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3513,7 +3348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fae860d-5bc0-449f-9931-aa2b7a12a6d0
+      - 39da2c0e-7772-4b12-bb28-91057e0a0390
     status: 200 OK
     code: 200
     duration: ""
@@ -3524,10 +3359,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3536,7 +3371,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:34 GMT
+      - Mon, 13 Nov 2023 14:01:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3546,7 +3381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74795e1e-36cb-43e8-8e2f-81c5840ef1b8
+      - 3c1de1f1-51d8-480f-bbb9-552572814986
     status: 200 OK
     code: 200
     duration: ""
@@ -3557,10 +3392,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3569,7 +3404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:39 GMT
+      - Mon, 13 Nov 2023 14:01:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3579,7 +3414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64ef6147-ded3-405a-a52d-6d06d99d201f
+      - 49f283e1-35dd-41ce-bb8e-db5f9e4d74f7
     status: 200 OK
     code: 200
     duration: ""
@@ -3590,10 +3425,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3602,7 +3437,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:44 GMT
+      - Mon, 13 Nov 2023 14:01:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3612,7 +3447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 920f7d9a-762c-4577-85ba-a6ee0651bb0e
+      - 6ee3c49e-f992-426b-9730-fbf0e82784ac
     status: 200 OK
     code: 200
     duration: ""
@@ -3623,10 +3458,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3635,7 +3470,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:49 GMT
+      - Mon, 13 Nov 2023 14:01:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3645,7 +3480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4e7c313-782f-4f94-8687-97e4f81ecde8
+      - b0093d40-0b48-48d0-9908-01e2e078e512
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,10 +3491,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3668,7 +3503,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:54 GMT
+      - Mon, 13 Nov 2023 14:01:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3678,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfcf2245-1161-41b1-bb7c-fdfa4fe86026
+      - a75839bf-3f23-4f39-87cf-1900e1eb654c
     status: 200 OK
     code: 200
     duration: ""
@@ -3689,10 +3524,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3701,7 +3536,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:21:59 GMT
+      - Mon, 13 Nov 2023 14:01:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3711,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e4e5a40-47b0-4d3d-902b-79f6a946c91a
+      - 53a5cbd2-4ab2-4f52-ac02-2e4135042202
     status: 200 OK
     code: 200
     duration: ""
@@ -3722,10 +3557,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:21:09.150250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -3734,7 +3569,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:04 GMT
+      - Mon, 13 Nov 2023 14:01:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3744,7 +3579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45ffd5ed-ace7-4726-a07e-f0c7814ea52e
+      - d9d94667-e55f-490f-8acc-b41967a9c707
     status: 200 OK
     code: 200
     duration: ""
@@ -3755,10 +3590,439 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af364831-f17c-4510-b0b3-66350b6b6ba7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:01:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a2d1a98a-efae-4efd-8434-611db50a4867
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4201569e-87e1-4efe-aedf-e228ebc452db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 48bf6963-71a8-4b9c-a456-688214d97029
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 678c7861-3b38-4b89-92bd-02b034a4717a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77d56859-92f4-4617-8162-9d4738f81f6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 65d42ac7-eb84-48ee-930a-8f62c866cac9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 96306268-4521-4d9b-bd9c-6f803ef2b36f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 29f6bf0f-4699-453c-8f02-c73543f9bbc8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6271c504-6520-4d01-bb20-343ae11ab4d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c186a2f-7cdb-4db3-a656-4beded0b7cf9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e0cd5fdc-89f1-46fb-b2f4-581f1093e424
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:00:52.364906Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1515"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:02:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ef54910e-8b35-4574-8525-5729cd55fd97
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:02:55.843356Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -3767,7 +4031,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:09 GMT
+      - Mon, 13 Nov 2023 14:02:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3777,7 +4041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b267d733-14a2-448a-9fc3-c07c265c7b66
+      - 5549060d-2d55-46a8-8f0e-890f65d46626
     status: 200 OK
     code: 200
     duration: ""
@@ -3788,10 +4052,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:02:55.843356Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -3800,7 +4064,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:02:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3810,7 +4074,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fe7e075-19bc-455e-ba18-0872d16eb4d5
+      - c2af8eb4-1ef1-4fc8-816e-cf89992374ea
     status: 200 OK
     code: 200
     duration: ""
@@ -3821,10 +4085,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BGZUUxR2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtWNFRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNOM0NtTmtNR0UxUkhOSFVFUXJlVUZhYzJ4V1ZIQkdiMm81ZEVab2IzY3hTSFJsYlVOd05VZEZSV3hZUlRaVFdGTXlaME5QUXk4eGIweEZUWEJYZDJsTmNWTUtVbXcxTVZKNlJVVkJTMFYzZVRSRlUwWkNjMVJpUzI5M1pHaFBNMUUyYVdoVlpYUktTR2hhUzJGYU4wVjNTRzl2ZDJrdmIzQnZVakoyV0dKd09IUXZkQXA1V1RGUFRtVnNXVkZCTm1SaVkxbDVjMGt4T1VGRmQySjZlVTlRWkdKWGNqUmpNM2MxVEhSamRrdENUMkkyYUdSSVMwY3piRXR5UTJKRFVFaDBXa2RQQ2pSRU0xbzFWM1l6U2tSdFFYSkNaMDVJVm1GTmNHWkxla281YnpGYU0ydE9LM2MxYjB0YVIyOURkRTlLY0dwbWFVb3ZZMlp5ZWtnNWEzQldRVTVqTTNnS1ZUaE1XVVE1VW1RNWFHdHpPVzFKYUZnNGVuTjZOWHBpYkUxRVRuWjBTV2hQT0RZeVNGUXZlVGRtZFRKUVoycDNWelU0YW1SRVRuVkJaVU5xVTB0cVV3cE1UbWxPVVVNNVVVRkJTV2hLYkVoMVNYQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBRVmQxYnpGeE9EVldTMUpXVWl0ME5qZFVOMVJzTVV4RFFrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSbVI2Ym1oYVNGWTBNbVEwZFZOWE1XSmtVMDB5YzIxTFVHUTFZMWd6YUVoa1pqVkhVbTlaZEV4eFJsVnBlVkV6ZHdwbVJrMUxPRnBaVGtKU2IxTjVjM0ZpYkRsb1RXNTRNR1JPY3pkcGIzQTVjRVJ4VlRKdmJ6aG5lbHBQTUdvemJXNDRiR1JhU3pacWNpdE9UVlZGWlhCaUNrbGtTV3BCUmtFeWN6Uk1hVFUwWWtSa2NrVmFSWEZWUlU0ck1qSTVTVkp0ZERsNWFrNDNjWGR6UjNKUE1EbDZVRXhZVDJSalJVZDJhamRLVlhkMWNEVUtSa3hCUldjMFNYRnBSRnBRUjFkTlVpOXZla05aVlRoc0wzQkVWbFowUWs0d1JEVnVSVGhHU1ZOM2RqbG5heTl4Y0ZWb1lreEJVRlJsVFVablExQnFTQXB5YVROcEswcGlUVmR2T1VsUmMzUTFXV3RDVjJFM2NtNDBkekJDVkZONEszYzVNa1ZxZEhOUWFFRkRTelZUY25GcFQzRXpLMXBTY2xoTVZtRXpiMnh1Q2xoWlNucFlOR1pFVlVjM2VWZHFOVEJoVVhac09IRnpRak50TWl0S1QwRk1ZWEZCU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzM3ZTUzOGIxLTg0OGMtNDMxYi05ZjdmLTgwMzU3YTVmNDhiMi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxcG1KZlFaQzN2Tkt1T3BodlpGMWNKV2UwSlNZVnExTnFKYlA0TFg0YWRZMWRqTXJTYVRpUUtCQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJCTVUweGIxaEVWRTE2VFZSRmVFMXFSVEJOUkVFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVWMkNtcGhiVTl1YjNZckwwaHpZbUZrWTBJNFpHaHJTVWRyVjJKVGVUTmpWbTlRVjFWcE5tSnVNbEYwVkhsM1lqbHRNVzF6Wm10c1FYTkdkU3RXY1dwSWQyTUtlRFZKYkZOMmNuSkJhM2wyZEd0a2JVaFFOakJMVFZkcGJIWkJjbHBOZGt0TGFrOWpPUzlOWXpSRWVUTjBObWMzVFc5Ull6RmxTbEpUTDBSU1VFRkpSUXBHY2pNNVp6SjVWMHB6VmxkUlkzTnRXbU42VFZwNVRFTkdRMDFWU0RkalNGWnZaMkl4V21FdmEydzVVbmxoVlZSamFWbHpVRUZvYmtOVlduZHhjV1JIQ25kdVptTnpRWFpVUWtWQ1lsaHZWVWM1TUZNMFdGbENLMDVZU2s1TVRXWlFWVE12VDNjeVRqTkZlREpxWkU1aWVrcHlaVkptUm1OcWNsTTJkMDl4ZEc4S2VYQmlOVzlPUjJOUWFpdE1ZM0JaZVhFMFIxZ3pNVGhPZEdrNGJtSkpaRk01VDNkNmVrTnJZbVY2VEZwSk1VNVljMVl4T0hsREwyVnVXa1ZxUlhVeFZ3cHJjalZuVVM5RE1HMXhlbTVGVms1UVJGTXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk5ORFF2YjBRNFFVdFVjVkZHZEZWNE9XMDJjakpTU0UxQmRIQk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNTMjh6Y1VOck5tazBXWEY2ZW5SR1VIWjVLelJRTlZCUVVWTmhjakpIVVN0dVFTdFBjalppUlN0eFVtZGtVVEpvU3dwcGFFRXJRMGRDVVV0bGMyeFJTRUZ3VmtkVlZYY3JNV05HU1M5WVYxSnphalZzYWxKNVVESTFNM2w2SzNaclEwUndVVnBCVkZkU1NWUXpOR1JsYkRKSUNtMWxkVEJLV1ZSeGJUTlZVRkJ6WTBjM2MyNHdlRTVNVkZaWmF6azFaWFZTWmxWMlR5czFhWEp5ZG5weVJrZEdSVEJGZWxVd2FtbG1TMFJtTWtOVGNFY0tVVkF3VVVab1NFaEpZVnBUYlZoTmFuUmxkWGRuZUROdFpUZHJORTFRTjBGNldsZHJWbU5YYzNKUFoyUkVlbWR1V1c4eWRIVldiekUyVjJGd2NVSnFTQXByY1RoS01YSm9VVE4wVFdsWFVVZHBUV1V4VlRWaFpXOXZabWxRV1dKS05XOHlOa00wT0RKclZucDBlVzl0VG5oaVJERnJhSGRFU0ZJM1ltRjJSSEJYQ2s5QlUyUXdVM0JYTDJZd1RWYzBXalpXYW1KbFIzUmpaRE01V21jeFpUbDBXbkV2THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2QxZDhiYTA3LTY0ZTYtNDNmMC1iMWVjLWU3OTRiYzY3YWU3Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKV01xaHA0eTFmeDJXYk1qR2RHU1F5OXRQNjIzSlZtRVRsdFBrYm14Y2VMY2k2amMwNVh2ZXhZNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -3833,7 +4097,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:03:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3843,7 +4107,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15a0637a-e3f8-4f45-b53c-9c7fb9263561
+      - 96ca1f27-d238-4a95-8aa6-49bc013d4cec
     status: 200 OK
     code: 200
     duration: ""
@@ -3854,10 +4118,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:02:55.843356Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -3866,7 +4130,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:03:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3876,7 +4140,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6cb304e-2240-47ba-b6a8-ab8741638871
+      - 9720e9e1-0db3-456b-b96a-5ce3bdeb844d
     status: 200 OK
     code: 200
     duration: ""
@@ -3887,10 +4151,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -3899,7 +4163,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:03:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3909,7 +4173,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0d7cf5e-48a4-4ed2-8005-8d891a63d45a
+      - 9570c4c4-12fc-474d-8e3e-accaacc93ab9
     status: 200 OK
     code: 200
     duration: ""
@@ -3920,10 +4184,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:02:55.843356Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1512"
@@ -3932,7 +4196,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:03:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3942,7 +4206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3306a50a-2469-4af8-8c53-4660a9364a58
+      - 51913cd7-7599-47c2-a303-842247783982
     status: 200 OK
     code: 200
     duration: ""
@@ -3953,10 +4217,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BGZUUxR2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtWNFRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNOM0NtTmtNR0UxUkhOSFVFUXJlVUZhYzJ4V1ZIQkdiMm81ZEVab2IzY3hTSFJsYlVOd05VZEZSV3hZUlRaVFdGTXlaME5QUXk4eGIweEZUWEJYZDJsTmNWTUtVbXcxTVZKNlJVVkJTMFYzZVRSRlUwWkNjMVJpUzI5M1pHaFBNMUUyYVdoVlpYUktTR2hhUzJGYU4wVjNTRzl2ZDJrdmIzQnZVakoyV0dKd09IUXZkQXA1V1RGUFRtVnNXVkZCTm1SaVkxbDVjMGt4T1VGRmQySjZlVTlRWkdKWGNqUmpNM2MxVEhSamRrdENUMkkyYUdSSVMwY3piRXR5UTJKRFVFaDBXa2RQQ2pSRU0xbzFWM1l6U2tSdFFYSkNaMDVJVm1GTmNHWkxla281YnpGYU0ydE9LM2MxYjB0YVIyOURkRTlLY0dwbWFVb3ZZMlp5ZWtnNWEzQldRVTVqTTNnS1ZUaE1XVVE1VW1RNWFHdHpPVzFKYUZnNGVuTjZOWHBpYkUxRVRuWjBTV2hQT0RZeVNGUXZlVGRtZFRKUVoycDNWelU0YW1SRVRuVkJaVU5xVTB0cVV3cE1UbWxPVVVNNVVVRkJTV2hLYkVoMVNYQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBRVmQxYnpGeE9EVldTMUpXVWl0ME5qZFVOMVJzTVV4RFFrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSbVI2Ym1oYVNGWTBNbVEwZFZOWE1XSmtVMDB5YzIxTFVHUTFZMWd6YUVoa1pqVkhVbTlaZEV4eFJsVnBlVkV6ZHdwbVJrMUxPRnBaVGtKU2IxTjVjM0ZpYkRsb1RXNTRNR1JPY3pkcGIzQTVjRVJ4VlRKdmJ6aG5lbHBQTUdvemJXNDRiR1JhU3pacWNpdE9UVlZGWlhCaUNrbGtTV3BCUmtFeWN6Uk1hVFUwWWtSa2NrVmFSWEZWUlU0ck1qSTVTVkp0ZERsNWFrNDNjWGR6UjNKUE1EbDZVRXhZVDJSalJVZDJhamRLVlhkMWNEVUtSa3hCUldjMFNYRnBSRnBRUjFkTlVpOXZla05aVlRoc0wzQkVWbFowUWs0d1JEVnVSVGhHU1ZOM2RqbG5heTl4Y0ZWb1lreEJVRlJsVFVablExQnFTQXB5YVROcEswcGlUVmR2T1VsUmMzUTFXV3RDVjJFM2NtNDBkekJDVkZONEszYzVNa1ZxZEhOUWFFRkRTelZUY25GcFQzRXpLMXBTY2xoTVZtRXpiMnh1Q2xoWlNucFlOR1pFVlVjM2VWZHFOVEJoVVhac09IRnpRak50TWl0S1QwRk1ZWEZCU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzM3ZTUzOGIxLTg0OGMtNDMxYi05ZjdmLTgwMzU3YTVmNDhiMi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxcG1KZlFaQzN2Tkt1T3BodlpGMWNKV2UwSlNZVnExTnFKYlA0TFg0YWRZMWRqTXJTYVRpUUtCQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJCTVUweGIxaEVWRTE2VFZSRmVFMXFSVEJOUkVFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVWMkNtcGhiVTl1YjNZckwwaHpZbUZrWTBJNFpHaHJTVWRyVjJKVGVUTmpWbTlRVjFWcE5tSnVNbEYwVkhsM1lqbHRNVzF6Wm10c1FYTkdkU3RXY1dwSWQyTUtlRFZKYkZOMmNuSkJhM2wyZEd0a2JVaFFOakJMVFZkcGJIWkJjbHBOZGt0TGFrOWpPUzlOWXpSRWVUTjBObWMzVFc5Ull6RmxTbEpUTDBSU1VFRkpSUXBHY2pNNVp6SjVWMHB6VmxkUlkzTnRXbU42VFZwNVRFTkdRMDFWU0RkalNGWnZaMkl4V21FdmEydzVVbmxoVlZSamFWbHpVRUZvYmtOVlduZHhjV1JIQ25kdVptTnpRWFpVUWtWQ1lsaHZWVWM1TUZNMFdGbENLMDVZU2s1TVRXWlFWVE12VDNjeVRqTkZlREpxWkU1aWVrcHlaVkptUm1OcWNsTTJkMDl4ZEc4S2VYQmlOVzlPUjJOUWFpdE1ZM0JaZVhFMFIxZ3pNVGhPZEdrNGJtSkpaRk01VDNkNmVrTnJZbVY2VEZwSk1VNVljMVl4T0hsREwyVnVXa1ZxUlhVeFZ3cHJjalZuVVM5RE1HMXhlbTVGVms1UVJGTXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk5ORFF2YjBRNFFVdFVjVkZHZEZWNE9XMDJjakpTU0UxQmRIQk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNTMjh6Y1VOck5tazBXWEY2ZW5SR1VIWjVLelJRTlZCUVVWTmhjakpIVVN0dVFTdFBjalppUlN0eFVtZGtVVEpvU3dwcGFFRXJRMGRDVVV0bGMyeFJTRUZ3VmtkVlZYY3JNV05HU1M5WVYxSnphalZzYWxKNVVESTFNM2w2SzNaclEwUndVVnBCVkZkU1NWUXpOR1JsYkRKSUNtMWxkVEJLV1ZSeGJUTlZVRkJ6WTBjM2MyNHdlRTVNVkZaWmF6azFaWFZTWmxWMlR5czFhWEp5ZG5weVJrZEdSVEJGZWxVd2FtbG1TMFJtTWtOVGNFY0tVVkF3VVVab1NFaEpZVnBUYlZoTmFuUmxkWGRuZUROdFpUZHJORTFRTjBGNldsZHJWbU5YYzNKUFoyUkVlbWR1V1c4eWRIVldiekUyVjJGd2NVSnFTQXByY1RoS01YSm9VVE4wVFdsWFVVZHBUV1V4VlRWaFpXOXZabWxRV1dKS05XOHlOa00wT0RKclZucDBlVzl0VG5oaVJERnJhSGRFU0ZJM1ltRjJSSEJYQ2s5QlUyUXdVM0JYTDJZd1RWYzBXalpXYW1KbFIzUmpaRE01V21jeFpUbDBXbkV2THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2QxZDhiYTA3LTY0ZTYtNDNmMC1iMWVjLWU3OTRiYzY3YWU3Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKV01xaHA0eTFmeDJXYk1qR2RHU1F5OXRQNjIzSlZtRVRsdFBrYm14Y2VMY2k2amMwNVh2ZXhZNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -3965,7 +4229,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:10 GMT
+      - Mon, 13 Nov 2023 14:03:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3975,7 +4239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4af25f54-3b9f-443f-bf52-7a4c0d4110ea
+      - 67b2f8f4-d03c-400b-ad35-48f69383dfe9
     status: 200 OK
     code: 200
     duration: ""
@@ -3986,43 +4250,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:08.733456Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1512"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:22:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04e2789d-3591-49f0-af4c-dff3bb355344
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-10T13:16:56.368889Z","dhcp_enabled":true,"id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-10T13:16:56.368889Z","id":"bf3a45b9-732b-4ae1-95cb-2c5163854879","subnet":"172.16.28.0/22","updated_at":"2023-11-10T13:16:56.368889Z"},{"created_at":"2023-11-10T13:16:56.368889Z","id":"0769cbbc-0a1d-4876-97bb-ccdb1662ad93","subnet":"fd63:256c:45f7:66c7::/64","updated_at":"2023-11-10T13:16:56.368889Z"}],"tags":[],"updated_at":"2023-11-10T13:16:56.368889Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-13T13:56:59.589895Z","dhcp_enabled":true,"id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-13T13:56:59.589895Z","id":"7a77031e-2d81-4829-93ae-94df87978ef8","subnet":"172.16.40.0/22","updated_at":"2023-11-13T13:56:59.589895Z"},{"created_at":"2023-11-13T13:56:59.589895Z","id":"5ac956e8-e2da-4c52-acc2-c7479f856231","subnet":"fd63:256c:45f7:4861::/64","updated_at":"2023-11-13T13:56:59.589895Z"}],"tags":[],"updated_at":"2023-11-13T13:56:59.589895Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "717"
@@ -4031,7 +4262,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:11 GMT
+      - Mon, 13 Nov 2023 14:03:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4041,7 +4272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4caa878b-01fd-48c5-81d6-47d74ba6fda0
+      - 210e12d0-cf2e-4802-989b-fca1184e9c9b
     status: 200 OK
     code: 200
     duration: ""
@@ -4052,10 +4283,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BGZUUxR2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtWNFRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNOM0NtTmtNR0UxUkhOSFVFUXJlVUZhYzJ4V1ZIQkdiMm81ZEVab2IzY3hTSFJsYlVOd05VZEZSV3hZUlRaVFdGTXlaME5QUXk4eGIweEZUWEJYZDJsTmNWTUtVbXcxTVZKNlJVVkJTMFYzZVRSRlUwWkNjMVJpUzI5M1pHaFBNMUUyYVdoVlpYUktTR2hhUzJGYU4wVjNTRzl2ZDJrdmIzQnZVakoyV0dKd09IUXZkQXA1V1RGUFRtVnNXVkZCTm1SaVkxbDVjMGt4T1VGRmQySjZlVTlRWkdKWGNqUmpNM2MxVEhSamRrdENUMkkyYUdSSVMwY3piRXR5UTJKRFVFaDBXa2RQQ2pSRU0xbzFWM1l6U2tSdFFYSkNaMDVJVm1GTmNHWkxla281YnpGYU0ydE9LM2MxYjB0YVIyOURkRTlLY0dwbWFVb3ZZMlp5ZWtnNWEzQldRVTVqTTNnS1ZUaE1XVVE1VW1RNWFHdHpPVzFKYUZnNGVuTjZOWHBpYkUxRVRuWjBTV2hQT0RZeVNGUXZlVGRtZFRKUVoycDNWelU0YW1SRVRuVkJaVU5xVTB0cVV3cE1UbWxPVVVNNVVVRkJTV2hLYkVoMVNYQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBRVmQxYnpGeE9EVldTMUpXVWl0ME5qZFVOMVJzTVV4RFFrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSbVI2Ym1oYVNGWTBNbVEwZFZOWE1XSmtVMDB5YzIxTFVHUTFZMWd6YUVoa1pqVkhVbTlaZEV4eFJsVnBlVkV6ZHdwbVJrMUxPRnBaVGtKU2IxTjVjM0ZpYkRsb1RXNTRNR1JPY3pkcGIzQTVjRVJ4VlRKdmJ6aG5lbHBQTUdvemJXNDRiR1JhU3pacWNpdE9UVlZGWlhCaUNrbGtTV3BCUmtFeWN6Uk1hVFUwWWtSa2NrVmFSWEZWUlU0ck1qSTVTVkp0ZERsNWFrNDNjWGR6UjNKUE1EbDZVRXhZVDJSalJVZDJhamRLVlhkMWNEVUtSa3hCUldjMFNYRnBSRnBRUjFkTlVpOXZla05aVlRoc0wzQkVWbFowUWs0d1JEVnVSVGhHU1ZOM2RqbG5heTl4Y0ZWb1lreEJVRlJsVFVablExQnFTQXB5YVROcEswcGlUVmR2T1VsUmMzUTFXV3RDVjJFM2NtNDBkekJDVkZONEszYzVNa1ZxZEhOUWFFRkRTelZUY25GcFQzRXpLMXBTY2xoTVZtRXpiMnh1Q2xoWlNucFlOR1pFVlVjM2VWZHFOVEJoVVhac09IRnpRak50TWl0S1QwRk1ZWEZCU1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzM3ZTUzOGIxLTg0OGMtNDMxYi05ZjdmLTgwMzU3YTVmNDhiMi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBxcG1KZlFaQzN2Tkt1T3BodlpGMWNKV2UwSlNZVnExTnFKYlA0TFg0YWRZMWRqTXJTYVRpUUtCQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:02:55.843356Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1512"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:03:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8878853-1abb-4a57-93f4-30986d434630
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJCTVUweGIxaEVWRTE2VFZSRmVFMXFSVEJOUkVFeFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVWMkNtcGhiVTl1YjNZckwwaHpZbUZrWTBJNFpHaHJTVWRyVjJKVGVUTmpWbTlRVjFWcE5tSnVNbEYwVkhsM1lqbHRNVzF6Wm10c1FYTkdkU3RXY1dwSWQyTUtlRFZKYkZOMmNuSkJhM2wyZEd0a2JVaFFOakJMVFZkcGJIWkJjbHBOZGt0TGFrOWpPUzlOWXpSRWVUTjBObWMzVFc5Ull6RmxTbEpUTDBSU1VFRkpSUXBHY2pNNVp6SjVWMHB6VmxkUlkzTnRXbU42VFZwNVRFTkdRMDFWU0RkalNGWnZaMkl4V21FdmEydzVVbmxoVlZSamFWbHpVRUZvYmtOVlduZHhjV1JIQ25kdVptTnpRWFpVUWtWQ1lsaHZWVWM1TUZNMFdGbENLMDVZU2s1TVRXWlFWVE12VDNjeVRqTkZlREpxWkU1aWVrcHlaVkptUm1OcWNsTTJkMDl4ZEc4S2VYQmlOVzlPUjJOUWFpdE1ZM0JaZVhFMFIxZ3pNVGhPZEdrNGJtSkpaRk01VDNkNmVrTnJZbVY2VEZwSk1VNVljMVl4T0hsREwyVnVXa1ZxUlhVeFZ3cHJjalZuVVM5RE1HMXhlbTVGVms1UVJGTXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk5ORFF2YjBRNFFVdFVjVkZHZEZWNE9XMDJjakpTU0UxQmRIQk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNTMjh6Y1VOck5tazBXWEY2ZW5SR1VIWjVLelJRTlZCUVVWTmhjakpIVVN0dVFTdFBjalppUlN0eFVtZGtVVEpvU3dwcGFFRXJRMGRDVVV0bGMyeFJTRUZ3VmtkVlZYY3JNV05HU1M5WVYxSnphalZzYWxKNVVESTFNM2w2SzNaclEwUndVVnBCVkZkU1NWUXpOR1JsYkRKSUNtMWxkVEJLV1ZSeGJUTlZVRkJ6WTBjM2MyNHdlRTVNVkZaWmF6azFaWFZTWmxWMlR5czFhWEp5ZG5weVJrZEdSVEJGZWxVd2FtbG1TMFJtTWtOVGNFY0tVVkF3VVVab1NFaEpZVnBUYlZoTmFuUmxkWGRuZUROdFpUZHJORTFRTjBGNldsZHJWbU5YYzNKUFoyUkVlbWR1V1c4eWRIVldiekUyVjJGd2NVSnFTQXByY1RoS01YSm9VVE4wVFdsWFVVZHBUV1V4VlRWaFpXOXZabWxRV1dKS05XOHlOa00wT0RKclZucDBlVzl0VG5oaVJERnJhSGRFU0ZJM1ltRjJSSEJYQ2s5QlUyUXdVM0JYTDJZd1RWYzBXalpXYW1KbFIzUmpaRE01V21jeFpUbDBXbkV2THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2QxZDhiYTA3LTY0ZTYtNDNmMC1iMWVjLWU3OTRiYzY3YWU3Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKV01xaHA0eTFmeDJXYk1qR2RHU1F5OXRQNjIzSlZtRVRsdFBrYm14Y2VMY2k2amMwNVh2ZXhZNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -4064,7 +4328,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:11 GMT
+      - Mon, 13 Nov 2023 14:03:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4074,7 +4338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 537c9c50-3eee-4f25-b827-4b52e0c7dded
+      - 06e1343f-aa91-474f-ad3f-90460b1f0b24
     status: 200 OK
     code: 200
     duration: ""
@@ -4085,7 +4349,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
@@ -4097,7 +4361,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:11 GMT
+      - Mon, 13 Nov 2023 14:03:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4107,7 +4371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18c9f76b-9fd5-405e-9741-7b4a6230d1f8
+      - 75c93892-1779-48c7-b960-458a4a2b4074
     status: 200 OK
     code: 200
     duration: ""
@@ -4118,7 +4382,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
@@ -4130,7 +4394,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:11 GMT
+      - Mon, 13 Nov 2023 14:03:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4140,7 +4404,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 808e89f9-60da-4e64-849e-a2531c0d90e4
+      - dc6b47fa-b3ab-4eb4-8c44-c51d81f8bc5a
     status: 200 OK
     code: 200
     duration: ""
@@ -4151,10 +4415,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:11.878466983Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:03:04.086654565Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1518"
@@ -4163,7 +4427,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:11 GMT
+      - Mon, 13 Nov 2023 14:03:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4173,7 +4437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b32d8bcb-99e4-446c-9cf8-cf8d1962ce5a
+      - 61338b2b-5c95-433c-9a0b-b58ee98fafcf
     status: 200 OK
     code: 200
     duration: ""
@@ -4184,10 +4448,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:11.878467Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:03:04.086655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -4196,7 +4460,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:11 GMT
+      - Mon, 13 Nov 2023 14:03:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4206,7 +4470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4674f4e8-a454-4a28-a802-d8b47df979c8
+      - 74fc363e-1335-40f9-ba2a-cc1075ccfbc3
     status: 200 OK
     code: 200
     duration: ""
@@ -4217,10 +4481,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://37e538b1-848c-431b-9f7f-80357a5f48b2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-10T13:21:09.134070Z","created_at":"2023-11-10T13:21:09.134070Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.37e538b1-848c-431b-9f7f-80357a5f48b2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"37e538b1-848c-431b-9f7f-80357a5f48b2","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"60e0b46f-f200-4645-ae6b-e8f8f4be54d2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-10T13:22:11.878467Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-13T14:00:52.342586Z","created_at":"2023-11-13T14:00:52.342586Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-13T14:03:04.086655Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1515"
@@ -4229,7 +4493,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:17 GMT
+      - Mon, 13 Nov 2023 14:03:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4239,7 +4503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bec5225-23ca-4ed5-9820-2288fb3925da
+      - 0a4e3a05-9554-45ec-a1c5-d4c7913ba3e8
     status: 200 OK
     code: 200
     duration: ""
@@ -4250,10 +4514,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/37e538b1-848c-431b-9f7f-80357a5f48b2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"37e538b1-848c-431b-9f7f-80357a5f48b2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d1d8ba07-64e6-43f0-b1ec-e794bc67ae7c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4262,7 +4526,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:03:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4272,7 +4536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bf19426-f460-4309-b1de-5bb0ea7d6f5c
+      - 14649177-d6e2-40b2-b2b9-810b29b73037
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4283,7 +4547,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/60e0b46f-f200-4645-ae6b-e8f8f4be54d2
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c7b367a2-b98a-4471-8fc4-8ed9cf4b84bd
     method: DELETE
   response:
     body: ""
@@ -4293,7 +4557,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:03:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4303,7 +4567,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c4356e0-ac48-4ae3-94c0-e968be6e6509
+      - 1db70aab-87bf-46cf-ad3c-74fcbe850be3
     status: 204 No Content
     code: 204
     duration: ""
@@ -4319,7 +4583,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680640592Z","created_at":"2023-11-10T13:22:22.680640592Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250226Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312333Z","created_at":"2023-11-13T14:03:15.115312333Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118166Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1491"
@@ -4328,7 +4592,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:03:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4338,7 +4602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44e9dec4-e44d-4cf8-96d5-67b17f478163
+      - 84bcf04f-e1af-46c2-a9b6-6159dea2d66a
     status: 200 OK
     code: 200
     duration: ""
@@ -4349,10 +4613,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4361,7 +4625,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:22 GMT
+      - Mon, 13 Nov 2023 14:03:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4371,7 +4635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e93017b9-d23a-4523-8d37-b97c881da288
+      - ec940f5c-df16-4bc2-a975-1d5f61dc01ae
     status: 200 OK
     code: 200
     duration: ""
@@ -4382,10 +4646,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4394,7 +4658,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:27 GMT
+      - Mon, 13 Nov 2023 14:03:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4404,7 +4668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4f8799b-e0ed-423a-9c25-6fec3e525e73
+      - a125072d-3b54-46ae-a62b-e717e83b6068
     status: 200 OK
     code: 200
     duration: ""
@@ -4415,10 +4679,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4427,7 +4691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:32 GMT
+      - Mon, 13 Nov 2023 14:03:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4437,7 +4701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e104b9b-d516-4414-a4ac-079d4509491d
+      - f616261a-8cdd-4ad8-ba2b-b98d73453338
     status: 200 OK
     code: 200
     duration: ""
@@ -4448,10 +4712,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4460,7 +4724,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:37 GMT
+      - Mon, 13 Nov 2023 14:03:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4470,7 +4734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3750b7cb-450b-496e-a976-5b18351bb55f
+      - b5ab6e15-8859-4a21-9932-c9c12f4f2b7d
     status: 200 OK
     code: 200
     duration: ""
@@ -4481,10 +4745,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4493,7 +4757,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:42 GMT
+      - Mon, 13 Nov 2023 14:03:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4503,7 +4767,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6484a103-16d7-4c74-b0f5-57cbe544d579
+      - 1ce54390-cf61-43e1-9409-3c14279bd55a
     status: 200 OK
     code: 200
     duration: ""
@@ -4514,10 +4778,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4526,7 +4790,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:48 GMT
+      - Mon, 13 Nov 2023 14:03:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4536,7 +4800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0f009d8-c57c-4d39-8b75-4c53833564d3
+      - 7de59017-19fd-46f7-9723-7657c88a3ea4
     status: 200 OK
     code: 200
     duration: ""
@@ -4547,10 +4811,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4559,7 +4823,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:53 GMT
+      - Mon, 13 Nov 2023 14:03:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4569,7 +4833,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a1c9e97-3c8f-4e61-9873-798c7942f8f6
+      - 2363078b-31f0-4920-9265-c2075b9a60c6
     status: 200 OK
     code: 200
     duration: ""
@@ -4580,10 +4844,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4592,7 +4856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:22:58 GMT
+      - Mon, 13 Nov 2023 14:03:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4602,7 +4866,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d652fdc-e4e6-412f-b56d-b5b65eaed7b1
+      - 2b256d0f-8b11-496a-b553-a100912e057a
     status: 200 OK
     code: 200
     duration: ""
@@ -4613,10 +4877,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4625,7 +4889,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:03 GMT
+      - Mon, 13 Nov 2023 14:03:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4635,7 +4899,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 895200f2-650a-45cf-bd1e-cdfa260f7e58
+      - a1348119-4818-44d4-b37b-759cb6c84b70
     status: 200 OK
     code: 200
     duration: ""
@@ -4646,10 +4910,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4658,7 +4922,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:08 GMT
+      - Mon, 13 Nov 2023 14:04:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4668,7 +4932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7816ab22-7f89-4576-a5ab-f0bfeeb3e77e
+      - ec51473b-e5c0-45da-aeea-b3901b04354a
     status: 200 OK
     code: 200
     duration: ""
@@ -4679,10 +4943,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4691,7 +4955,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:13 GMT
+      - Mon, 13 Nov 2023 14:04:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4701,7 +4965,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c03f30e-4cdf-47ee-bd04-88f0b7ec3b8a
+      - b324caca-9513-461f-bc08-923f81e09ceb
     status: 200 OK
     code: 200
     duration: ""
@@ -4712,10 +4976,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4724,7 +4988,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:18 GMT
+      - Mon, 13 Nov 2023 14:04:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4734,7 +4998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b630a1b0-76da-4c50-a969-9d3774ffad46
+      - cb4725c5-643e-44fe-a40c-425423182909
     status: 200 OK
     code: 200
     duration: ""
@@ -4745,10 +5009,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4757,7 +5021,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:23 GMT
+      - Mon, 13 Nov 2023 14:04:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4767,7 +5031,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91a3222a-eb6b-42b1-b84d-dae61ca7e16d
+      - e6c04b88-8624-4230-91ef-837082e5c462
     status: 200 OK
     code: 200
     duration: ""
@@ -4778,10 +5042,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4790,7 +5054,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:28 GMT
+      - Mon, 13 Nov 2023 14:04:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4800,7 +5064,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84c3239f-9e26-41e9-877a-ee6f589a302b
+      - 9bda90ab-23df-4a50-b90c-2521bff2eba3
     status: 200 OK
     code: 200
     duration: ""
@@ -4811,10 +5075,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4823,7 +5087,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:33 GMT
+      - Mon, 13 Nov 2023 14:04:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4833,7 +5097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3df24bd-2680-4bf1-9375-090177a1361e
+      - 088a79b4-62d1-4460-a8c8-43d728f8e3af
     status: 200 OK
     code: 200
     duration: ""
@@ -4844,10 +5108,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:22:22.692250Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:03:15.126118Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -4856,7 +5120,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:38 GMT
+      - Mon, 13 Nov 2023 14:04:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4866,7 +5130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 976b568b-198b-47b7-ac8a-e85f63a35818
+      - 0f34643e-80b5-40b2-b277-3f751bc3f837
     status: 200 OK
     code: 200
     duration: ""
@@ -4877,10 +5141,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:04:35.358499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -4889,7 +5153,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:43 GMT
+      - Mon, 13 Nov 2023 14:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4899,7 +5163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31ba0c13-7b74-433f-af67-930418d668a8
+      - 7ed63f58-6021-4f14-931b-ac5535f7f6b4
     status: 200 OK
     code: 200
     duration: ""
@@ -4910,10 +5174,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:04:35.358499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -4922,7 +5186,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:43 GMT
+      - Mon, 13 Nov 2023 14:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4932,7 +5196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7df81a85-8c7f-4398-9e51-f90b02f55976
+      - 35023c37-56ba-45ac-851c-32325df8b060
     status: 200 OK
     code: 200
     duration: ""
@@ -4943,10 +5207,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJOZUU1c2IxaEVWRTE2VFZSRmVFMXFSVEJOUkUxNFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxGeUNrVktUSE5vVTJSdFRuTnhjVzE0TUdKbGIxZ3dRVkkyUnk5TVVVWmpTMHAzYkVJNU5UTjZlRzFsT1VoVFptVjBabEY1UzJabVZESnVNVk5DWTFwbFExSUtiakJLTDB0bFJEUmFSMk5GY2xoWFN6ZHhXVkZJVlhBMVZXeEhkMkp3YWxGaVdWRnplWGxqY1VSQ1dHdFlOR1VyVVZZck9EZGFURk5wVjJsbWVVTlJTQXBDU3pCU2VVNU1LMEprVkhac2Rua3hPVUY0TUZZclFuRXJTRnBqVGt4aWVsQlRhV3RJUkdvNE5VRnpkR3M1UWsxd09UZFVkbTV1V21SREsycHZOa2RwQ2tabGMyTm9jV2hNTVhrNWNrRXdUM0J1UVhjMWMwMXhTMmt2VkdKSk1HTkJWa0Z0WnpoS1JtbFVNV1kzUjNGeGRDdHBZVWxHUldwM2Vrd3lZbmQ0UTBvS2FuaHdObGQ1ZDJJM2JIbDVZV3RuUkhWbU1WRnRZa3RpUlV4a1FrMDFWR1JoYWtZNFZrcFNTbmRQYTFoRFEzRmhWek0xZVhabWRDdHdZelZPVGxabk1Rb3dWWFIxZW1aUmRrZEJPRmRCVkcxRmNFNXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9NazFNUnpaWVExSkJRVmRVZWtoTmNYQXpkRVU1U0cxVlNsaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaR3BVYlhKSlMyeERNbGxHT0doNWVrbzBXbWd6VkZGMGRXdHFPVzVtVlRSM2NucFJVR1k0U25CelJsbEJPRlJsV2dweFZWUjBMelVyT1ZsRWVIbEpOSGszV0dKWlJqVjFjakkwYkVobVVrMDBlVlEzWlVWbE9GcGxUM0o2VkZWdWEybzBWRmhRV0dacWJHWnFiV3BvYm10WkNtUnNiblJSTjFOdk5uaGlkWEJHYUVZek5sSldSSHBuTVRCWloxUTJRblF5Tld0WGVsQlJVblExYTFFeFpYTnlaR1ZhSzNkd1EzZHVWSFJDUzBGaFZ6QUtVblY2VEhkMVNtdFRhRE5JUmpoVmVETTNUVkI2Tmpad2RVNVNUV0pHWmtWWFIzQnVPVWs0TWpRM2RVVldTMU53ZWxoWmRreHRja2xXT1hnM2JrbHNWd3AyWkVaclIzRktRMmxQYlhSMFREYzVNbTg1UW5Oa1MycDRTVWxEVTBrd2NUVTRUa2x3WkZsVFpFVldNVWhCV1RodmMyZGtXbEZMYjNSblFVWlhaU3QzQ2xrM2QybE5TelpWV1dkMmFVSjBUM3AwT0V4WFpFVmtlbG92UjFkclJ5OVFabXA2TUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzE3ZTAyNjQ2LTFmNDYtNGYwNS04YzhkLWE0MDJmODAyZGU1Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbWxSWVZ2ZzhQbW1rZ1MzbWRZUWJiTnkwYXM3M0gycVVNcGJpbXVyQVRxNktIMm9EMkV3NGRPTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -4955,7 +5219,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:43 GMT
+      - Mon, 13 Nov 2023 14:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4965,7 +5229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09dd7158-6b00-416f-9cce-8f98be411118
+      - 0f69ae27-d7dd-4b3e-bbb3-7db03f14bfce
     status: 200 OK
     code: 200
     duration: ""
@@ -4976,10 +5240,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:04:35.358499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -4988,7 +5252,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:43 GMT
+      - Mon, 13 Nov 2023 14:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4998,7 +5262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3476c08d-844e-4775-9a7e-d688fe81a8cf
+      - 4a53eb19-0c1d-454f-af76-c85efc8e1974
     status: 200 OK
     code: 200
     duration: ""
@@ -5009,10 +5273,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:04:35.358499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -5021,7 +5285,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:44 GMT
+      - Mon, 13 Nov 2023 14:04:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5031,7 +5295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cecab382-2b65-46bb-9eea-1276613249d5
+      - c939dc8d-c930-4c6e-9029-e71b9185d3d1
     status: 200 OK
     code: 200
     duration: ""
@@ -5042,10 +5306,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJOZUU1c2IxaEVWRTE2VFZSRmVFMXFSVEJOUkUxNFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxGeUNrVktUSE5vVTJSdFRuTnhjVzE0TUdKbGIxZ3dRVkkyUnk5TVVVWmpTMHAzYkVJNU5UTjZlRzFsT1VoVFptVjBabEY1UzJabVZESnVNVk5DWTFwbFExSUtiakJLTDB0bFJEUmFSMk5GY2xoWFN6ZHhXVkZJVlhBMVZXeEhkMkp3YWxGaVdWRnplWGxqY1VSQ1dHdFlOR1VyVVZZck9EZGFURk5wVjJsbWVVTlJTQXBDU3pCU2VVNU1LMEprVkhac2Rua3hPVUY0TUZZclFuRXJTRnBqVGt4aWVsQlRhV3RJUkdvNE5VRnpkR3M1UWsxd09UZFVkbTV1V21SREsycHZOa2RwQ2tabGMyTm9jV2hNTVhrNWNrRXdUM0J1UVhjMWMwMXhTMmt2VkdKSk1HTkJWa0Z0WnpoS1JtbFVNV1kzUjNGeGRDdHBZVWxHUldwM2Vrd3lZbmQ0UTBvS2FuaHdObGQ1ZDJJM2JIbDVZV3RuUkhWbU1WRnRZa3RpUlV4a1FrMDFWR1JoYWtZNFZrcFNTbmRQYTFoRFEzRmhWek0xZVhabWRDdHdZelZPVGxabk1Rb3dWWFIxZW1aUmRrZEJPRmRCVkcxRmNFNXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9NazFNUnpaWVExSkJRVmRVZWtoTmNYQXpkRVU1U0cxVlNsaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaR3BVYlhKSlMyeERNbGxHT0doNWVrbzBXbWd6VkZGMGRXdHFPVzVtVlRSM2NucFJVR1k0U25CelJsbEJPRlJsV2dweFZWUjBMelVyT1ZsRWVIbEpOSGszV0dKWlJqVjFjakkwYkVobVVrMDBlVlEzWlVWbE9GcGxUM0o2VkZWdWEybzBWRmhRV0dacWJHWnFiV3BvYm10WkNtUnNiblJSTjFOdk5uaGlkWEJHYUVZek5sSldSSHBuTVRCWloxUTJRblF5Tld0WGVsQlJVblExYTFFeFpYTnlaR1ZhSzNkd1EzZHVWSFJDUzBGaFZ6QUtVblY2VEhkMVNtdFRhRE5JUmpoVmVETTNUVkI2Tmpad2RVNVNUV0pHWmtWWFIzQnVPVWs0TWpRM2RVVldTMU53ZWxoWmRreHRja2xXT1hnM2JrbHNWd3AyWkVaclIzRktRMmxQYlhSMFREYzVNbTg1UW5Oa1MycDRTVWxEVTBrd2NUVTRUa2x3WkZsVFpFVldNVWhCV1RodmMyZGtXbEZMYjNSblFVWlhaU3QzQ2xrM2QybE5TelpWV1dkMmFVSjBUM3AwT0V4WFpFVmtlbG92UjFkclJ5OVFabXA2TUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzE3ZTAyNjQ2LTFmNDYtNGYwNS04YzhkLWE0MDJmODAyZGU1Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbWxSWVZ2ZzhQbW1rZ1MzbWRZUWJiTnkwYXM3M0gycVVNcGJpbXVyQVRxNktIMm9EMkV3NGRPTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -5054,7 +5318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:44 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5064,7 +5328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 575c319f-eb5a-451d-96bc-a33abf23c262
+      - bb2bc63b-7dda-4d7f-b584-b2aacad5dc8e
     status: 200 OK
     code: 200
     duration: ""
@@ -5075,10 +5339,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:04:35.358499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -5087,7 +5351,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:44 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5097,7 +5361,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d74c56ca-ea95-4af8-881b-a653d16ff58d
+      - d59a7219-b86b-4b91-95ee-220eaec098d0
     status: 200 OK
     code: 200
     duration: ""
@@ -5108,10 +5372,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJOZUU1c2IxaEVWRTE2VFZSRmVFMXFSVEJOUkUxNFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxGeUNrVktUSE5vVTJSdFRuTnhjVzE0TUdKbGIxZ3dRVkkyUnk5TVVVWmpTMHAzYkVJNU5UTjZlRzFsT1VoVFptVjBabEY1UzJabVZESnVNVk5DWTFwbFExSUtiakJLTDB0bFJEUmFSMk5GY2xoWFN6ZHhXVkZJVlhBMVZXeEhkMkp3YWxGaVdWRnplWGxqY1VSQ1dHdFlOR1VyVVZZck9EZGFURk5wVjJsbWVVTlJTQXBDU3pCU2VVNU1LMEprVkhac2Rua3hPVUY0TUZZclFuRXJTRnBqVGt4aWVsQlRhV3RJUkdvNE5VRnpkR3M1UWsxd09UZFVkbTV1V21SREsycHZOa2RwQ2tabGMyTm9jV2hNTVhrNWNrRXdUM0J1UVhjMWMwMXhTMmt2VkdKSk1HTkJWa0Z0WnpoS1JtbFVNV1kzUjNGeGRDdHBZVWxHUldwM2Vrd3lZbmQ0UTBvS2FuaHdObGQ1ZDJJM2JIbDVZV3RuUkhWbU1WRnRZa3RpUlV4a1FrMDFWR1JoYWtZNFZrcFNTbmRQYTFoRFEzRmhWek0xZVhabWRDdHdZelZPVGxabk1Rb3dWWFIxZW1aUmRrZEJPRmRCVkcxRmNFNXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9NazFNUnpaWVExSkJRVmRVZWtoTmNYQXpkRVU1U0cxVlNsaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaR3BVYlhKSlMyeERNbGxHT0doNWVrbzBXbWd6VkZGMGRXdHFPVzVtVlRSM2NucFJVR1k0U25CelJsbEJPRlJsV2dweFZWUjBMelVyT1ZsRWVIbEpOSGszV0dKWlJqVjFjakkwYkVobVVrMDBlVlEzWlVWbE9GcGxUM0o2VkZWdWEybzBWRmhRV0dacWJHWnFiV3BvYm10WkNtUnNiblJSTjFOdk5uaGlkWEJHYUVZek5sSldSSHBuTVRCWloxUTJRblF5Tld0WGVsQlJVblExYTFFeFpYTnlaR1ZhSzNkd1EzZHVWSFJDUzBGaFZ6QUtVblY2VEhkMVNtdFRhRE5JUmpoVmVETTNUVkI2Tmpad2RVNVNUV0pHWmtWWFIzQnVPVWs0TWpRM2RVVldTMU53ZWxoWmRreHRja2xXT1hnM2JrbHNWd3AyWkVaclIzRktRMmxQYlhSMFREYzVNbTg1UW5Oa1MycDRTVWxEVTBrd2NUVTRUa2x3WkZsVFpFVldNVWhCV1RodmMyZGtXbEZMYjNSblFVWlhaU3QzQ2xrM2QybE5TelpWV1dkMmFVSjBUM3AwT0V4WFpFVmtlbG92UjFkclJ5OVFabXA2TUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzE3ZTAyNjQ2LTFmNDYtNGYwNS04YzhkLWE0MDJmODAyZGU1Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbWxSWVZ2ZzhQbW1rZ1MzbWRZUWJiTnkwYXM3M0gycVVNcGJpbXVyQVRxNktIMm9EMkV3NGRPTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -5120,7 +5384,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:44 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5130,7 +5394,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f4018e4-0520-4225-bcfd-3483b6f3e833
+      - e2b98b6c-9d5d-40ed-89ce-4786b01c2056
     status: 200 OK
     code: 200
     duration: ""
@@ -5141,7 +5405,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
@@ -5153,7 +5417,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:44 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5163,7 +5427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 558c1407-84b2-49b0-a749-633a34b8c1e5
+      - 56408680-5b86-4dc5-afac-5931a8b42e42
     status: 200 OK
     code: 200
     duration: ""
@@ -5174,7 +5438,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
@@ -5186,7 +5450,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5196,7 +5460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec0ea766-f0bc-4130-9a75-91b4895d3dc2
+      - 29c5460b-5661-4590-8bc9-d6eea0f98169
     status: 200 OK
     code: 200
     duration: ""
@@ -5207,7 +5471,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
@@ -5219,7 +5483,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5229,7 +5493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - faaa3552-f900-4933-8661-f14f712f727c
+      - ac36aec1-4f4d-4d18-b9d7-684ab251d3a7
     status: 200 OK
     code: 200
     duration: ""
@@ -5240,10 +5504,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:22:22.680641Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-10T13:23:41.631261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:03:15.115312Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-13T14:04:35.358499Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -5252,7 +5516,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5262,7 +5526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2229bed-3dea-433d-9677-888887de90d5
+      - 9abf347f-a33f-4910-959d-cda4ee25bee5
     status: 200 OK
     code: 200
     duration: ""
@@ -5275,10 +5539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617937557Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801920680Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300948981Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391483723Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1488"
@@ -5287,7 +5551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5297,7 +5561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 263ee2e1-fcac-4bef-b50d-7cc37f17fbd7
+      - 0ef630fe-e80f-4959-9b90-831c422f8050
     status: 200 OK
     code: 200
     duration: ""
@@ -5308,10 +5572,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5320,7 +5584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:45 GMT
+      - Mon, 13 Nov 2023 14:04:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5330,7 +5594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c538c4bc-b37f-4e7d-ae92-66c286e8f135
+      - 987c5522-b83a-4330-9639-07c19d1dbf1c
     status: 200 OK
     code: 200
     duration: ""
@@ -5341,10 +5605,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5353,7 +5617,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:51 GMT
+      - Mon, 13 Nov 2023 14:04:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5363,7 +5627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cabfa20-0ea1-41d5-b02d-850025757d74
+      - e262ceb8-7e7b-4585-a1bb-5f615bb75902
     status: 200 OK
     code: 200
     duration: ""
@@ -5374,10 +5638,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5386,7 +5650,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:23:56 GMT
+      - Mon, 13 Nov 2023 14:04:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5396,7 +5660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4e077cc-5588-4d66-87e7-7806a408172b
+      - ec4e7c41-b859-4d6a-b77e-2c4deca8ec1a
     status: 200 OK
     code: 200
     duration: ""
@@ -5407,10 +5671,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5419,7 +5683,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:01 GMT
+      - Mon, 13 Nov 2023 14:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5429,7 +5693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c04aafa-ca6e-4fd5-854d-6e01053ce2e4
+      - b10c2423-53ae-4c17-862c-1786e0b84ff1
     status: 200 OK
     code: 200
     duration: ""
@@ -5440,10 +5704,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5452,7 +5716,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:06 GMT
+      - Mon, 13 Nov 2023 14:04:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5462,7 +5726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66c5886a-4982-49b1-b83b-071cc7958d01
+      - 6c7cce4c-000f-4277-81de-e7e6b79fcc09
     status: 200 OK
     code: 200
     duration: ""
@@ -5473,10 +5737,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5485,7 +5749,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:11 GMT
+      - Mon, 13 Nov 2023 14:05:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5495,7 +5759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eea3787d-d613-4bbb-a2d5-673bff2a49e7
+      - d6831083-7256-4625-af6d-db196ccdbdf5
     status: 200 OK
     code: 200
     duration: ""
@@ -5506,10 +5770,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5518,7 +5782,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:16 GMT
+      - Mon, 13 Nov 2023 14:05:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5528,7 +5792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c788d958-6460-4d43-9a5e-190d6b1bc64c
+      - aff59dd4-e9f0-45f7-b9b5-6864bb1f1b33
     status: 200 OK
     code: 200
     duration: ""
@@ -5539,10 +5803,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5551,7 +5815,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:21 GMT
+      - Mon, 13 Nov 2023 14:05:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5561,7 +5825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ab76677-633f-4a5c-83b8-71b6581132f7
+      - a40d37a1-5cd8-4525-adc8-d5fc6b338381
     status: 200 OK
     code: 200
     duration: ""
@@ -5572,10 +5836,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5584,7 +5848,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:26 GMT
+      - Mon, 13 Nov 2023 14:05:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5594,7 +5858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29cc261c-5536-4e6a-9cb7-8b5a4293918a
+      - c8f03d95-4a0e-4aeb-9f1f-90e1c87a37cc
     status: 200 OK
     code: 200
     duration: ""
@@ -5605,10 +5869,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5617,7 +5881,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:31 GMT
+      - Mon, 13 Nov 2023 14:05:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5627,7 +5891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ff6c802-b5af-43bc-bcbf-419e15fdc092
+      - a9a86e3b-52ca-4838-bd4d-21a763c7d56f
     status: 200 OK
     code: 200
     duration: ""
@@ -5638,10 +5902,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5650,7 +5914,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:36 GMT
+      - Mon, 13 Nov 2023 14:05:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5660,7 +5924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1632a06-2743-4b8a-a0cf-d6b3ddafbf70
+      - f8ef0299-9c35-43fa-b16c-546c826d7624
     status: 200 OK
     code: 200
     duration: ""
@@ -5671,10 +5935,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5683,7 +5947,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:41 GMT
+      - Mon, 13 Nov 2023 14:05:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5693,7 +5957,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aec59cb5-39ca-427c-867b-768cacc3230e
+      - fa46d222-e06a-4a4e-b63d-2b8290dfeccc
     status: 200 OK
     code: 200
     duration: ""
@@ -5704,10 +5968,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5716,7 +5980,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:46 GMT
+      - Mon, 13 Nov 2023 14:05:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5726,7 +5990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8d1eb70-4818-4611-a0c6-7f1bffa84d7b
+      - 634295d4-3421-4fde-a249-aa9bbdd07ac2
     status: 200 OK
     code: 200
     duration: ""
@@ -5737,10 +6001,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5749,7 +6013,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:51 GMT
+      - Mon, 13 Nov 2023 14:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5759,7 +6023,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9536c68-a34d-46b3-aa5a-a8e5617f77c1
+      - 1075ca5e-76df-4b43-9eb8-575508eb8658
     status: 200 OK
     code: 200
     duration: ""
@@ -5770,10 +6034,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5782,7 +6046,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:24:56 GMT
+      - Mon, 13 Nov 2023 14:05:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5792,7 +6056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 591d6eca-7ee7-48d6-b136-35ce07408749
+      - 347b34f7-2752-4fb1-b3d6-6e1c0a63aebc
     status: 200 OK
     code: 200
     duration: ""
@@ -5803,10 +6067,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5815,7 +6079,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:01 GMT
+      - Mon, 13 Nov 2023 14:05:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5825,7 +6089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59b7c1f7-48a2-437c-b72b-5a4bccfeda66
+      - f817873e-7789-4f19-94eb-b016e0ca3528
     status: 200 OK
     code: 200
     duration: ""
@@ -5836,10 +6100,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5848,7 +6112,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:06 GMT
+      - Mon, 13 Nov 2023 14:06:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5858,7 +6122,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b557da2-f45b-4eff-a59c-a6a03787d77a
+      - 1cbde80a-f200-4a58-a299-9d7b6b9519d8
     status: 200 OK
     code: 200
     duration: ""
@@ -5869,10 +6133,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5881,7 +6145,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:12 GMT
+      - Mon, 13 Nov 2023 14:06:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5891,7 +6155,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed721fa8-9ff2-4711-b9f3-18e5b992fcb8
+      - fbcb3022-3ac0-4903-92bf-543a00cfc6dc
     status: 200 OK
     code: 200
     duration: ""
@@ -5902,10 +6166,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:23:45.801921Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -5914,7 +6178,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:17 GMT
+      - Mon, 13 Nov 2023 14:06:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5924,7 +6188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8b85a33-db17-4984-a200-cd2a0e63442d
+      - 8e91ba49-08ab-43ef-945b-10563695d676
     status: 200 OK
     code: 200
     duration: ""
@@ -5935,10 +6199,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:18.338690Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1482"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 66d945bf-1577-42e6-afe4-fc5c4ceb708b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:04:38.391484Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1482"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:06:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7d450fe4-9bb6-4d8a-a218-b0500e6d47b1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:24.389433Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -5947,7 +6277,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:22 GMT
+      - Mon, 13 Nov 2023 14:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5957,7 +6287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5edae30-4668-4cc3-9fa3-877e8707dc38
+      - dee6edf8-be7f-497a-b7aa-5c7ac29a91fd
     status: 200 OK
     code: 200
     duration: ""
@@ -5970,10 +6300,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747379Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942311Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -5982,7 +6312,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:22 GMT
+      - Mon, 13 Nov 2023 14:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5992,7 +6322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1d5d04b-2963-4ea3-8c58-6ac1c935be14
+      - 38700877-00c5-4cc2-ba66-8f4ad883625d
     status: 200 OK
     code: 200
     duration: ""
@@ -6003,10 +6333,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6015,7 +6345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:22 GMT
+      - Mon, 13 Nov 2023 14:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6025,7 +6355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae6764f0-c4f2-4800-a1b6-468b264e92d8
+      - 725a05f6-01ca-4163-a5fe-b95d043d1620
     status: 200 OK
     code: 200
     duration: ""
@@ -6036,10 +6366,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6048,7 +6378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:27 GMT
+      - Mon, 13 Nov 2023 14:06:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6058,7 +6388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08ed3b36-978b-4866-a339-5f16f5f6ffa3
+      - 27015a84-79f9-42ed-af53-85539db6cada
     status: 200 OK
     code: 200
     duration: ""
@@ -6069,10 +6399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6081,7 +6411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:32 GMT
+      - Mon, 13 Nov 2023 14:06:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6091,7 +6421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c4534c4-68ce-40cb-924b-7f630c649f6c
+      - 28383f1e-3083-44a0-af1e-44ee20161964
     status: 200 OK
     code: 200
     duration: ""
@@ -6102,10 +6432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6114,7 +6444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:37 GMT
+      - Mon, 13 Nov 2023 14:06:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6124,7 +6454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 057c935f-67a2-4cc1-a93f-c8c5b34a0b27
+      - 98db794d-feae-438f-8600-7463f3232160
     status: 200 OK
     code: 200
     duration: ""
@@ -6135,10 +6465,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6147,7 +6477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:42 GMT
+      - Mon, 13 Nov 2023 14:06:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6157,7 +6487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1313c499-2182-460b-b300-b52945c1c7b1
+      - ea6e04b6-ed85-4ad8-9343-73f9cc2f14a7
     status: 200 OK
     code: 200
     duration: ""
@@ -6168,10 +6498,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6180,7 +6510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:47 GMT
+      - Mon, 13 Nov 2023 14:06:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6190,7 +6520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ea550a1-c874-4409-a645-5616b0d2287c
+      - 2b78517a-8e61-4c2b-b158-328138278426
     status: 200 OK
     code: 200
     duration: ""
@@ -6201,10 +6531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:22.187747Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6213,7 +6543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:52 GMT
+      - Mon, 13 Nov 2023 14:06:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6223,7 +6553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21c5e814-2e13-4c5b-b7da-1d1b4c749afd
+      - 2a146918-7d98-4d87-ad53-495303319add
     status: 200 OK
     code: 200
     duration: ""
@@ -6234,10 +6564,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:06:25.588942Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1482"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:07:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5a1cbc40-2981-4ceb-8bec-41225d071ee2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:07:03.471202Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -6246,7 +6609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:57 GMT
+      - Mon, 13 Nov 2023 14:07:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6256,7 +6619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79239230-e672-45cb-99d2-14eb7ada3a92
+      - 39a33ee1-c354-41d2-ad75-8a028f7cbedb
     status: 200 OK
     code: 200
     duration: ""
@@ -6267,10 +6630,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:07:03.471202Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -6279,7 +6642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:25:57 GMT
+      - Mon, 13 Nov 2023 14:07:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6289,7 +6652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35f8b453-0cab-41d7-9942-3ce778a7644f
+      - 093ad5b5-7d97-4a1a-9146-477ed8cb59f4
     status: 200 OK
     code: 200
     duration: ""
@@ -6300,10 +6663,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJOZUU1c2IxaEVWRTE2VFZSRmVFMXFSVEJOUkUxNFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxGeUNrVktUSE5vVTJSdFRuTnhjVzE0TUdKbGIxZ3dRVkkyUnk5TVVVWmpTMHAzYkVJNU5UTjZlRzFsT1VoVFptVjBabEY1UzJabVZESnVNVk5DWTFwbFExSUtiakJLTDB0bFJEUmFSMk5GY2xoWFN6ZHhXVkZJVlhBMVZXeEhkMkp3YWxGaVdWRnplWGxqY1VSQ1dHdFlOR1VyVVZZck9EZGFURk5wVjJsbWVVTlJTQXBDU3pCU2VVNU1LMEprVkhac2Rua3hPVUY0TUZZclFuRXJTRnBqVGt4aWVsQlRhV3RJUkdvNE5VRnpkR3M1UWsxd09UZFVkbTV1V21SREsycHZOa2RwQ2tabGMyTm9jV2hNTVhrNWNrRXdUM0J1UVhjMWMwMXhTMmt2VkdKSk1HTkJWa0Z0WnpoS1JtbFVNV1kzUjNGeGRDdHBZVWxHUldwM2Vrd3lZbmQ0UTBvS2FuaHdObGQ1ZDJJM2JIbDVZV3RuUkhWbU1WRnRZa3RpUlV4a1FrMDFWR1JoYWtZNFZrcFNTbmRQYTFoRFEzRmhWek0xZVhabWRDdHdZelZPVGxabk1Rb3dWWFIxZW1aUmRrZEJPRmRCVkcxRmNFNXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9NazFNUnpaWVExSkJRVmRVZWtoTmNYQXpkRVU1U0cxVlNsaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaR3BVYlhKSlMyeERNbGxHT0doNWVrbzBXbWd6VkZGMGRXdHFPVzVtVlRSM2NucFJVR1k0U25CelJsbEJPRlJsV2dweFZWUjBMelVyT1ZsRWVIbEpOSGszV0dKWlJqVjFjakkwYkVobVVrMDBlVlEzWlVWbE9GcGxUM0o2VkZWdWEybzBWRmhRV0dacWJHWnFiV3BvYm10WkNtUnNiblJSTjFOdk5uaGlkWEJHYUVZek5sSldSSHBuTVRCWloxUTJRblF5Tld0WGVsQlJVblExYTFFeFpYTnlaR1ZhSzNkd1EzZHVWSFJDUzBGaFZ6QUtVblY2VEhkMVNtdFRhRE5JUmpoVmVETTNUVkI2Tmpad2RVNVNUV0pHWmtWWFIzQnVPVWs0TWpRM2RVVldTMU53ZWxoWmRreHRja2xXT1hnM2JrbHNWd3AyWkVaclIzRktRMmxQYlhSMFREYzVNbTg1UW5Oa1MycDRTVWxEVTBrd2NUVTRUa2x3WkZsVFpFVldNVWhCV1RodmMyZGtXbEZMYjNSblFVWlhaU3QzQ2xrM2QybE5TelpWV1dkMmFVSjBUM3AwT0V4WFpFVmtlbG92UjFkclJ5OVFabXA2TUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzE3ZTAyNjQ2LTFmNDYtNGYwNS04YzhkLWE0MDJmODAyZGU1Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbWxSWVZ2ZzhQbW1rZ1MzbWRZUWJiTnkwYXM3M0gycVVNcGJpbXVyQVRxNktIMm9EMkV3NGRPTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -6312,7 +6675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:00 GMT
+      - Mon, 13 Nov 2023 14:07:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6322,7 +6685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2be67cd5-7083-4e77-8d36-bb06fa020559
+      - 74825584-de8c-43e5-acc8-0db78fe0fb1a
     status: 200 OK
     code: 200
     duration: ""
@@ -6333,10 +6696,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:07:03.471202Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -6345,7 +6708,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:00 GMT
+      - Mon, 13 Nov 2023 14:07:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6355,7 +6718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a7d06f0-5533-4623-8f02-a5b335996f17
+      - a46b3bb0-5490-4622-a867-8531f52280ce
     status: 200 OK
     code: 200
     duration: ""
@@ -6366,10 +6729,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:07:03.471202Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -6378,7 +6741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:01 GMT
+      - Mon, 13 Nov 2023 14:07:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6388,7 +6751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f99c004d-762e-4ac6-bdea-4ed51978e803
+      - 1d62757b-2b27-482e-a669-e8bf76e22fa8
     status: 200 OK
     code: 200
     duration: ""
@@ -6399,10 +6762,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJOZUU1c2IxaEVWRTE2VFZSRmVFMXFSVEJOUkUxNFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxGeUNrVktUSE5vVTJSdFRuTnhjVzE0TUdKbGIxZ3dRVkkyUnk5TVVVWmpTMHAzYkVJNU5UTjZlRzFsT1VoVFptVjBabEY1UzJabVZESnVNVk5DWTFwbFExSUtiakJLTDB0bFJEUmFSMk5GY2xoWFN6ZHhXVkZJVlhBMVZXeEhkMkp3YWxGaVdWRnplWGxqY1VSQ1dHdFlOR1VyVVZZck9EZGFURk5wVjJsbWVVTlJTQXBDU3pCU2VVNU1LMEprVkhac2Rua3hPVUY0TUZZclFuRXJTRnBqVGt4aWVsQlRhV3RJUkdvNE5VRnpkR3M1UWsxd09UZFVkbTV1V21SREsycHZOa2RwQ2tabGMyTm9jV2hNTVhrNWNrRXdUM0J1UVhjMWMwMXhTMmt2VkdKSk1HTkJWa0Z0WnpoS1JtbFVNV1kzUjNGeGRDdHBZVWxHUldwM2Vrd3lZbmQ0UTBvS2FuaHdObGQ1ZDJJM2JIbDVZV3RuUkhWbU1WRnRZa3RpUlV4a1FrMDFWR1JoYWtZNFZrcFNTbmRQYTFoRFEzRmhWek0xZVhabWRDdHdZelZPVGxabk1Rb3dWWFIxZW1aUmRrZEJPRmRCVkcxRmNFNXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9NazFNUnpaWVExSkJRVmRVZWtoTmNYQXpkRVU1U0cxVlNsaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaR3BVYlhKSlMyeERNbGxHT0doNWVrbzBXbWd6VkZGMGRXdHFPVzVtVlRSM2NucFJVR1k0U25CelJsbEJPRlJsV2dweFZWUjBMelVyT1ZsRWVIbEpOSGszV0dKWlJqVjFjakkwYkVobVVrMDBlVlEzWlVWbE9GcGxUM0o2VkZWdWEybzBWRmhRV0dacWJHWnFiV3BvYm10WkNtUnNiblJSTjFOdk5uaGlkWEJHYUVZek5sSldSSHBuTVRCWloxUTJRblF5Tld0WGVsQlJVblExYTFFeFpYTnlaR1ZhSzNkd1EzZHVWSFJDUzBGaFZ6QUtVblY2VEhkMVNtdFRhRE5JUmpoVmVETTNUVkI2Tmpad2RVNVNUV0pHWmtWWFIzQnVPVWs0TWpRM2RVVldTMU53ZWxoWmRreHRja2xXT1hnM2JrbHNWd3AyWkVaclIzRktRMmxQYlhSMFREYzVNbTg1UW5Oa1MycDRTVWxEVTBrd2NUVTRUa2x3WkZsVFpFVldNVWhCV1RodmMyZGtXbEZMYjNSblFVWlhaU3QzQ2xrM2QybE5TelpWV1dkMmFVSjBUM3AwT0V4WFpFVmtlbG92UjFkclJ5OVFabXA2TUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzE3ZTAyNjQ2LTFmNDYtNGYwNS04YzhkLWE0MDJmODAyZGU1Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbWxSWVZ2ZzhQbW1rZ1MzbWRZUWJiTnkwYXM3M0gycVVNcGJpbXVyQVRxNktIMm9EMkV3NGRPTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -6411,7 +6774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:01 GMT
+      - Mon, 13 Nov 2023 14:07:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6421,7 +6784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44575731-9707-4836-950f-d5158a4cd408
+      - 2d4eaa12-4d4b-407c-9f3d-ca254d927496
     status: 200 OK
     code: 200
     duration: ""
@@ -6432,10 +6795,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:25:56.226647Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:07:03.471202Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -6444,7 +6807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:01 GMT
+      - Mon, 13 Nov 2023 14:07:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6454,7 +6817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aee19847-51f7-4266-abc2-69babfe44d73
+      - 561f3e72-3904-4734-a5c7-305144e960f2
     status: 200 OK
     code: 200
     duration: ""
@@ -6465,10 +6828,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BKZVU1R2IxaEVWRTE2VFZSRmQwOVVSWHBOYWtsNVRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVaMENqUm9hRk5xTVRab1Qya3piVFpSVFhkcVdVTnJVVmxTZUhaeFdEUm5Obk5vU1dkRldVVnVjM0Z0VFhoaVJHTmlZMDAxV1U1S1IybHRSSFpOWWk5eVNHTUtaV2MxYW5aQll6TnNUbFZzT1haV1Z6TXJSV04xVlRWRFpYaG1MM0JsZUhWbVZsaFZOVGs1ZVhRd2MzTmFiVlk1VVVjelpXTllibHBFWlRCTWREWjBkUXBoUkZjMWJGQlRRM1JxVERrek5WTTRhV2RZZUZSelUzSXhjV0pVVnpsMlVsSklkVEEyTTNGUFZrUnBabXhoY1RjemNYUTNhV0U1WVVVNVpubDRTblZZQ2pKTFVrNUtVWGxPU21WMVRubEZZMlJGWkZRd1NrcFBlVWh2SzJweFExbFBPVmhvWkRGUVpEWlFNR3BWZGtkclowTlZUbEZaTkZKdE1sWTFiV2hKTDBNS1dtTjFZVVkyUjFVdk1qVnNVbWd3U1VjNVpXMWlVa1F3Tm5wT01sUmxSRE5ZYURodGIxZFZiV2RTTDNkVFpubFNkMlp0WkRWcVNYbEZVRGhpZEV0T0x3cHlaalJUWlVsTFYzcElUMmhKU1hScVJ6a3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklSMFpsV21GSU9HNHlTelV6U0dKdWFFUkZhMlF6VjI5YVkwaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaMnBVTVhkNGNpOTJhV2g1WldSSlp6aFdlV3hXV21SQ1p5OWxkemswZG5ONmJEZFpVbmw2VWk5cVdIZGFPRmMxUVFwdGNHVkJlbEJOV1VkWGNHOXVWSFIzYTBnM2RVRXJPR2hUTUhseGNEWTFTa2xtVjFZdllXOVVSMDg0TldORlNrc3hVMWRZYUc1NFRWWjJja1pSTmpSVkNuTTBXbFJCTTB3emRqSTVNRU56ZG5NMFFuQkVaMlF6UTBSbWNHUk9lbUZYVWtRdlduTnpUVzFFTTJ0RVIxWkNiamhJWW5nMlRGVkZlbFpKWXpGaVQzRUthaloxYkRkck1XWkdSbHBaUjJKRWVEZFNTalZDTjBaUGJrdFdhWFl6UzI5TlIyZHdNRWQxVVVGeFdVcFFMMWxtWlZCUk9EQnRPWFZOWkc0NWQzQjBad3BQV1hacFRWcFBkbVJ2WkdkQ1NGSkRXR3RTY2xkRFJsQnZhVzFMZDJ0TFVHTTFSbVpwVVZKS1kwZHNhRVZrWlROWFpDdHFWV3h0ZW1FMlkzQkxXVGRrQ25JNVJsUjVhM1JsU1VaTVprWm1OVUpMYjBJeE9FNVlSakZXZGpkUFpXYzRObXhDUWdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2NhNTdlMmJjLTlhYTgtNDE1Yy04NzdjLTBiZmYwMTk4OWVjZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA2U0NTd0JoVXZOVU90TFZiaDNkcUZzWWMzODNsYUp1WDIwVklUMWVkclF4OVIwZG9uV3lUajZMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJOZUU1c2IxaEVWRTE2VFZSRmVFMXFSVEJOUkUxNFRteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxGeUNrVktUSE5vVTJSdFRuTnhjVzE0TUdKbGIxZ3dRVkkyUnk5TVVVWmpTMHAzYkVJNU5UTjZlRzFsT1VoVFptVjBabEY1UzJabVZESnVNVk5DWTFwbFExSUtiakJLTDB0bFJEUmFSMk5GY2xoWFN6ZHhXVkZJVlhBMVZXeEhkMkp3YWxGaVdWRnplWGxqY1VSQ1dHdFlOR1VyVVZZck9EZGFURk5wVjJsbWVVTlJTQXBDU3pCU2VVNU1LMEprVkhac2Rua3hPVUY0TUZZclFuRXJTRnBqVGt4aWVsQlRhV3RJUkdvNE5VRnpkR3M1UWsxd09UZFVkbTV1V21SREsycHZOa2RwQ2tabGMyTm9jV2hNTVhrNWNrRXdUM0J1UVhjMWMwMXhTMmt2VkdKSk1HTkJWa0Z0WnpoS1JtbFVNV1kzUjNGeGRDdHBZVWxHUldwM2Vrd3lZbmQ0UTBvS2FuaHdObGQ1ZDJJM2JIbDVZV3RuUkhWbU1WRnRZa3RpUlV4a1FrMDFWR1JoYWtZNFZrcFNTbmRQYTFoRFEzRmhWek0xZVhabWRDdHdZelZPVGxabk1Rb3dWWFIxZW1aUmRrZEJPRmRCVkcxRmNFNXpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9NazFNUnpaWVExSkJRVmRVZWtoTmNYQXpkRVU1U0cxVlNsaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNaR3BVYlhKSlMyeERNbGxHT0doNWVrbzBXbWd6VkZGMGRXdHFPVzVtVlRSM2NucFJVR1k0U25CelJsbEJPRlJsV2dweFZWUjBMelVyT1ZsRWVIbEpOSGszV0dKWlJqVjFjakkwYkVobVVrMDBlVlEzWlVWbE9GcGxUM0o2VkZWdWEybzBWRmhRV0dacWJHWnFiV3BvYm10WkNtUnNiblJSTjFOdk5uaGlkWEJHYUVZek5sSldSSHBuTVRCWloxUTJRblF5Tld0WGVsQlJVblExYTFFeFpYTnlaR1ZhSzNkd1EzZHVWSFJDUzBGaFZ6QUtVblY2VEhkMVNtdFRhRE5JUmpoVmVETTNUVkI2Tmpad2RVNVNUV0pHWmtWWFIzQnVPVWs0TWpRM2RVVldTMU53ZWxoWmRreHRja2xXT1hnM2JrbHNWd3AyWkVaclIzRktRMmxQYlhSMFREYzVNbTg1UW5Oa1MycDRTVWxEVTBrd2NUVTRUa2x3WkZsVFpFVldNVWhCV1RodmMyZGtXbEZMYjNSblFVWlhaU3QzQ2xrM2QybE5TelpWV1dkMmFVSjBUM3AwT0V4WFpFVmtlbG92UjFkclJ5OVFabXA2TUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzE3ZTAyNjQ2LTFmNDYtNGYwNS04YzhkLWE0MDJmODAyZGU1Yy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnbWxSWVZ2ZzhQbW1rZ1MzbWRZUWJiTnkwYXM3M0gycVVNcGJpbXVyQVRxNktIMm9EMkV3NGRPTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -6477,7 +6840,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:01 GMT
+      - Mon, 13 Nov 2023 14:07:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6487,7 +6850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba0e276a-0cf0-4025-991b-657300899fb6
+      - ec3a54e9-29ae-4152-abad-f70c90bbc129
     status: 200 OK
     code: 200
     duration: ""
@@ -6498,7 +6861,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
@@ -6510,7 +6873,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:01 GMT
+      - Mon, 13 Nov 2023 14:07:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6520,7 +6883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ebde85d-cd18-4583-a665-f7c88784b702
+      - 58480115-dbff-4ca9-82e1-c49eb46061f7
     status: 200 OK
     code: 200
     duration: ""
@@ -6531,7 +6894,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
@@ -6543,7 +6906,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:01 GMT
+      - Mon, 13 Nov 2023 14:07:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6553,7 +6916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db0b259f-7cb0-4822-85fd-045fd25b314b
+      - 7bec1df7-0bf2-4791-8a1f-49fe7765a837
     status: 200 OK
     code: 200
     duration: ""
@@ -6564,10 +6927,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:26:02.229198961Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:07:07.981228434Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1485"
@@ -6576,7 +6939,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:02 GMT
+      - Mon, 13 Nov 2023 14:07:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6586,7 +6949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f05f8c7-c6c7-4051-a9d8-4e8b35b65317
+      - 4c776250-bb17-47a9-b484-f11043ceccf6
     status: 200 OK
     code: 200
     duration: ""
@@ -6597,10 +6960,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:26:02.229199Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:07:07.981228Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6609,7 +6972,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:02 GMT
+      - Mon, 13 Nov 2023 14:07:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6619,7 +6982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 178d1a5e-e05e-4aeb-9a6e-9e52f93159e2
+      - 9b51e565-625b-4e8c-b4e6-d07ab59437e7
     status: 200 OK
     code: 200
     duration: ""
@@ -6630,10 +6993,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ca57e2bc-9aa8-415c-877c-0bff01989ece.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-10T13:23:45.617938Z","created_at":"2023-11-10T13:22:22.680641Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ca57e2bc-9aa8-415c-877c-0bff01989ece.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-10T13:26:02.229199Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17e02646-1f46-4f05-8c8d-a402f802de5c.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-13T14:04:38.300949Z","created_at":"2023-11-13T14:03:15.115312Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17e02646-1f46-4f05-8c8d-a402f802de5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17e02646-1f46-4f05-8c8d-a402f802de5c","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-13T14:07:07.981228Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1482"
@@ -6642,7 +7005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:07 GMT
+      - Mon, 13 Nov 2023 14:07:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6652,7 +7015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af4e3a79-22ea-422d-8106-f062516d10b3
+      - c1b640ab-a71c-4805-a46a-3059d6d81a07
     status: 200 OK
     code: 200
     duration: ""
@@ -6663,10 +7026,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/ca57e2bc-9aa8-415c-877c-0bff01989ece
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17e02646-1f46-4f05-8c8d-a402f802de5c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ca57e2bc-9aa8-415c-877c-0bff01989ece","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"17e02646-1f46-4f05-8c8d-a402f802de5c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6675,7 +7038,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:12 GMT
+      - Mon, 13 Nov 2023 14:07:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6685,7 +7048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a9694d6-b828-477d-861b-231c4c342a88
+      - a6eb8683-6aa6-41c4-a266-94a05e1a0166
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6701,7 +7064,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548612820Z","created_at":"2023-11-10T13:26:12.548612820Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566358602Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362294Z","created_at":"2023-11-13T14:07:18.292362294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305064791Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1479"
@@ -6710,7 +7073,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:12 GMT
+      - Mon, 13 Nov 2023 14:07:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6720,7 +7083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcc8b7fd-3ba8-4396-af77-3625c77cbcf9
+      - 845a9b6a-a103-43fa-85f1-d88b32ba2dd9
     status: 200 OK
     code: 200
     duration: ""
@@ -6731,10 +7094,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -6743,7 +7106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:12 GMT
+      - Mon, 13 Nov 2023 14:07:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6753,7 +7116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79cadd68-1a6b-4ada-8422-f84c0847e122
+      - 96b54321-ae79-4d96-81b3-b4bfc331828e
     status: 200 OK
     code: 200
     duration: ""
@@ -6764,10 +7127,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -6776,7 +7139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:17 GMT
+      - Mon, 13 Nov 2023 14:07:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6786,7 +7149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59b0cf29-cc60-4c6f-8622-8a15eb3b9c20
+      - 27d7bc73-d254-4333-9de4-f6cea23505cc
     status: 200 OK
     code: 200
     duration: ""
@@ -6797,10 +7160,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -6809,7 +7172,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:22 GMT
+      - Mon, 13 Nov 2023 14:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6819,7 +7182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37ab03f7-5b36-43b4-8a59-f63f1f2db1e4
+      - 0c10e4a6-472d-46e1-bdc3-3f0f4631e638
     status: 200 OK
     code: 200
     duration: ""
@@ -6830,10 +7193,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -6842,7 +7205,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:27 GMT
+      - Mon, 13 Nov 2023 14:07:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6852,7 +7215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a71f9392-ace9-4970-b6ba-0486e611584f
+      - df3bfe56-7251-4402-803a-19b084002ced
     status: 200 OK
     code: 200
     duration: ""
@@ -6863,10 +7226,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -6875,7 +7238,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:32 GMT
+      - Mon, 13 Nov 2023 14:07:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6885,7 +7248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3dc49c2-7e92-4cf8-a242-e282f0a2af0a
+      - 85b88bb3-2393-40fe-b75f-b9bb73a00709
     status: 200 OK
     code: 200
     duration: ""
@@ -6896,10 +7259,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -6908,7 +7271,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:37 GMT
+      - Mon, 13 Nov 2023 14:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6918,7 +7281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - daf03522-aa8c-42c8-8673-078cd4c5ee22
+      - 91965cad-74fc-4ac3-91a3-535bb291d1bf
     status: 200 OK
     code: 200
     duration: ""
@@ -6929,10 +7292,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -6941,7 +7304,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:42 GMT
+      - Mon, 13 Nov 2023 14:07:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6951,7 +7314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f07513c6-2747-4473-8dcd-3e65c8e65ed6
+      - c309195e-97e5-4ba9-a059-637c16c74ca6
     status: 200 OK
     code: 200
     duration: ""
@@ -6962,10 +7325,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -6974,7 +7337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:47 GMT
+      - Mon, 13 Nov 2023 14:07:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6984,7 +7347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0d035cb-3001-406c-b09d-8ea3eefefbd0
+      - fbfaac71-4149-4d70-8ab4-1d01810e3fb7
     status: 200 OK
     code: 200
     duration: ""
@@ -6995,10 +7358,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -7007,7 +7370,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:53 GMT
+      - Mon, 13 Nov 2023 14:07:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7017,7 +7380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8eaf1563-aa06-47d7-963b-5549c8303c13
+      - cc071e09-5b20-489a-84be-50a85bbe9b2d
     status: 200 OK
     code: 200
     duration: ""
@@ -7028,10 +7391,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -7040,7 +7403,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:26:58 GMT
+      - Mon, 13 Nov 2023 14:08:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7050,7 +7413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bc5c18f-8027-4cfa-832c-12dbccda230c
+      - 13de6c28-3f02-412c-9856-c8e09a60871a
     status: 200 OK
     code: 200
     duration: ""
@@ -7061,10 +7424,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -7073,7 +7436,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:03 GMT
+      - Mon, 13 Nov 2023 14:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7083,7 +7446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43dcc545-cd03-4c23-b998-359d35f42161
+      - beaa23af-92af-4d19-abc1-d66163dcc0d9
     status: 200 OK
     code: 200
     duration: ""
@@ -7094,10 +7457,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -7106,7 +7469,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:08 GMT
+      - Mon, 13 Nov 2023 14:08:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7116,7 +7479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 182943d7-46a5-499e-a34a-b075a46fe11a
+      - ae128dc7-33b1-4fd4-bce9-cfe794be4fc7
     status: 200 OK
     code: 200
     duration: ""
@@ -7127,10 +7490,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -7139,7 +7502,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:13 GMT
+      - Mon, 13 Nov 2023 14:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7149,7 +7512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4588aeb-4e21-4936-821f-62865c9222f9
+      - 2b46d1e6-9291-4388-97ee-7a23edd05bab
     status: 200 OK
     code: 200
     duration: ""
@@ -7160,10 +7523,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:26:12.566359Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -7172,7 +7535,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:18 GMT
+      - Mon, 13 Nov 2023 14:08:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7182,7 +7545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc00d16a-e26f-44ec-9bb5-9e88004895cf
+      - b5098010-5a57-4c2b-ad61-50374f40fdbb
     status: 200 OK
     code: 200
     duration: ""
@@ -7193,10 +7556,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:23.092971Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1470"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b8fdfe5f-7da8-4f69-8900-dfc2e5bc6412
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1470"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f1dbb0b3-c651-41f8-97fe-50b95c6a9343
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1470"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 908b2aef-77ed-40ae-970c-14c6959270a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:07:18.305065Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1470"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Nov 2023 14:08:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0f4c2391-de3e-4330-8ade-49f19b316c6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:08:45.939401Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1467"
@@ -7205,7 +7700,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:23 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7215,7 +7710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c3d0810-e944-40f0-9508-836e633940b0
+      - 589be91e-55c0-4c0e-abb0-b9f980ea3b43
     status: 200 OK
     code: 200
     duration: ""
@@ -7226,10 +7721,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:23.092971Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:08:45.939401Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1467"
@@ -7238,7 +7733,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:23 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7248,7 +7743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65da0008-339c-4a8f-a97e-a5d54d51c7c5
+      - d303bf78-b4ac-4fdf-a072-50a151b5fad5
     status: 200 OK
     code: 200
     duration: ""
@@ -7259,10 +7754,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BaZUUweGIxaEVWRTE2VFZSRmQwOVVSWHBOYWxsNFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGtOb0NrSjNTVTVUUVVsRFlUVlhOelJrTlVSQlIwWXhjVmRrVTBGalVUbHFaR1l5V0V4bk5tbHlWVEptTTJKSU5WVlpOMll6Y1RoS1NWSk5Ra056T0RWMmJGVUtNazlIVDFOdFFrSlJNMEZ1WW05TFpGWldiMU55Y0VsUlprcHhjMnhuV1ZGRlQyZ3dVbTVFY2tSdlptWlJhV0pTWVRNNVIwa3hOVEJ5T1ZOMlJrWTJUQXA0U2xoM1YyYzRZbGRpUzBWVkt5dEtTVUpGZVZnMk0zSnJVMlEyTTFod1RGUndWMUozVkdFclMzQk1NWEZrZGxsdmNUa3ZhM2Q2VUZONVRGaFplRWhHQ2xsTE9UbEVXVEYyYVhCNGNEa3haVmR1TXpoNGQyRjJUakUzWTBad1JqTk5NVEpYYnpjNWVFaGxSV05LWTJWSWVFZzBiRWhGTW5sMmMxQmlibVF2U0hZS01rbDVVVVEzVm10blNWTkxlRkF3U213dlZVZFpOMWQ0VEdOM2IwOTJXSFpETWs5SFVqaENVRXBCUkhkb2VrdEViRXhHYW04MVlrbzNiVzVWZGxGR1JRcEdhQzg0V0VGRlNFNHlNVkJCV0hCRFR6RXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpVVGg0TVZoVWFYZDVRVkkyUVdsTWRTOTJXRmhxZHpGTVRrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWSE5LTW14TlEwbHNNbmRIY0RWR1drWktLM2RKTUVnM1lrTkVlWHBrVW0xS1JISlhTMU5OT0ZRMk9VeG9iRTFLU1FwMFRVWjNOelJuVlV0NWQzVnRaRUkyTldaT01rOWhSRFZzU25OblZHdzVORFowUmtWclYxVldNMnB0YUdjeUwxQk9jM3BFUlZsSVFtVk1NRmxJSzNadkNrcGxOMHBPYVVkamEyTjFXSGRYYkhrMlVUZG5ha1pJTUZoQ2QzaG5jRFJHYUc5M2F5OVJXVFo0VkRGR2NXWnRaVlk0ZG01R1pqTkNUa2hqT0hSc1FVSUthSGRtU2tkMU0yMVlNMVoxVTB0TmFVNURSbXB1UmxsdlIwNXJMemx6YkhBd1VHTjBPVkY0VVdWR2JWUnlkVXRWWkU1WlQzTlZlRGxDZEVab1YyMVVkUW96V2xkMVVrbFpiM0pIY0drd2VqaExRbEpuYjJJeFZscHJlbVZIU3pOc1puWXdMMVo1Y0VVMk1EZHhWa3hHU1VaVloxTmpNbUYzV0ZCeE1FbEdZVloyQ21ob2JWVXpWMlZTYUZoRlNUUjNTMlEyZGtsa01WSlhWeTloVDJobVIzUkJaWEJ4YXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzEyZDdmYjUxLTcxNGQtNDA3OC05ZTRkLWZhODAyOWU0MWUwZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1QWJDVjFnSEl4RFk5UXZKUGNWVGozdEczVWtVa0pDVjduVDZxREwxdnU1bE1TY1JGcVRTUkNRQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJqZUU5V2IxaEVWRTE2VFZSRmVFMXFSVEJOUkdONFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUZwQkNuZE5SeTlEUVZaVmVVVkdSRVZ2TDJwM0t6VXJTWFlyWW5jMlIxcHlWVkpSZW10MGRHdG9MMHh6V0hWalFsTjVMM0pWY0d0R05YVkZhMWQ2VVRRdlRWQUtPR2g2TUhSbFdEUnhaMWw2Ym14a1oycGtXVWQ1Y0ZsVVdYaEROVVoxTUVWaU1UZHNUMVpzU21JeVZVcGpjWE5aVmpSeVNqUmxNM2Q2T0hrclptSXdOQXBzUTFCUmFsaDZkMVpZVEhVclRsbDFiSFl2U1hsd1MwRktZVWx2T0dvMFNYVXdUa1JxUzJ4dVEwdE5PRzk0ZG1wd2JXSjZja2hEUlRsWWRWWnFOblJLQ2s5cVJGVjBVbVpuTHpCU09TOWxRbGhTU0dOcFJsQTVVR1ZpY0VOeE1EaHlPVGh1U2tsc1pIUTNSRkpvTlhSS2FIb3ZRVGh1YUhabFRFZDRhUzk0VjNJS1NHNTVkakE0VEZwSmVrbERReTl4TWxsUFNraFlZV1pSZEhsSFNURmtjVFE1S3padk9IVXlWVEJEU1VoYVRpc3hVa1p4ZFRscVRVTTBPVmRsZWxOeU13cE9PVmhJU0dOVGMxRnBWRnBpY2tsc2JHaHJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9lR05sV21wVVN6ZEJTek16YWpSR1VVOUlSMHBRTDBNNU5rNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRlRlowTHpkVFRHdFBRMEZSVGtOUE1rWXdiMkZtU1RndlpEQmFNRVpUZWtSeE5tbHZUbk5MZERoRFRHaE5WMGt2T0FvNWFYbzNTRk5ZUW5oTE9GTlJaSGhJVWtwVWFuWlVRVEkzTVROT1dHSmFaVXd6VEZkaGFGaHBjakZNWmpGb2RrVTRUMkZKVEhGQmRXeDBOSFp5UlhwNkNubGFSR1o2ZEc1c1pXcHJRMk5aVkhaTVpUZHdSWE5KWkhoUE1FRlBURTFrUVVSWlpWUm1VVTFzUTI5dFVVdFlMM04xVm1ZNVF6RjJlSGgyZW5kaFdqZ0tXbTlwWW05RU0zWklNM2x2UjNsWmRuTnhSVkpVYlUxNGIxWktLek15VDJ4clZHRldWM1IwUmxkUU5YbDFaWG94TVdsdE9HTXdNblJYUVhaNWJsQlRPQW8wWlZGR1dHMDJXR1pyWXpWbmNYaHhlVVJqWm5aNVVHdzFUVVI2VjBKak1DOHhkREpCZGk5QlFVUjFUVU40UW14SVpHOTNiVVZ4S3pCT01qUk9UbVpZQ2tNclJsb3lXUzlSZGpGQlduZHdiemRUWTNoT1NWRmxSbVZ5ZFhveVJFaEVRMFZyTmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzNjZDYwZjBlLWYwZjMtNDA5My1hZTFiLThmNzE5ZjBmMWI5My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHV0xuSHhSREh0dkFDUlJJMzFnUlplVk1SVm94TDZpNjc5WWtqMzJuc2cwMkhSRWViUHRNWDVqVw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -7271,7 +7766,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:23 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7281,7 +7776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81411bde-bf46-494c-83b9-60a64082923f
+      - 01b8d39a-6ffe-40ee-b8db-0ff6cd69d4cc
     status: 200 OK
     code: 200
     duration: ""
@@ -7292,10 +7787,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:23.092971Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:08:45.939401Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1467"
@@ -7304,7 +7799,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:23 GMT
+      - Mon, 13 Nov 2023 14:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7314,7 +7809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 464aa79d-78e0-4d59-8225-70f1fd0c7311
+      - 2103e382-2a53-4a07-b8a4-dfba4d484423
     status: 200 OK
     code: 200
     duration: ""
@@ -7325,10 +7820,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:23.092971Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:08:45.939401Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1467"
@@ -7337,7 +7832,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:23 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7347,7 +7842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76a6dcff-ee5a-4d6e-9749-048891bed2af
+      - 664f04ec-7a0f-43ad-8e09-813bc82262e8
     status: 200 OK
     code: 200
     duration: ""
@@ -7358,10 +7853,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkUFZFVjZUV3BaZUUweGIxaEVWRTE2VFZSRmQwOVVSWHBOYWxsNFRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGtOb0NrSjNTVTVUUVVsRFlUVlhOelJrTlVSQlIwWXhjVmRrVTBGalVUbHFaR1l5V0V4bk5tbHlWVEptTTJKSU5WVlpOMll6Y1RoS1NWSk5Ra056T0RWMmJGVUtNazlIVDFOdFFrSlJNMEZ1WW05TFpGWldiMU55Y0VsUlprcHhjMnhuV1ZGRlQyZ3dVbTVFY2tSdlptWlJhV0pTWVRNNVIwa3hOVEJ5T1ZOMlJrWTJUQXA0U2xoM1YyYzRZbGRpUzBWVkt5dEtTVUpGZVZnMk0zSnJVMlEyTTFod1RGUndWMUozVkdFclMzQk1NWEZrZGxsdmNUa3ZhM2Q2VUZONVRGaFplRWhHQ2xsTE9UbEVXVEYyYVhCNGNEa3haVmR1TXpoNGQyRjJUakUzWTBad1JqTk5NVEpYYnpjNWVFaGxSV05LWTJWSWVFZzBiRWhGTW5sMmMxQmlibVF2U0hZS01rbDVVVVEzVm10blNWTkxlRkF3U213dlZVZFpOMWQ0VEdOM2IwOTJXSFpETWs5SFVqaENVRXBCUkhkb2VrdEViRXhHYW04MVlrbzNiVzVWZGxGR1JRcEdhQzg0V0VGRlNFNHlNVkJCV0hCRFR6RXdRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpVVGg0TVZoVWFYZDVRVkkyUVdsTWRTOTJXRmhxZHpGTVRrZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRWSE5LTW14TlEwbHNNbmRIY0RWR1drWktLM2RKTUVnM1lrTkVlWHBrVW0xS1JISlhTMU5OT0ZRMk9VeG9iRTFLU1FwMFRVWjNOelJuVlV0NWQzVnRaRUkyTldaT01rOWhSRFZzU25OblZHdzVORFowUmtWclYxVldNMnB0YUdjeUwxQk9jM3BFUlZsSVFtVk1NRmxJSzNadkNrcGxOMHBPYVVkamEyTjFXSGRYYkhrMlVUZG5ha1pJTUZoQ2QzaG5jRFJHYUc5M2F5OVJXVFo0VkRGR2NXWnRaVlk0ZG01R1pqTkNUa2hqT0hSc1FVSUthSGRtU2tkMU0yMVlNMVoxVTB0TmFVNURSbXB1UmxsdlIwNXJMemx6YkhBd1VHTjBPVkY0VVdWR2JWUnlkVXRWWkU1WlQzTlZlRGxDZEVab1YyMVVkUW96V2xkMVVrbFpiM0pIY0drd2VqaExRbEpuYjJJeFZscHJlbVZIU3pOc1puWXdMMVo1Y0VVMk1EZHhWa3hHU1VaVloxTmpNbUYzV0ZCeE1FbEdZVloyQ21ob2JWVXpWMlZTYUZoRlNUUjNTMlEyZGtsa01WSlhWeTloVDJobVIzUkJaWEJ4YXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzEyZDdmYjUxLTcxNGQtNDA3OC05ZTRkLWZhODAyOWU0MWUwZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1QWJDVjFnSEl4RFk5UXZKUGNWVGozdEczVWtVa0pDVjduVDZxREwxdnU1bE1TY1JGcVRTUkNRQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhoTmFrVXdUVVJqZUU5V2IxaEVWRTE2VFZSRmVFMXFSVEJOUkdONFQxWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVUZwQkNuZE5SeTlEUVZaVmVVVkdSRVZ2TDJwM0t6VXJTWFlyWW5jMlIxcHlWVkpSZW10MGRHdG9MMHh6V0hWalFsTjVMM0pWY0d0R05YVkZhMWQ2VVRRdlRWQUtPR2g2TUhSbFdEUnhaMWw2Ym14a1oycGtXVWQ1Y0ZsVVdYaEROVVoxTUVWaU1UZHNUMVpzU21JeVZVcGpjWE5aVmpSeVNqUmxNM2Q2T0hrclptSXdOQXBzUTFCUmFsaDZkMVpZVEhVclRsbDFiSFl2U1hsd1MwRktZVWx2T0dvMFNYVXdUa1JxUzJ4dVEwdE5PRzk0ZG1wd2JXSjZja2hEUlRsWWRWWnFOblJLQ2s5cVJGVjBVbVpuTHpCU09TOWxRbGhTU0dOcFJsQTVVR1ZpY0VOeE1EaHlPVGh1U2tsc1pIUTNSRkpvTlhSS2FIb3ZRVGh1YUhabFRFZDRhUzk0VjNJS1NHNTVkakE0VEZwSmVrbERReTl4TWxsUFNraFlZV1pSZEhsSFNURmtjVFE1S3padk9IVXlWVEJEU1VoYVRpc3hVa1p4ZFRscVRVTTBPVmRsZWxOeU13cE9PVmhJU0dOVGMxRnBWRnBpY2tsc2JHaHJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9lR05sV21wVVN6ZEJTek16YWpSR1VVOUlSMHBRTDBNNU5rNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRlRlowTHpkVFRHdFBRMEZSVGtOUE1rWXdiMkZtU1RndlpEQmFNRVpUZWtSeE5tbHZUbk5MZERoRFRHaE5WMGt2T0FvNWFYbzNTRk5ZUW5oTE9GTlJaSGhJVWtwVWFuWlVRVEkzTVROT1dHSmFaVXd6VEZkaGFGaHBjakZNWmpGb2RrVTRUMkZKVEhGQmRXeDBOSFp5UlhwNkNubGFSR1o2ZEc1c1pXcHJRMk5aVkhaTVpUZHdSWE5KWkhoUE1FRlBURTFrUVVSWlpWUm1VVTFzUTI5dFVVdFlMM04xVm1ZNVF6RjJlSGgyZW5kaFdqZ0tXbTlwWW05RU0zWklNM2x2UjNsWmRuTnhSVkpVYlUxNGIxWktLek15VDJ4clZHRldWM1IwUmxkUU5YbDFaWG94TVdsdE9HTXdNblJYUVhaNWJsQlRPQW8wWlZGR1dHMDJXR1pyWXpWbmNYaHhlVVJqWm5aNVVHdzFUVVI2VjBKak1DOHhkREpCZGk5QlFVUjFUVU40UW14SVpHOTNiVVZ4S3pCT01qUk9UbVpZQ2tNclJsb3lXUzlSZGpGQlduZHdiemRUWTNoT1NWRmxSbVZ5ZFhveVJFaEVRMFZyTmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzNjZDYwZjBlLWYwZjMtNDA5My1hZTFiLThmNzE5ZjBmMWI5My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBHV0xuSHhSREh0dkFDUlJJMzFnUlplVk1SVm94TDZpNjc5WWtqMzJuc2cwMkhSRWViUHRNWDVqVw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2622"
@@ -7370,7 +7865,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:23 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7380,7 +7875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16b3435d-5173-4703-87ce-554151fa5da3
+      - cb7c32d7-8481-4436-ae42-6ae832b6d01a
     status: 200 OK
     code: 200
     duration: ""
@@ -7391,10 +7886,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:24.397999031Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:08:51.770422565Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1473"
@@ -7403,7 +7898,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:24 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7413,7 +7908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7afc61be-74b2-43b7-8d51-af58938679e0
+      - 553a0556-3ac6-4044-a48a-c951f1766844
     status: 200 OK
     code: 200
     duration: ""
@@ -7424,10 +7919,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:24.397999Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-13T14:07:18.292362Z","created_at":"2023-11-13T14:07:18.292362Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-13T14:08:51.770423Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1470"
@@ -7436,7 +7931,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:24 GMT
+      - Mon, 13 Nov 2023 14:08:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7446,7 +7941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66a8631f-8a03-4553-ad05-6bb3f496e8e1
+      - dfee8a16-f878-4ff9-bc63-495c96678294
     status: 200 OK
     code: 200
     duration: ""
@@ -7457,43 +7952,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://12d7fb51-714d-4078-9e4d-fa8029e41e0f.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-10T13:26:12.548613Z","created_at":"2023-11-10T13:26:12.548613Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.12d7fb51-714d-4078-9e4d-fa8029e41e0f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-10T13:27:24.397999Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1470"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Nov 2023 13:27:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6692e21f-77b3-49ae-94f0-2403b2d1f868
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7502,7 +7964,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:34 GMT
+      - Mon, 13 Nov 2023 14:08:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7512,7 +7974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54b16392-6ed9-41cf-a7c2-c3e2c6da1edc
+      - da7cc574-c503-4bb0-b498-2e238b8e99d1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7523,10 +7985,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/12d7fb51-714d-4078-9e4d-fa8029e41e0f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"12d7fb51-714d-4078-9e4d-fa8029e41e0f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"3cd60f0e-f0f3-4093-ae1b-8f719f0f1b93","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7535,7 +7997,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Nov 2023 13:27:34 GMT
+      - Mon, 13 Nov 2023 14:08:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7545,7 +8007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c6fa271-7f63-4ade-a4f3-0a8a987e853c
+      - 29d2ed4e-ce85-4d90-92ec-3562300b1106
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
In an attempt to fix the random deletion errors in the nightly tests, we should declare the CheckDestroy functions in the order they should be called.

Also TestAccScalewayK8SCluster_PoolPrivateNetwork serves no purpose now that all clusters must have a private network.